### PR TITLE
Stop sorting keys.

### DIFF
--- a/testdata/rsyncd.json
+++ b/testdata/rsyncd.json
@@ -58,14 +58,14 @@
     "Program": "rsyncd.mtail",
     "Kind": 0,
     "Keys": [
-      "module",
-      "operation"
+      "operation",
+      "module"
     ],
     "LabelValues": [
       {
         "Labels": [
-          "module",
-          "send"
+          "send",
+          "module"
         ],
         "Value": {
           "Value": 2,
@@ -74,8 +74,8 @@
       },
       {
         "Labels": [
-          "repo",
-          "send"
+          "send",
+          "repo"
         ],
         "Value": {
           "Value": 25,

--- a/vm/parser.y
+++ b/vm/parser.y
@@ -8,7 +8,6 @@ import (
     "io"
     "fmt"
     "regexp"
-    "sort"
     "strconv"
 
     "github.com/google/mtail/metrics"
@@ -334,7 +333,6 @@ decl
 	} else {
         n = d.name
    	}
-      sort.Sort(sort.StringSlice(d.keys))
       d.m = metrics.NewMetric(n, mtaillex.(*parser).name, d.kind, d.keys...)
       d.sym = mtaillex.(*parser).s.addSym(d.name, IDSymbol, d.m,
                                            mtaillex.(*parser).t.pos)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"regexp"
 	"runtime/debug"
-	"sort"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -348,7 +347,6 @@ func (v *VM) execute(t *thread, i instr) {
 			//fmt.Printf("Keys: %v\n", keys)
 		}
 		//fmt.Printf("Keys: %v\n", keys)
-		sort.Sort(sort.StringSlice(keys))
 		d, err := m.GetDatum(keys...)
 		if err != nil {
 			v.errorf("GetDatum failed: %s", err)


### PR DESCRIPTION
I don't know why this was done originally, but sorting the keys breaks most multi-dimensional metrics. The test cases seem to have been very lucky.