### PR TITLE
Remove timestamps from Prometheus exporter

### DIFF
--- a/exporter/export_prometheus.go
+++ b/exporter/export_prometheus.go
@@ -18,7 +18,7 @@ var (
 )
 
 const (
-	prometheusFormat = "%s{%s} %d %d\n"
+	prometheusFormat = "%s{%s} %d\n"
 )
 
 func noHyphens(s string) string {
@@ -61,6 +61,5 @@ func metricToPrometheus(hostname string, m *metrics.Metric, l *metrics.LabelSet)
 	return fmt.Sprintf(prometheusFormat,
 		noHyphens(m.Name),
 		strings.Join(s, ","),
-		l.Datum.Get(),
-		l.Datum.Time.UnixNano()/int64(1e6))
+		l.Datum.Get())
 }

--- a/exporter/export_prometheus_test.go
+++ b/exporter/export_prometheus_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/google/mtail/metrics"
 	"github.com/kylelemons/godebug/pretty"
@@ -29,10 +28,10 @@ var handlePrometheusTests = []struct {
 				Name:        "foo",
 				Program:     "test",
 				Kind:        metrics.Counter,
-				LabelValues: []*metrics.LabelValue{&metrics.LabelValue{Labels: []string{}, Value: &metrics.Datum{Value: 1, Time: time.Date(2014, time.April, 16, 216, 35, 0, 0, time.UTC)}}}},
+				LabelValues: []*metrics.LabelValue{&metrics.LabelValue{Labels: []string{}, Value: &metrics.Datum{Value: 1}}}},
 		},
 		`# TYPE foo counter
-foo{prog="test",instance="gunstar"} 1 1398386100000
+foo{prog="test",instance="gunstar"} 1
 `,
 	},
 	{"dimensioned",
@@ -42,11 +41,11 @@ foo{prog="test",instance="gunstar"} 1 1398386100000
 				Program:     "test",
 				Kind:        metrics.Counter,
 				Keys:        []string{"a", "b"},
-				LabelValues: []*metrics.LabelValue{&metrics.LabelValue{Labels: []string{"1", "2"}, Value: &metrics.Datum{Value: 1, Time: time.Date(2014, time.April, 16, 216, 35, 0, 0, time.UTC)}}},
+				LabelValues: []*metrics.LabelValue{&metrics.LabelValue{Labels: []string{"1", "2"}, Value: &metrics.Datum{Value: 1}}},
 			},
 		},
 		`# TYPE foo counter
-foo{a="1",b="2",prog="test",instance="gunstar"} 1 1398386100000
+foo{a="1",b="2",prog="test",instance="gunstar"} 1
 `,
 	},
 }


### PR DESCRIPTION
Returning the "last updated" time for a counter is not correct for
Prometheus metrics.  It's recommended to omit the timestamp and allow
the server to pick the timestamp.