### PR TITLE
Add example apache metrics-friendly config

### DIFF
--- a/examples/apache_metrics.mtail
+++ b/examples/apache_metrics.mtail
@@ -1,0 +1,40 @@
+# Copyright 2015 Ben Kochie <superq@gmail.com>. All Rights Reserved.
+# This file is available under the Apache license.
+
+# Parser for a metrics-friendly apache log format
+# LogFormat "%v:%p %R %m %>s %H conn=%X %D %O %I %k" metrics
+counter apache_http_requests_total by server_port, handler, request_method, request_status, request_protocol
+counter apache_http_connections_total by server_port, handler, request_method, request_status, request_protocol, connection_status
+counter apache_http_requests_time_microseconds_total by server_port, handler, request_method, request_status, request_protocol
+counter apache_http_sent_bytes_total by server_port, handler, request_method, request_status, request_protocol
+counter apache_http_recieved_bytes_total by server_port, handler, request_method, request_status, request_protocol
+
+/^/ +
+/(?P<server_port>\S+) / + # %v:%p - The canonical ServerName of the server serving the request. : The canonical port of the server serving the request.
+/(?P<handler>\S+) / + # %R - The handler generating the response (if any).
+/(?P<request_method>[A-Z]+) / + # %m - The request method.
+/(?P<request_status>\d{3}) / + # %>s - Status.
+/(?P<request_protocol>\S+) / + # %H - The request protocol.
+/(?P<connection_status>conn=.) / + # %X - Connection status when response is completed
+/(?P<time_us>\d+) / + # %D - The time taken to serve the request, in microseconds.
+/(?P<sent_bytes>\d+) / + # %O - Bytes sent, including headers.
+/(?P<recived_bytes>\d+) / + # %I - Bytes received, including request and headers.
+/(?P<keepalives>\d+)/ + # %k - Number of keepalive requests handled on this connection.
+/$/ {
+  apache_http_requests_total[$server_port][$handler][$request_method][$request_status][$request_protocol]++
+  apache_http_requests_time_microseconds_total[$server_port][$handler][$request_method][$request_status][$request_protocol] += $time_us
+  apache_http_sent_bytes_total[$server_port][$handler][$request_method][$request_status][$request_protocol] += $sent_bytes
+  apache_http_recieved_bytes_total[$server_port][$handler][$request_method][$request_status][$request_protocol] += $recived_bytes
+
+  ### Connection status when response is completed:
+  # X = Connection aborted before the response completed.
+  # + = Connection may be kept alive after the response is sent.
+  # - = Connection will be closed after the response is sent.
+  / conn=X / {
+    apache_http_connections_total[$server_port][$handler][$request_method][$request_status][$request_protocol]["aborted"]++
+  }
+  # Will not include all closed connections. :-(
+  / conn=- / {
+    apache_http_connections_total[$server_port][$handler][$request_method][$request_status][$request_protocol]["closed"]++
+  }
+}


### PR DESCRIPTION
Add a new custom apache LogFormat for getting the most out of apache
request logging.

`LogFormat "%v:%p %R %m %>s %H conn=%X %D %O %I %k" metrics`

New metrics are now possible:
* apache_http_requests_total
* apache_http_connections_total (only partly useful)
* apache_http_requests_time_microseconds_total
* apache_http_sent_bytes_total
* apache_http_recieved_bytes_total

All of these metrics are by server_port, handler, request_method,
request_status, request_protocol.