### PR TITLE
Timer as gauge for Prometheus/CollectD

### DIFF
--- a/exporter/collectd.go
+++ b/exporter/collectd.go
@@ -30,9 +30,16 @@ func metricToCollectd(hostname string, m *metrics.Metric, l *metrics.LabelSet) s
 	return fmt.Sprintf(collectdFormat,
 		hostname,
 		m.Program,
-		strings.ToLower(m.Kind.String()),
+		kindToCollectdType(m.Kind),
 		formatLabels(m.Name, l.Labels, "-", "-"),
 		*pushInterval,
 		l.Datum.Time/1e9,
 		l.Datum.Get())
+}
+
+func kindToCollectdType(kind metrics.Kind) string {
+	if kind != metrics.Timer {
+		return strings.ToLower(kind.String())
+	}
+	return "gauge"
 }

--- a/exporter/export_test.go
+++ b/exporter/export_test.go
@@ -59,6 +59,18 @@ func TestMetricToCollectd(t *testing.T) {
 	if len(diff) > 0 {
 		t.Errorf("String didn't match:\n%s", diff)
 	}
+
+	timingMetric := metrics.NewMetric("foo", "prog", metrics.Timer)
+	d, _ = timingMetric.GetDatum()
+	d.Set(123, ts)
+	ms.Add(timingMetric)
+
+	r = FakeSocketWrite(metricToCollectd, timingMetric)
+	expected = []string{"PUTVAL \"gunstar/mtail-prog/gauge-foo\" interval=60 1343124840:123\n"}
+	diff = pretty.Compare(r, expected)
+	if len(diff) > 0 {
+		t.Errorf("String didn't match:\n%s", diff)
+	}
 }
 
 func TestMetricToGraphite(t *testing.T) {

--- a/exporter/prometheus_test.go
+++ b/exporter/prometheus_test.go
@@ -48,6 +48,30 @@ foo{prog="test",instance="gunstar"} 1
 foo{a="1",b="2",prog="test",instance="gunstar"} 1
 `,
 	},
+	{"gauge",
+		[]*metrics.Metric{
+			&metrics.Metric{
+				Name:        "foo",
+				Program:     "test",
+				Kind:        metrics.Gauge,
+				LabelValues: []*metrics.LabelValue{&metrics.LabelValue{Labels: []string{}, Value: &metrics.Datum{Value: 1}}}},
+		},
+		`# TYPE foo gauge
+foo{prog="test",instance="gunstar"} 1
+`,
+	},
+	{"timer",
+		[]*metrics.Metric{
+			&metrics.Metric{
+				Name:        "foo",
+				Program:     "test",
+				Kind:        metrics.Timer,
+				LabelValues: []*metrics.LabelValue{&metrics.LabelValue{Labels: []string{}, Value: &metrics.Datum{Value: 1}}}},
+		},
+		`# TYPE foo gauge
+foo{prog="test",instance="gunstar"} 1
+`,
+	},
 }
 
 func TestHandlePrometheus(t *testing.T) {


### PR DESCRIPTION
Related to Issue #15 

The `timer` metric is specific to the StatsD exporter. For the other exporters, it should be exposed as a `gauge`.

Prometheus and CollectD exporters publish their metrics with the type/kind info. In these cases, we ensure that `timer` is published as `gauge`.

Graphite and Varz don't expect metric type/kind info so I've not made any changes there.
