### PR TITLE
Output string constants when dumping bytecode.

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -570,6 +570,10 @@ func (v *VM) DumpByteCode(name string) {
 	for i, re := range v.re {
 		fmt.Printf(" %8d /%s/\n", i, re)
 	}
+	fmt.Println("Strings")
+	for i, str := range v.str {
+		fmt.Printf(" %8d \"%s\"\n", i, str)
+	}
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 0, 0, 1, ' ', tabwriter.AlignRight)
 


### PR DESCRIPTION
This makes it possible to follow the 'str' instructions.