### PR TITLE
Fix two bugs in one_shot line handling.

### DIFF
--- a/mtail/mtail.go
+++ b/mtail/mtail.go
@@ -13,6 +13,7 @@ import (
 	"os/signal"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -61,9 +62,12 @@ func (m *Mtail) OneShot(logfile string, print bool) (count int64, err error) {
 Loop:
 	for {
 		line, err := r.ReadString('\n')
+		line = strings.TrimSuffix(line, "\n")
 		switch {
 		case err == io.EOF:
-			m.lines <- line
+			if len(line) > 0 {
+				m.lines <- line
+			}
 			break Loop
 		case err != nil:
 			return 0, fmt.Errorf("failed to read from %q: %s", logfile, err)


### PR DESCRIPTION
- Lines read in one_shot mode are sent to the VM with trailing newlines
  still intact, which means simple regexes like /^1$/ will never match
  in one_shot mode.
- When EOF is reached, the current line buffer is sent, even if it's
  empty.

The former is fixed by trimming trailing newlines from the line before
sending it to the VM. The latter is fixed by not sending an empty string
on EOF.

Empty lines are still passed through as before.