### PR TITLE
Fix deadlock on removal of watches

### DIFF
--- a/tailer/tail.go
+++ b/tailer/tail.go
@@ -208,10 +208,13 @@ func (t *Tailer) handleLogCreate(pathname string) {
 			// flush the old log, pathname is still an index into t.files with the old inode.
 			t.handleLogUpdate(pathname)
 			fd.Close()
-			err := t.w.Remove(pathname)
-			if err != nil {
-				glog.Infof("Failed removing watches on %s: %s", pathname, err)
-			}
+			go func() {
+				// Run in goroutine as Remove may block waiting on event processing.
+				err := t.w.Remove(pathname)
+				if err != nil {
+					glog.Infof("Failed removing watches on %s: %s", pathname, err)
+				}
+			}()
 			t.openLogPath(pathname, true)
 		} else {
 			glog.V(1).Infof("Path %s already being watched, and inode not changed.",


### PR DESCRIPTION
fsnotify has the inherent problem that the Watcher.Remove method
relies on events still being read from the events channel
(https://github.com/fsnotify/fsnotify/blob/master/inotify.go#L158). However,
the mtail code stops reading from the event channel until
Watcher.Remove has returned. Certain events, happening with the right
timing, can trigger this deadlock. This leads to
https://github.com/google/mtail/issues/27 , i.e. now and then, on
systems where logfiles are rotated away, mtail hangs.

This PR fixes the problem by running the Watcher.Remove call in its
own goroutine. I'm not entirely sure about undesired side effects, but
in our large-scale mtail setup at SoundCloud, it fixed the original
problem and didn't cause any new ones so far.

Ideally, we should have a test for the bug, but it's hard to recreate
the exact course of events reliably.

And obviously, I think the real problem is how fsnotify handles this
internally.

@jaqx0r 