### PR TITLE
convert type for other platforms

### DIFF
--- a/tailer/tail.go
+++ b/tailer/tail.go
@@ -183,7 +183,7 @@ func inode(f os.FileInfo) uint64 {
 	}
 	switch s := s.(type) {
 	case *syscall.Stat_t:
-		return s.Ino
+		return uint64(s.Ino)
 	default:
 		return 0
 	}


### PR DESCRIPTION
This pull request converts the type of an inode in the stat object to the type required by the function. This enables mtail to compile on platforms other than linux and darwin.