### PR TITLE
Replace glog.Error with glog.Errorf

### DIFF
--- a/mtail/mtail.go
+++ b/mtail/mtail.go
@@ -103,7 +103,7 @@ func (m *Mtail) StartTailing() error {
 	for _, fd := range m.o.LogFds {
 		f := os.NewFile(uintptr(fd), strconv.Itoa(fd))
 		if f == nil {
-			glog.Error("Attempt to reopen fd %q returned nil", fd)
+			glog.Errorf("Attempt to reopen fd %q returned nil", fd)
 			continue
 		}
 		if e := m.t.TailFile(f); e != nil {


### PR DESCRIPTION
Due having a placeholder in the string by bet that this is a typo.