### PR TITLE
Return error when program loading failed

### DIFF
--- a/vm/loader.go
+++ b/vm/loader.go
@@ -64,7 +64,10 @@ func (l *Loader) LoadProgs(programPath string) error {
 			if fi.IsDir() {
 				continue
 			}
-			l.LoadProg(path.Join(programPath, fi.Name()))
+			err = l.LoadProg(path.Join(programPath, fi.Name()))
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	default:


### PR DESCRIPTION
I just run mtail, test a simple program, and found that when program has syntax error, mtail will not print any error messages. 

So I hack the code and fix this problem. 
