### PR TITLE
Use string quoting for prometheus export

### DIFF
--- a/exporter/prometheus.go
+++ b/exporter/prometheus.go
@@ -54,7 +54,7 @@ func (e *Exporter) HandlePrometheusMetrics(w http.ResponseWriter, r *http.Reques
 func metricToPrometheus(hostname string, m *metrics.Metric, l *metrics.LabelSet) string {
 	var s []string
 	for k, v := range l.Labels {
-		s = append(s, fmt.Sprintf("%s=\"%s\"", k, v))
+		s = append(s, fmt.Sprintf("%s=%q", k, v))
 	}
 	sort.Strings(s)
 	s = append(s, fmt.Sprintf("prog=\"%s\"", m.Program))

--- a/exporter/prometheus_test.go
+++ b/exporter/prometheus_test.go
@@ -72,6 +72,20 @@ foo{prog="test",instance="gunstar"} 1
 foo{prog="test",instance="gunstar"} 1
 `,
 	},
+	{"quotes",
+		[]*metrics.Metric{
+			&metrics.Metric{
+				Name:        "foo",
+				Program:     "test",
+				Kind:        metrics.Counter,
+				Keys:        []string{"a"},
+				LabelValues: []*metrics.LabelValue{&metrics.LabelValue{Labels: []string{"str\"bang\"blah"}, Value: &metrics.Datum{Value: 1}}},
+			},
+		},
+		`# TYPE foo counter
+foo{a="str\"bang\"blah",prog="test",instance="gunstar"} 1
+`,
+	},
 }
 
 func TestHandlePrometheus(t *testing.T) {


### PR DESCRIPTION
This fixes a problem with metrics export when a label value includes double quotes (I'm evil and have a cron job text in a label value when exporting stuff from cron.log)
