### PR TITLE
exporter: add prefix option for graphite/statsd metrics

### DIFF
--- a/exporter/collectd.go
+++ b/exporter/collectd.go
@@ -13,12 +13,14 @@ import (
 )
 
 const (
-	collectdFormat = "PUTVAL \"%s/mtail-%s/%s-%s\" interval=%d %d:%d\n"
+	collectdFormat = "PUTVAL \"%s/%smtail-%s/%s-%s\" interval=%d %d:%d\n"
 )
 
 var (
 	collectdSocketPath = flag.String("collectd_socketpath", "",
 		"Path to collectd unixsock to write metrics to.")
+	collectdPrefix = flag.String("collectd_prefix", "",
+		"Prefix to use for collectd metrics.")
 
 	collectdExportTotal   = expvar.NewInt("collectd_export_total")
 	collectdExportSuccess = expvar.NewInt("collectd_export_success")
@@ -29,6 +31,7 @@ func metricToCollectd(hostname string, m *metrics.Metric, l *metrics.LabelSet) s
 	defer m.RUnlock()
 	return fmt.Sprintf(collectdFormat,
 		hostname,
+		*collectdPrefix,
 		m.Program,
 		kindToCollectdType(m.Kind),
 		formatLabels(m.Name, l.Labels, "-", "-"),

--- a/exporter/graphite.go
+++ b/exporter/graphite.go
@@ -14,6 +14,8 @@ import (
 var (
 	graphiteHostPort = flag.String("graphite_host_port", "",
 		"Host:port to graphite carbon server to write metrics to.")
+	graphitePrefix = flag.String("graphite_prefix", "",
+		"Prefix to use for graphite metrics.")
 
 	graphiteExportTotal   = expvar.NewInt("graphite_export_total")
 	graphiteExportSuccess = expvar.NewInt("graphite_export_success")
@@ -22,7 +24,8 @@ var (
 func metricToGraphite(hostname string, m *metrics.Metric, l *metrics.LabelSet) string {
 	m.RLock()
 	defer m.RUnlock()
-	return fmt.Sprintf("%s.%s %v %v\n",
+	return fmt.Sprintf("%s%s.%s %v %v\n",
+		*graphitePrefix,
 		m.Program,
 		formatLabels(m.Name, l.Labels, ".", "."),
 		l.Datum.Get(),

--- a/exporter/statsd.go
+++ b/exporter/statsd.go
@@ -14,6 +14,8 @@ import (
 var (
 	statsdHostPort = flag.String("statsd_hostport", "",
 		"Host:port to statsd server to write metrics to.")
+	statsdPrefix = flag.String("statsd_prefix", "",
+		"Prefix to use for statsd metrics.")
 
 	statsdExportTotal   = expvar.NewInt("statsd_export_total")
 	statsdExportSuccess = expvar.NewInt("statsd_export_success")
@@ -31,7 +33,8 @@ func metricToStatsd(hostname string, m *metrics.Metric, l *metrics.LabelSet) str
 	case metrics.Timer:
 		t = "ms" // StatsD Timer
 	}
-	return fmt.Sprintf("%s.%s:%d|%s",
+	return fmt.Sprintf("%s%s.%s:%d|%s",
+		*statsdPrefix,
 		m.Program,
 		formatLabels(m.Name, l.Labels, ".", "."),
 		l.Datum.Get(), t)


### PR DESCRIPTION
Useful for example to further namespace metrics by host or other criteria.
