### PR TITLE
exporter: increase logging verbosity for metric pushes

### DIFF
--- a/exporter/export.go
+++ b/exporter/export.go
@@ -101,7 +101,7 @@ func (e *Exporter) writeSocketMetrics(c net.Conn, f formatter, exportTotal *expv
 		for l := range lc {
 			line := f(e.hostname, m, l)
 			n, err := fmt.Fprint(c, line)
-			glog.Infof("Sent %d bytes\n", n)
+			glog.V(2).Infof("Sent %d bytes\n", n)
 			if err == nil {
 				exportSuccess.Add(1)
 			} else {
@@ -116,7 +116,7 @@ func (e *Exporter) writeSocketMetrics(c net.Conn, f formatter, exportTotal *expv
 // TODO(jaq) rename to PushMetrics.
 func (e *Exporter) WriteMetrics() {
 	for _, target := range e.pushTargets {
-		glog.Infof("pushing to %s", target.addr)
+		glog.V(2).Infof("pushing to %s", target.addr)
 		conn, err := net.Dial(target.net, target.addr)
 		if err != nil {
 			glog.Infof("pusher dial error: %s", err)


### PR DESCRIPTION
When pushing metrics e.g. to graphite the default verbosity spams logs a
little I'd say, e.g.:

I1107 19:58:30.027436   14445 export.go:119] pushing to XXX
I1107 19:58:30.028448   14445 export.go:104] Sent 53 bytes
I1107 19:58:30.028472   14445 export.go:104] Sent 57 bytes
I1107 19:58:30.028499   14445 export.go:104] Sent 83 bytes
I1107 19:58:30.028513   14445 export.go:104] Sent 82 bytes
I1107 19:58:30.028539   14445 export.go:104] Sent 81 bytes
I1107 19:58:30.028578   14445 export.go:104] Sent 65 bytes
I1107 19:58:30.028595   14445 export.go:104] Sent 64 bytes
I1107 19:58:30.028610   14445 export.go:104] Sent 71 bytes