### PR TITLE
Ignore hidden program files

### DIFF
--- a/vm/loader.go
+++ b/vm/loader.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/golang/glog"
@@ -83,6 +84,10 @@ func (l *Loader) LoadProgs(programPath string) error {
 // the program is the basename of the file.
 func (l *Loader) LoadProg(programPath string) error {
 	name := filepath.Base(programPath)
+	if strings.HasPrefix(name, ".") {
+		glog.Infof("Skipping %s because it is a hidden file.", programPath)
+		return nil
+	}
 	if filepath.Ext(name) != fileExt {
 		glog.Infof("Skipping %s due to file extension.", programPath)
 		return nil

--- a/vm/loader_test.go
+++ b/vm/loader_test.go
@@ -174,3 +174,29 @@ func TestProcessEvents(t *testing.T) {
 
 	}
 }
+
+var testProgFiles = []string{
+	"test.wrongext",
+	"test.mtail",
+	".test",
+}
+
+func TestLoadProg(t *testing.T) {
+	w := watcher.NewFakeWatcher()
+	store := metrics.NewStore()
+	inLines := make(chan string)
+	fs := afero.NewMemMapFs()
+	o := LoaderOptions{store, inLines, w, fs, false, false, false, false, true}
+	l, err := NewLoader(o)
+	if err != nil {
+		t.Fatalf("couldn't create loader: %s", err)
+	}
+
+	for _, f := range testProgFiles {
+		afero.WriteFile(fs, f, []byte(testProgram), 0644)
+		err = l.LoadProg(f)
+		if err != nil {
+			t.Fatalf("couldn't load file: %s error: %s", f, err)
+		}
+	}
+}


### PR DESCRIPTION
Ignore "hidden" program files that start with a `.`.  This avoids
attempting to load temp files deployed by config management systems.