### PR TITLE
compare unexported fields with deep.Equal

### DIFF
--- a/vm/checker_test.go
+++ b/vm/checker_test.go
@@ -150,6 +150,10 @@ func TestCheckTypeExpressions(t *testing.T) {
 			continue
 		}
 
+		defaultCompareUnexportedFields := deep.CompareUnexportedFields
+		deep.CompareUnexportedFields = true
+		defer func() { deep.CompareUnexportedFields = defaultCompareUnexportedFields }()
+
 		diff := deep.Equal(tc.expected, tc.expr.Type())
 		if len(diff) > 0 {
 			t.Errorf("Unspected return for input %d:\n%s", i, diff)

--- a/vm/codegen_test.go
+++ b/vm/codegen_test.go
@@ -45,7 +45,7 @@ var testCodeGenPrograms = []struct {
 			instr{jnm, 11},
 			instr{setmatched, false},
 			instr{push, 0},
-			instr{capref, 0},
+			instr{capref, 1},
 			instr{str, 0},
 			instr{strptime, 2},
 			instr{mload, 0},
@@ -83,13 +83,13 @@ var testCodeGenPrograms = []struct {
 			instr{mload, 0},
 			instr{dload, 0},
 			instr{push, 0},
-			instr{capref, 0},
+			instr{capref, 1},
 			instr{iadd, nil},
 			instr{iset, nil},
 			instr{mload, 1},
 			instr{dload, 0},
 			instr{push, 0},
-			instr{capref, 0},
+			instr{capref, 1},
 			instr{iset, nil},
 			instr{setmatched, true}}},
 	{"cond expr gt",
@@ -194,7 +194,7 @@ var testCodeGenPrograms = []struct {
 			instr{jnm, 14},
 			instr{setmatched, false},
 			instr{push, 0},
-			instr{capref, 0},
+			instr{capref, 1},
 			instr{push, 1},
 			instr{cmp, 1},
 			instr{jm, 13},
@@ -264,12 +264,12 @@ $1 ** $2
 `,
 		[]instr{
 			instr{match, 0},
-			instr{jnm, 7},
+			instr{jnm, 9},
 			instr{setmatched, false},
 			instr{push, 0},
-			instr{capref, 0},
-			instr{push, 0},
 			instr{capref, 1},
+			instr{push, 0},
+			instr{capref, 2},
 			instr{ipow, nil},
 			instr{setmatched, true}}},
 	{"indexed expr", `
@@ -370,7 +370,7 @@ gauge f
 			instr{capref, 1},
 			instr{iset, nil},
 			instr{setmatched, true},
-			instr{match, 0},
+			instr{match, 1},
 			instr{jnm, 18},
 			instr{setmatched, false},
 			instr{mload, 1},
@@ -402,6 +402,11 @@ func TestCodegen(t *testing.T) {
 			t.Logf("AST:\n%s", s.Dump(ast))
 			continue
 		}
+
+		defaultCompareUnexportedFields := deep.CompareUnexportedFields
+		deep.CompareUnexportedFields = true
+		defer func() { deep.CompareUnexportedFields = defaultCompareUnexportedFields }()
+
 		if diff := deep.Equal(tc.prog, obj.prog); diff != nil {
 			t.Errorf("%s: VM prog doesn't match.\n%s", tc.name, diff)
 			t.Logf("Expected:\n%s\nReceived:\n%s", tc.prog, obj.prog)

--- a/vm/lexer_test.go
+++ b/vm/lexer_test.go
@@ -139,7 +139,7 @@ var lexerTests = []lexerTest{
 		token{CAPREF, "1", position{"numerical capref", 0, 0, 1}},
 		token{EOF, "", position{"numerical capref", 0, 2, 2}}}},
 	{"capref with trailing punc", "$foo,", []token{
-		token{CAPREF, "foo", position{"capref with trailing punc", 0, 0, 3}},
+		token{CAPREF_NAMED, "foo", position{"capref with trailing punc", 0, 0, 3}},
 		token{COMMA, ",", position{"capref with trailing punc", 0, 4, 4}},
 		token{EOF, "", position{"capref with trailing punc", 0, 5, 5}}}},
 	{"quoted string", `"asdf"`, []token{
@@ -163,7 +163,7 @@ var lexerTests = []lexerTest{
 			token{NL, "\n", position{"large program", 1, 29, -1}},
 			token{BUILTIN, "strptime", position{"large program", 1, 2, 9}},
 			token{LPAREN, "(", position{"large program", 1, 10, 10}},
-			token{CAPREF, "date", position{"large program", 1, 11, 15}},
+			token{CAPREF_NAMED, "date", position{"large program", 1, 11, 15}},
 			token{COMMA, ",", position{"large program", 1, 16, 16}},
 			token{STRING, "%Y/%m/%d %H:%M:%S", position{"large program", 1, 18, 36}},
 			token{RPAREN, ")", position{"large program", 1, 37, 37}},
@@ -215,6 +215,11 @@ func TestLex(t *testing.T) {
 	for _, tc := range lexerTests {
 		t.Logf("Starting %s", tc.name)
 		tokens := collect(&tc)
+
+		defaultCompareUnexportedFields := deep.CompareUnexportedFields
+		deep.CompareUnexportedFields = true
+		defer func() { deep.CompareUnexportedFields = defaultCompareUnexportedFields }()
+
 		if diff := deep.Equal(tc.tokens, tokens); diff != nil {
 			t.Errorf("%s tokens didn't match:\n%s:", tc.name, diff)
 		}


### PR DESCRIPTION
Set `deep.CompareUnexportedFields` to `true` if `deep.Equal`
is used to compare structs with unexported fields.