### PR TITLE
[WIP] add support for histogram

### DIFF
--- a/emgen/emgen.go
+++ b/emgen/emgen.go
@@ -44,7 +44,7 @@ var table = map[string]node{
 	"decl":          {[][]string{{"hide_spec", "type_spec", "declarator"}}, ""},
 	"hide_spec":     {[][]string{{""}, {"hidden"}}, ""},
 	"declarator":    {[][]string{{"declarator", "by_spec"}, {"declarator", "as_spec"}, {"ID"}, {"STRING"}}, ""},
-	"type_spec":     {[][]string{{"counter"}, {"gauge"}}, ""},
+	"type_spec":     {[][]string{{"counter"}, {"gauge"}, {"histogram"}}, ""},
 	"by_spec":       {[][]string{{"by", "by_expr_list"}}, ""},
 	"by_expr_list":  {[][]string{{"ID"}, {"STRING"}, {"by_expr_list", ",", "ID"}, {"by_expr_list", ",", "STRING"}}, ""},
 	"as_spec":       {[][]string{{"as", "STRING"}}, ""},

--- a/metrics/datum/buckets.go
+++ b/metrics/datum/buckets.go
@@ -1,0 +1,119 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+// This file is available under the Apache license.
+
+package datum
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type Range struct {
+	Min float64
+	Max float64
+}
+
+type bucketCount struct {
+	Range Range
+	Count uint64
+}
+
+func (r *Range) Contains(v float64) bool {
+	return r.Min <= v && v < r.Max
+}
+
+// BucketsDatum describes a floating point value at a given timestamp.
+type BucketsDatum struct {
+	datum
+	sync.RWMutex
+	buckets []bucketCount
+	count   uint64
+	sum     float64
+}
+
+func (*BucketsDatum) Type() Type { return Buckets }
+
+func (d *BucketsDatum) Value() string {
+	return fmt.Sprintf("%g", d.Get())
+}
+
+func (d *BucketsDatum) Set(v float64, ts time.Time) {
+	d.Lock()
+	defer d.Unlock()
+
+	for i, b := range d.buckets {
+		if b.Range.Contains(v) {
+			d.buckets[i].Count++
+			break
+		}
+	}
+
+	d.count++
+	d.sum += v
+
+	d.stamp(ts)
+}
+
+func (d *BucketsDatum) Get() float64 {
+	d.RLock()
+	defer d.RUnlock()
+
+	return d.sum
+}
+
+func (d *BucketsDatum) String() string {
+	return fmt.Sprintf("%g@%d", d.Get(), atomic.LoadInt64(&d.time))
+}
+
+func (d *BucketsDatum) Count() uint64 {
+	return atomic.LoadUint64(&d.count)
+}
+
+func (d *BucketsDatum) Sum() float64 {
+	d.RLock()
+	defer d.RUnlock()
+
+	return d.sum
+}
+
+func (d *BucketsDatum) AddBucket(r Range) {
+	d.Lock()
+	defer d.Unlock()
+
+	d.buckets = append(d.buckets, bucketCount{r, 0})
+}
+
+func (d *BucketsDatum) Buckets() map[Range]uint64 {
+	d.RLock()
+	defer d.RUnlock()
+
+	b := make(map[Range]uint64)
+	for _, bc := range d.buckets {
+		b[bc.Range] = bc.Count
+	}
+	return b
+}
+
+func (d *BucketsDatum) MarshalJSON() ([]byte, error) {
+	d.RLock()
+	defer d.RUnlock()
+
+	bs := make(map[string]uint64, 0)
+
+	for _, b := range d.buckets {
+		bs[strconv.FormatFloat(b.Range.Max, 'g', -1, 64)] = b.Count
+	}
+
+	j := struct {
+		Buckets map[string]uint64
+		Count   uint64
+		Sum     float64
+		Time    int64
+	}{bs, d.count, d.sum, atomic.LoadInt64(&d.time)}
+
+	return json.Marshal(j)
+}

--- a/metrics/datum/datum.go
+++ b/metrics/datum/datum.go
@@ -14,6 +14,7 @@ type Type int
 const (
 	Int Type = iota
 	Float
+	Buckets
 )
 
 func (t Type) String() string {
@@ -22,6 +23,8 @@ func (t Type) String() string {
 		return "Int"
 	case Float:
 		return "Float"
+	case Buckets:
+		return "Buckets"
 	}
 	return "?"
 }
@@ -62,6 +65,10 @@ func NewFloat() Datum {
 	return MakeFloat(0., zeroTime)
 }
 
+func NewBuckets(buckets []Range) Datum {
+	return MakeBuckets(0., buckets, zeroTime)
+}
+
 func MakeInt(v int64, ts time.Time) Datum {
 	d := &intDatum{}
 	d.Set(v, ts)
@@ -70,6 +77,17 @@ func MakeInt(v int64, ts time.Time) Datum {
 
 func MakeFloat(v float64, ts time.Time) Datum {
 	d := &floatDatum{}
+	d.Set(v, ts)
+	return d
+}
+
+func MakeBuckets(v float64, buckets []Range, ts time.Time) Datum {
+	d := &BucketsDatum{}
+
+	for _, r := range buckets {
+		d.AddBucket(r)
+	}
+
 	d.Set(v, ts)
 	return d
 }
@@ -96,6 +114,8 @@ func SetInt(d Datum, v int64, ts time.Time) {
 	switch d := d.(type) {
 	case *intDatum:
 		d.Set(v, ts)
+	case *BucketsDatum:
+		d.Set(float64(v), ts)
 	default:
 		panic(fmt.Sprintf("datum %v is not an Int", d))
 	}
@@ -105,6 +125,8 @@ func SetFloat(d Datum, v float64, ts time.Time) {
 	switch d := d.(type) {
 	case *floatDatum:
 		d.Set(v, ts)
+	case *BucketsDatum:
+		d.Set(float64(v), ts)
 	default:
 		panic(fmt.Sprintf("datum %v is not a Float", d))
 	}

--- a/testdata/reader.go
+++ b/testdata/reader.go
@@ -17,7 +17,7 @@ import (
 	"github.com/google/mtail/metrics/datum"
 )
 
-var var_re = regexp.MustCompile(`^(counter|gauge|timer) ([^ ]+)(?: {([^}]+)})?(?: ([+-]?\d+(?:\.\d+(?:[eE]-?\d+)?)?))?(?: (.+))?`)
+var var_re = regexp.MustCompile(`^(counter|gauge|timer|histogram) ([^ ]+)(?: {([^}]+)})?(?: ([+-]?\d+(?:\.\d+(?:[eE]-?\d+)?)?))?(?: (.+))?`)
 
 // Find a metric in a store
 func FindMetricOrNil(store *metrics.Store, name string) *metrics.Metric {
@@ -61,6 +61,8 @@ func ReadTestData(file io.Reader, programfile string, store *metrics.Store) {
 			kind = metrics.Gauge
 		case "timer":
 			kind = metrics.Timer
+		case "histogram":
+			kind = metrics.Histogram
 		}
 		glog.V(2).Infof("match[4]: %q", match[4])
 		typ := datum.Int

--- a/vm/ast.go
+++ b/vm/ast.go
@@ -165,6 +165,7 @@ type declNode struct {
 	name         string
 	hidden       bool
 	keys         []string
+	buckets      []float64
 	kind         metrics.Kind
 	exportedName string
 	sym          *Symbol
@@ -175,7 +176,9 @@ func (n *declNode) Pos() *position {
 }
 
 func (n *declNode) Type() Type {
-	if n.sym != nil {
+	if n.kind == metrics.Histogram {
+		return Buckets
+	} else if n.sym != nil {
 		return n.sym.Type.Root()
 	}
 	return Undef

--- a/vm/lexer.go
+++ b/vm/lexer.go
@@ -51,6 +51,7 @@ var lexemeName = map[lexeme]string{
 	COUNTER:    "COUNTER",
 	GAUGE:      "GAUGE",
 	TIMER:      "TIMER",
+	HISTOGRAM:  "HISTOGRAM",
 	AS:         "AS",
 	BY:         "BY",
 	HIDDEN:     "HIDDEN",
@@ -61,6 +62,7 @@ var lexemeName = map[lexeme]string{
 	OTHERWISE:  "OTHERWISE",
 	ELSE:       "ELSE",
 	DEL:        "DEL",
+	WITH:       "WITH",
 }
 
 func (t lexeme) String() string {
@@ -80,10 +82,12 @@ var keywords = map[string]lexeme{
 	"del":       DEL,
 	"else":      ELSE,
 	"gauge":     GAUGE,
+	"histogram": HISTOGRAM,
 	"hidden":    HIDDEN,
 	"next":      NEXT,
 	"otherwise": OTHERWISE,
 	"timer":     TIMER,
+	"with":      WITH,
 }
 
 // List of builtin functions.  Keep this list sorted!

--- a/vm/lexer_test.go
+++ b/vm/lexer_test.go
@@ -61,7 +61,7 @@ var lexerTests = []lexerTest{
 		token{MOD, "%", position{"operators", 0, 49, 49}},
 		token{EOF, "", position{"operators", 0, 50, 50}}}},
 	{"keywords",
-		"counter\ngauge\nas\nby\nhidden\ndef\nnext\nconst\ntimer\notherwise\nelse\ndel\n", []token{
+		"counter\ngauge\nas\nby\nhidden\ndef\nnext\nconst\ntimer\notherwise\nelse\ndel\nhistogram\n", []token{
 			token{COUNTER, "counter", position{"keywords", 0, 0, 6}},
 			token{NL, "\n", position{"keywords", 1, 7, -1}},
 			token{GAUGE, "gauge", position{"keywords", 1, 0, 4}},
@@ -86,7 +86,9 @@ var lexerTests = []lexerTest{
 			token{NL, "\n", position{"keywords", 11, 4, -1}},
 			token{DEL, "del", position{"keywords", 11, 0, 2}},
 			token{NL, "\n", position{"keywords", 12, 3, -1}},
-			token{EOF, "", position{"keywords", 12, 0, 0}}}},
+			token{HISTOGRAM, "histogram", position{"keywords", 12, 0, 8}},
+			token{NL, "\n", position{"keywords", 13, 9, -1}},
+			token{EOF, "", position{"keywords", 13, 0, 0}}}},
 	{"builtins",
 		"strptime\ntimestamp\ntolower\nlen\nstrtol\nsettime\n", []token{
 			token{BUILTIN, "strptime", position{"builtins", 0, 0, 7}},

--- a/vm/types.go
+++ b/vm/types.go
@@ -66,11 +66,12 @@ func (t *TypeOperator) String() string {
 
 // Builtin types
 var (
-	Undef  = &TypeOperator{"Undef"}
-	None   = &TypeOperator{"None"}
-	Int    = &TypeOperator{"Int"}
-	Float  = &TypeOperator{"Float"}
-	String = &TypeOperator{"String"}
+	Undef   = &TypeOperator{"Undef"}
+	None    = &TypeOperator{"None"}
+	Int     = &TypeOperator{"Int"}
+	Float   = &TypeOperator{"Float"}
+	String  = &TypeOperator{"String"}
+	Buckets = &TypeOperator{"Buckets"}
 )
 
 // Unify performs type unification of both parameter Types.  It returns the


### PR DESCRIPTION
It still needs some work, testing, and docs, but I'd like your feedback. I'm completely sure about the new datum `Buckets` and the syntax.

A histogram is defined as `histogram <name> with 0, .1, .3, 1.`. It has the same syntax as the other metrics plus the keyword `with` to define the metric's buckets.

A histogram always uses the datum `Buckets`, when a new value
is assigned to the metric (`iset`), it will:

+ increment the counter for the observed value.
+ increment the total count.
+ update the total sum of all the observations.

Thank you.