### PR TITLE
Remove instance label from Prometheus format

### DIFF
--- a/exporter/prometheus.go
+++ b/exporter/prometheus.go
@@ -66,7 +66,6 @@ func metricToPrometheus(hostname string, m *metrics.Metric, l *metrics.LabelSet)
 	}
 	sort.Strings(s)
 	s = append(s, fmt.Sprintf("prog=\"%s\"", m.Program))
-	s = append(s, fmt.Sprintf("instance=\"%s\"", hostname))
 	return fmt.Sprintf(prometheusFormat,
 		noHyphens(m.Name),
 		strings.Join(s, ","),

--- a/exporter/prometheus_test.go
+++ b/exporter/prometheus_test.go
@@ -33,7 +33,7 @@ var handlePrometheusTests = []struct {
 				LabelValues: []*metrics.LabelValue{&metrics.LabelValue{Labels: []string{}, Value: datum.MakeInt(1, time.Unix(0, 0))}}},
 		},
 		`# TYPE foo counter
-foo{prog="test",instance="gunstar"} 1
+foo{prog="test"} 1
 `,
 	},
 	{"dimensioned",
@@ -47,7 +47,7 @@ foo{prog="test",instance="gunstar"} 1
 			},
 		},
 		`# TYPE foo counter
-foo{a="1",b="2",prog="test",instance="gunstar"} 1
+foo{a="1",b="2",prog="test"} 1
 `,
 	},
 	{"gauge",
@@ -59,7 +59,7 @@ foo{a="1",b="2",prog="test",instance="gunstar"} 1
 				LabelValues: []*metrics.LabelValue{&metrics.LabelValue{Labels: []string{}, Value: datum.MakeInt(1, time.Unix(0, 0))}}},
 		},
 		`# TYPE foo gauge
-foo{prog="test",instance="gunstar"} 1
+foo{prog="test"} 1
 `,
 	},
 	{"timer",
@@ -71,7 +71,7 @@ foo{prog="test",instance="gunstar"} 1
 				LabelValues: []*metrics.LabelValue{&metrics.LabelValue{Labels: []string{}, Value: datum.MakeInt(1, time.Unix(0, 0))}}},
 		},
 		`# TYPE foo gauge
-foo{prog="test",instance="gunstar"} 1
+foo{prog="test"} 1
 `,
 	},
 	{"quotes",
@@ -85,7 +85,7 @@ foo{prog="test",instance="gunstar"} 1
 			},
 		},
 		`# TYPE foo counter
-foo{a="str\"bang\"blah",prog="test",instance="gunstar"} 1
+foo{a="str\"bang\"blah",prog="test"} 1
 `,
 	},
 }

--- a/metrics/metric_test.go
+++ b/metrics/metric_test.go
@@ -15,6 +15,25 @@ import (
 	"github.com/google/mtail/metrics/datum"
 )
 
+func TestKindType(t *testing.T) {
+	v := Kind(0)
+	if s := v.String(); s != "Unknown" {
+		t.Errorf("Kind.String() returned %q not Unknown", s)
+	}
+	v = Counter
+	if s := v.String(); s != "Counter" {
+		t.Errorf("Kind.String() returned %q not Counter", s)
+	}
+	v = Gauge
+	if s := v.String(); s != "Gauge" {
+		t.Errorf("Kind.String() returned %q not Gauge", s)
+	}
+	v = Timer
+	if s := v.String(); s != "Timer" {
+		t.Errorf("Kind.String() returned %q not Timer", s)
+	}
+}
+
 func TestScalarMetric(t *testing.T) {
 	v := NewMetric("test", "prog", Counter, Int)
 	d, _ := v.GetDatum()


### PR DESCRIPTION
Prometheus creates instance labels at discovery time.  It is against
best practices to include it in metric output.