### PR TITLE
Resolves #82 allow specific bind interface

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,6 +99,10 @@ func main() {
 			glog.Exitf("No logs specified to tail; use -logs or -logfds")
 		}
 	}
+	if _, err := strconv.Atoi(*port); err == nil {
+		// If supplied port is a bare int try prepending ":" for implicit global bind
+		*port = ":" + *port
+	}
 	o := mtail.Options{
 		Progs:                *progs,
 		LogPathPatterns:      logs,

--- a/main.go
+++ b/main.go
@@ -51,8 +51,9 @@ var logs seqStringFlag
 var logFds seqIntFlag
 
 var (
-	port  = flag.String("port", "3903", "HTTP port to listen on.")
-	progs = flag.String("progs", "", "Name of the directory containing mtail programs")
+	port    = flag.Int("port", 3903, "HTTP port to listen on.")
+	address = flag.String("address", "", "IP address on which to bind HTTP listener")
+	progs   = flag.String("progs", "", "Name of the directory containing mtail programs")
 
 	// Compiler behaviour flags
 	oneShot        = flag.Bool("one_shot", false, "Run the contents of the provided logs until EOF and exit.")
@@ -111,15 +112,12 @@ func main() {
 			glog.Exitf("No logs specified to tail; use -logs or -logfds")
 		}
 	}
-	if _, err := strconv.Atoi(*port); err == nil {
-		// If supplied port is a bare int try prepending ":" for implicit global bind
-		*port = ":" + *port
-	}
+	hostport := fmt.Sprintf("%s:%d", *address, *port)
 	o := mtail.Options{
 		Progs:                *progs,
 		LogPathPatterns:      logs,
 		LogFds:               logFds,
-		Port:                 *port,
+		Port:                 hostport,
 		OneShot:              *oneShot,
 		OneShotMetrics:       *oneShotMetrics,
 		CompileOnly:          *compileOnly,

--- a/mtail/mtail.go
+++ b/mtail/mtail.go
@@ -148,10 +148,10 @@ func (m *MtailServer) InitLoader() error {
 const statusTemplate = `
 <html>
 <head>
-<title>mtail on :{{.Port}}</title>
+<title>mtail on {{.Port}}</title>
 </head>
 <body>
-<h1>mtail on :{{.Port}}</h1>
+<h1>mtail on {{.Port}}</h1>
 <p>Build: {{.BuildInfo}}</p>
 <p>Metrics: <a href="/json">json</a>, <a href="/metrics">prometheus</a>, <a href="/varz">varz</a></p>
 <p>Debug: <a href="/debug/pprof">debug/pprof</a>, <a href="/debug/vars">debug/vars</a></p>
@@ -285,7 +285,7 @@ func (m *MtailServer) Serve() {
 
 	go func() {
 		glog.Infof("Listening on port %s", m.o.Port)
-		err := http.ListenAndServe(":"+m.o.Port, nil)
+		err := http.ListenAndServe(m.o.Port, nil)
 		if err != nil {
 			glog.Exit(err)
 		}


### PR DESCRIPTION
* Add a bit of logic between parsing flags and instantiating mtail
  instance to decide whether to use an implicit global bind
* Updated `MtailServer` to not munge `port` since the value in `o` is
  already corrected.