### PR TITLE
Fix rails sample in regards to parsing errors 500

### DIFF
--- a/examples/rails.mtail
+++ b/examples/rails.mtail
@@ -21,7 +21,7 @@ counter rails_requests_completed_milliseconds_bucket by le, status
   rails_requests_started[$verb]++
 }
 
-/^Completed (?P<status>\d{3}) \w+ in (?P<request_milliseconds>\d+)ms .*$/ {
+/^Completed (?P<status>\d{3}) .+ in (?P<request_milliseconds>\d+)ms .*$/ {
   ###
   # Total numer of completed requests by status
   # 


### PR DESCRIPTION
An error 500 will print "Internal Server Error" as the description of
the status code, this does not matches `\w+` as the parsing will stop in
the first space character making the whole line to be excluded.

This commit fixes this by using the dot char to match instead.