### PR TITLE
Make links at `index.md` clickable

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,6 @@ Metrics are exported for scraping by a collector as JSON or Prometheus format
 over HTTP, or can be periodically sent to a collectd, statsd, or Graphite
 collector socket.
 
-Read more about the [Programming Guide](Programming-Guide), [Language](Language), [Building from source](Building) from source, help for [Interoperability](Interoperability) with other monitoring system components, and [Deploying](Deploying) and [Troubleshooting](Troubleshooting)
+Read more about the [Programming Guide](Programming-Guide.md), [Language](Language.md), [Building from source](Building.md) from source, help for [Interoperability](Interoperability.md) with other monitoring system components, and [Deploying](Deploying.md) and [Troubleshooting](Troubleshooting.md)
 
 Mailing list: https://groups.google.com/forum/#!forum/mtail-users


### PR DESCRIPTION
As far as I see, `docs/...` are not used to build something and references to `.md` files are okay (and that's what github expects to make links clickable instead of 404).