### PR TITLE
WIP: #127 merge duplicate metrics instead of adding them.

### DIFF
--- a/metrics/store.go
+++ b/metrics/store.go
@@ -5,8 +5,10 @@ package metrics
 
 import (
 	"encoding/json"
+	"reflect"
 	"sync"
 
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 )
 
@@ -26,13 +28,43 @@ func NewStore() (s *Store) {
 func (s *Store) Add(m *Metric) error {
 	s.Lock()
 	defer s.Unlock()
+	dupeIndex := -1
 	if len(s.Metrics[m.Name]) > 0 {
 		t := s.Metrics[m.Name][0].Kind
 		if m.Kind != t {
 			return errors.Errorf("Metric %s has different kind %s to existing %s.", m.Name, m.Kind, t)
 		}
+
+		// To avoid duplicate metrics:
+		// - copy old LabelValues into new metric;
+		// - discard old metric.
+		for i, v := range s.Metrics[m.Name] {
+			//
+			if v.Program != m.Program {
+				continue
+			}
+			if v.Type != m.Type {
+				continue
+			}
+			if reflect.DeepEqual(v.Keys, m.Keys) {
+				continue
+			}
+			dupeIndex = i
+			glog.Infof("Found duped metric: %d", dupeIndex)
+			for j, oldLabel := range v.LabelValues {
+				glog.Warningf("Labels: %d %s", j, oldLabel.Labels)
+				d, err := v.GetDatum(oldLabel.Labels...)
+				if err == nil {
+					m.LabelValues = append(m.LabelValues, &LabelValue{oldLabel.Labels, d})
+				}
+			}
+		}
 	}
+
 	s.Metrics[m.Name] = append(s.Metrics[m.Name], m)
+	if dupeIndex >= 0 {
+		s.Metrics[m.Name] = append(s.Metrics[m.Name][0:dupeIndex], s.Metrics[m.Name][dupeIndex+1:]...)
+	}
 	return nil
 }
 

--- a/metrics/store_test.go
+++ b/metrics/store_test.go
@@ -18,3 +18,41 @@ func TestMatchingKind(t *testing.T) {
 		t.Fatal("should be err")
 	}
 }
+
+func TestDuplicateMetric(t *testing.T) {
+	expectedMetrics := 0
+	s := NewStore()
+	_ = s.Add(NewMetric("foo", "prog", Counter, Int, "user", "host"))
+	_ = s.Add(NewMetric("foo", "prog", Counter, Int))
+	expectedMetrics++
+	if len(s.Metrics["foo"]) != expectedMetrics {
+		t.Fatalf("should not add duplicate metric. Store: %s", s)
+	}
+
+	_ = s.Add(NewMetric("foo", "prog", Counter, Float))
+	t.Logf("Store: %s", s)
+	expectedMetrics++
+	if len(s.Metrics["foo"]) != expectedMetrics {
+		t.Fatalf("should add metric of a different type: %s", s)
+	}
+
+	_ = s.Add(NewMetric("foo", "prog", Counter, Int, "user", "host", "zone", "domain"))
+	t.Logf("Store: %s", s)
+	if len(s.Metrics["foo"]) != expectedMetrics {
+		t.Fatalf("should not add duplicate metric, but replace the old one. Store: %s", s)
+	}
+
+	_ = s.Add(NewMetric("foo", "prog1", Counter, Int))
+	t.Logf("Store: %s", s)
+	expectedMetrics++
+	if len(s.Metrics["foo"]) != expectedMetrics {
+		t.Fatalf("should add metric with a different prog: %s", s)
+	}
+
+	_ = s.Add(NewMetric("foo", "prog1", Counter, Float))
+	t.Logf("Store: %s", s)
+	expectedMetrics++
+	if len(s.Metrics["foo"]) != expectedMetrics {
+		t.Fatalf("should add metric of a different type: %s", s)
+	}
+}


### PR DESCRIPTION
## what does this PR do

When a new metric is added via store.Add:

  - checks if there's another metric with the same labels
  - if so, copies LabelValues in the new metric
  - pop the old one from the array