### PR TITLE
Create apache_common.mtail

### DIFF
--- a/examples/apache_common.mtail
+++ b/examples/apache_common.mtail
@@ -1,0 +1,24 @@
+# Parser for the common apache log format as follow.
+# LogFormat "%h %l %u %t \"%r\" %>s %b %D \"%{Referer}i\" \"%{User-agent}i\"
+counter apache_http_requests_total by request_method, http_version, status_code
+counter apache_http_bytes_total by request_method, http_version, status_code
+gauge apache_http_response_time by remote_host, request_method, request_uri, status_code, user_agent
+gauge apache_http_response_size by remote_host, request_method, request_uri, status_code, user_agent
+
+/^/ +
+/(?P<remote_host>[0-9A-Za-z\.-]+) / + # %h
+/(?P<remote_logname>[0-9A-Za-z-]+) / + # %l
+/(?P<remote_username>[0-9A-Za-z-]+) / + # %u
+/(?P<timestamp>\[\d{2}\/\w{3}\/\d{4}:\d{2}:\d{2}:\d{2} (\+|-)\d{4}\]) / + # %u
+/"(?P<request_method>[A-Z]+) (?P<request_uri>\S+) (?P<http_version>HTTP\/[0-9\.]+)" / + # \"%r\"
+/(?P<status_code>\d{3}) / + # %>s
+/(?P<response_size>\d+) / + # %b
+/(?P<response_time>\d+) / + # %D
+/"(?P<referer>\S+)" / + # \"%{Referer}i\"
+/"(?P<user_agent>[[:print:]]+)"/ + # \"%{User-agent}i\"
+/$/ {
+  apache_http_requests_total[$request_method][$http_version][$status_code]++
+  apache_http_bytes_total[$request_method][$http_version][$status_code] += $response_size
+  apache_http_response_time[$remote_host][$request_method][$request_uri][$status_code][$user_agent] = $response_time
+  apache_http_response_size[$remote_host][$request_method][$request_uri][$status_code][$user_agent] = $response_size
+}


### PR DESCRIPTION
A mtail config for apache common log which extrat the field of %D & %b

The example metric as following:
```
apache_http_response_time{remote_host="127.0.0.1",request_method="GET",request_uri="/server-status?auto",status_code="200",user_agent="Go-http-client/1.1",prog="apache_common.mtail"} 545
```