### PR TITLE
set default time zone to "Local"

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ var (
 
 	// Runtime behaviour flags
 	syslogUseCurrentYear = flag.Bool("syslog_use_current_year", true, "Patch yearless timestamps with the present year.")
-	overrideTimezone     = flag.String("override_timezone", "", "If set, use the provided timezone in timestamp conversion, instead of the local zone.")
+	overrideTimezone     = flag.String("override_timezone", "Local", "If set, use the provided timezone in timestamp conversion, instead of the local zone.")
 	emitProgLabel        = flag.Bool("emit_prog_label", true, "Emit the 'prog' label in variable exports.")
 
 	// Debugging flags


### PR DESCRIPTION
https://github.com/golang/go/blob/7340d1397701a0dc4d2570dac6414f0cdec3fff8/src/time/zoneinfo.go#L280
When Location's name is set to “”，the timezone will be load as UTC.
Therefore, according to the usage of overrideTimezone, I think its default value should be "Local".