### PR TITLE
Fix tl;dr building recipe and some links

### DIFF
--- a/docs/Building.md
+++ b/docs/Building.md
@@ -10,7 +10,8 @@ You will need to install Go 1.7 or higher.
 
 ```
 cd $GOPATH/src
-go get https://github.com/google/mtail
+go get github.com/google/mtail
+cd github.com/google/mtail
 make
 ```
 

--- a/docs/Deploying.md
+++ b/docs/Deploying.md
@@ -13,7 +13,7 @@ The `--help` flag will print a list of flags for configuring `mtail`.
 Basic flags necessary to start `mtail`:
 
   * `--logs` is a comma separated list of filenames to extract from, but can also be used multiple times, and each filename can be a [glob pattern](http://godoc.org/path/filepath#Match).
-  * `--progs` is a directory path containing [mtail programs](Language). Programs must have the `.mtail` suffix.
+  * `--progs` is a directory path containing [mtail programs](Language.md). Programs must have the `.mtail` suffix.
 
 mtail runs an HTTP server on port 3903, which can be changed with the `--port` flag.
 
@@ -32,7 +32,7 @@ changes.
 
 ## Writing the programme
 
-Read the [Programming Guide](Programming-Guide) for instructions on how to write an `mtail` program.
+Read the [Programming Guide](Programming-Guide.md) for instructions on how to write an `mtail` program.
 
 ## Getting the Metrics Out
 
@@ -64,7 +64,7 @@ Additionally, the flag `metric_push_interval_seconds` can be used to configure t
 
 ## Troubleshooting
 
-Lots of state is logged to the log file, by default in `/tmp/mtail.INFO`.  See [Troubleshooting](Troubleshooting) for more information.
+Lots of state is logged to the log file, by default in `/tmp/mtail.INFO`.  See [Troubleshooting](Troubleshooting.md) for more information.
 
 N.B. Oneshot mode (the `one_shot` flag on the commandline) can be used to check
 that a program is correctly reading metrics from a log, but with the following

--- a/docs/Interoperability.md
+++ b/docs/Interoperability.md
@@ -1,6 +1,6 @@
 # Introduction
 
-mtail is only part of a monitoring ecosystem -- it fills the gap between applications that export no metrics of their own in a [common protocol](Metrics) and the timeseries database.
+mtail is only part of a monitoring ecosystem -- it fills the gap between applications that export no metrics of their own in a [common protocol](Metrics.md) and the timeseries database.
 
 # Details
 

--- a/docs/Language.md
+++ b/docs/Language.md
@@ -4,7 +4,7 @@ As `mtail` is designed to tail log files and apply regular expressions to new lo
 
 It resembles another, more famous pattern-action language, that of AWK.
 
-This page errs on the side of a language specification and reference.  See the [Programming Guide](Programming-Guide) for a gentler introduction to writing `mtail` programs.
+This page errs on the side of a language specification and reference.  See the [Programming Guide](Programming-Guide.md) for a gentler introduction to writing `mtail` programs.
 
 # Program Execution
 

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -50,4 +50,4 @@ The `TestExamplePrograms` behaves like the `one_shot` flag, and
 
 # Troubleshooting
 
-For more information about debugging mtail programs, see the tips under [Troubleshooting](Troubleshooting)
+For more information about debugging mtail programs, see the tips under [Troubleshooting](Troubleshooting.md)


### PR DESCRIPTION
Otherwise `go get` from go1.9.2 failed with

```
$ go get https://github.com/google/mtail
package https:/github.com/google/mtail: "https://" not allowed in import path
```