### PR TITLE
Adding cross-building to Makefile & Travis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,19 @@ jobs:
           path: coverage.html
           destination: coverage
 
+  deploy:
+    working_directory: /go/src/github.com/google/mtail
+    docker:
+      - image: circleci/golang:1.9
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: make vm/parser.go
+      - run: make crossbuild
+      - run: go get github.com/tcnksm/ghr
+      - run: ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace `git describe --tags` build/
+
 # Using workflows to sequence each of our builds in parallel, and coverage
 # depending on all of them.  These two lists need to be updated when the inputs
 # of the build matrix change.
@@ -113,3 +126,11 @@ workflows:
             - build-go1.8-4
             - build-go1.8-2
             - build-go1.8-1
+      - deploy:
+          requires:
+            - coverage
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /^v.*/

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ foo.log
 /.gen-dep-stamp
 /cpu.out
 /mem.out
+/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+sudo: false
 
 # Must generate the parser before installing deps or go get will error out on
 # undefined lexer tokens.
@@ -11,7 +12,7 @@ install:
  - travis_retry make install_deps
 
 # Run all tests, under race detector.
-script: time make testrace
+script: make && go test
 
 # Run tests at these Go versions.  YAML always attempts to autoconvert
 # numerics, which famously turns "1.10" into "1.1", so quote all our versions
@@ -35,6 +36,15 @@ matrix:
   allow_failures:
     - go: tip
 
+before_deploy:
+  - make crossbuild
 
-# Not using sudo, can use containers.
-sudo: false
+deploy:
+  provider: releases
+  skip_cleanup: true
+  file_glob: true
+  file:
+    - build/*
+  on:
+    tags: true
+

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ covclean:
 
 version := $(shell git describe --tags)
 revision := $(shell git rev-parse HEAD)
+release := $(shell git describe --tags | cut -d"-" -f 1,2)
 
 install mtail: $(GOFILES) .dep-stamp
 	go install -ldflags "-X main.Version=${version} -X main.Revision=${revision}"
@@ -39,6 +40,13 @@ vm/parser.go: vm/parser.y .gen-dep-stamp
 
 emgen/emgen: emgen/emgen.go
 	cd emgen && go build
+
+install_gox:
+	go get github.com/mitchellh/gox
+
+crossbuild: install_gox $(GOFILES) .dep-stamp
+	mkdir -p build
+	gox --output="./build/mtail_${release}_{{.OS}}_{{.Arch}}" -osarch="linux/amd64 windows/amd64 darwin/amd64" -arch="amd64"
 
 .PHONY: test check
 check test: $(GOFILES) $(GOTESTFILES) .dep-stamp


### PR DESCRIPTION
1. Adds crossbuilds for amd64 on Linux/Darwin/Windows using gox
2. Adds deploy step to both Travis and Circle since I couldn't work out which is current. The deploy step only triggers on commits with tags.
3. You'll need to specify GH api keys for both to make this work.
