### PR TITLE
[docs] change time.Parse example default format

### DIFF
--- a/docs/Programming-Guide.md
+++ b/docs/Programming-Guide.md
@@ -77,7 +77,7 @@ def syslog {
         }
         # If the RFC3339 style matched, parse it this way.
         len($rfc3339_date) > 0 {
-            strptime($rfc3339_date, "2006-01-02T03:04:05-0700")
+            strptime($rfc3339_date, "2006-01-02T15:04:05-0700")
         }
         # Call into the decorated block
         next


### PR DESCRIPTION
03 format is for Kitchen

```
package main

import (
    "time"
    "fmt"
)

func main(){
    fmt.Println(time.Parse("2006/01/02 03", "2018/04/09 00"))
    // 2018-04-09 00:00:00 +0000 UTC <nil>
    fmt.Println(time.Parse("2006/01/02 03", "2018/04/09 12"))
    // 2018-04-09 12:00:00 +0000 UTC <nil>
    fmt.Println(time.Parse("2006/01/02 03", "2018/04/09 13"))
    // 0001-01-01 00:00:00 +0000 UTC parsing time "2018/04/09 13": hour out of range
}
```