### PR TITLE
fix some codespell issues

### DIFF
--- a/mtail/mtail.go
+++ b/mtail/mtail.go
@@ -70,7 +70,7 @@ func (m *MtailServer) StartTailing() error {
 	return nil
 }
 
-// InitLoader constructs a new program loader and performs the inital load of program files in the program directory.
+// InitLoader constructs a new program loader and performs the initial load of program files in the program directory.
 func (m *MtailServer) InitLoader() error {
 	o := vm.LoaderOptions{
 		Store:                m.store,

--- a/vm/checker.go
+++ b/vm/checker.go
@@ -143,14 +143,14 @@ func (c *checker) VisitBefore(node astNode) Visitor {
 	return c
 }
 
-// checkSymbolUsage emits errors if any elegible symbols in the current scope
+// checkSymbolUsage emits errors if any eligible symbols in the current scope
 // are not marked as used.
 func (c *checker) checkSymbolUsage() {
 	for _, sym := range c.scope.Symbols {
 		if !sym.Used {
 			// Users don't have control over the patterns given from decorators
 			// so this should never be an error; but it can be useful to know
-			// if a program is doing unneccessary work.
+			// if a program is doing unnecessary work.
 			if sym.Kind == CaprefSymbol {
 				if sym.Addr == 0 {
 					// Don't warn about the zeroth capture group; it's not user-defined.
@@ -164,7 +164,7 @@ func (c *checker) checkSymbolUsage() {
 	}
 }
 
-// VisitAfter perfoms the type annotation and checking, once the child nodes of
+// VisitAfter performs the type annotation and checking, once the child nodes of
 // expressions have been annotated and checked.
 func (c *checker) VisitAfter(node astNode) {
 	switch n := node.(type) {

--- a/vm/lexer.go
+++ b/vm/lexer.go
@@ -498,7 +498,7 @@ Loop:
 }
 
 // Lex a capture group reference. These are local variable references to
-// capture groups in the preceeding regular expression.
+// capture groups in the preceding regular expression.
 func lexCapref(l *lexer) stateFn {
 	l.skip() // Skip the leading $
 	named := false

--- a/vm/loader.go
+++ b/vm/loader.go
@@ -344,7 +344,7 @@ func (l *Loader) processEvents(events <-chan watcher.Event) {
 		case watcher.CreateEvent:
 			l.w.Add(event.Pathname)
 		default:
-			glog.V(1).Infof("Unexected event type %+#v", event)
+			glog.V(1).Infof("Unexpected event type %+#v", event)
 		}
 	}
 }

--- a/watcher/log_watcher_test.go
+++ b/watcher/log_watcher_test.go
@@ -101,28 +101,28 @@ func TestLogWatcher(t *testing.T) {
 		switch e := e.(type) {
 		case DeleteEvent:
 			if e.Pathname != filepath.Join(workdir, "logfile") {
-				t.Errorf("delete doesnt' match")
+				t.Errorf("delete doesn't match")
 			}
 		default:
 
 			t.Errorf("wrong event type: %v", e)
 		}
 	case <-time.After(deadline):
-		t.Errorf("didn't receive delete befor timeout")
+		t.Errorf("didn't receive delete before timeout")
 	}
 	select {
 	case e := <-eventsChannel:
 		switch e := e.(type) {
 		case CreateEvent:
 			if e.Pathname != filepath.Join(workdir, "logfile2") {
-				t.Errorf("create doesnt' match")
+				t.Errorf("create doesn't match")
 			}
 		default:
 
 			t.Errorf("wrong event type: %v", e)
 		}
 	case <-time.After(deadline):
-		t.Errorf("didn't receive create message befor timeout")
+		t.Errorf("didn't receive create message before timeout")
 	}
 	if err := os.Chmod(filepath.Join(workdir, "logfile2"), os.ModePerm); err != nil {
 		t.Fatal(err)
@@ -132,14 +132,14 @@ func TestLogWatcher(t *testing.T) {
 		switch e := e.(type) {
 		case UpdateEvent:
 			if e.Pathname != filepath.Join(workdir, "logfile2") {
-				t.Errorf("update doesnt' match")
+				t.Errorf("update doesn't match")
 			}
 		default:
 
 			t.Errorf("wrong event type: %v", e)
 		}
 	case <-time.After(deadline):
-		t.Errorf("didn't receive update message befor timeout")
+		t.Errorf("didn't receive update message before timeout")
 	}
 	if err := os.Remove(filepath.Join(workdir, "logfile2")); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Hi @jaqx0r ,

I fixed some [codespell](https://github.com/lucasdemarchi/codespell) issues. This tool could be integrated to the CI.

```
$ codespell -S vendor*,*git/objects*
WARNING: Binary file: ./logo.png 
WARNING: Binary file: ./.git/index 
./tailer/tail_test.go:110: nd  ==> and, 2nd
./tailer/tail.go:210: Seeked  ==> Sought
./tailer/tail.go:232: seeked  ==> sought
```