### PR TITLE
Docker Automated Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM golang:1.10.1-alpine3.7 AS builder
-
-RUN apk add --update git make \
-  && git clone https://github.com/google/mtail.git /go/src/github.com/google/mtail \
-  && cd /go/src/github.com/google/mtail \
-  && make
+RUN apk add --update git make
+WORKDIR /go/src/github.com/google/mtail
+COPY . /go/src/github.com/google/mtail
+RUN make
 
 
 FROM alpine:3.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,32 @@
-FROM golang:1.9-alpine
+FROM golang:1.10.1-alpine3.7 AS builder
 
-WORKDIR /go/src/github.com/google/mtail
-COPY . /go/src/github.com/google/mtail
+RUN apk add --update git make \
+  && git clone https://github.com/google/mtail.git /go/src/github.com/google/mtail \
+  && cd /go/src/github.com/google/mtail \
+  && make
 
-RUN apk add --update --no-cache --virtual build-dependencies git make \
-      && export GOPATH=/go \
-      && make \
-      && apk del build-dependencies
 
-ENTRYPOINT ["mtail"]
+FROM alpine:3.7
+
+ARG version=0.0.0-local
+ARG build_date=unknown
+ARG commit_hash=unknown
+ARG vcs_url=unknown
+ARG vcs_branch=unknown
+
+EXPOSE 3093
+ENTRYPOINT ["/usr/bin/mtail"]
+
+LABEL org.label-schema.vendor='Google' \
+    org.label-schema.name='mtail' \
+    org.label-schema.description='extract whitebox monitoring data from application logs for collection in a timeseries database' \
+    org.label-schema.usage='https://github.com/google/mtail/blob/master/docs/Programming-Guide.md' \
+    org.label-schema.url='https://github.com/google/mtail' \
+    org.label-schema.vcs-url=$vcs_url \
+    org.label-schema.vcs-branch=$vcs_branch \
+    org.label-schema.vcs-ref=$commit_hash \
+    org.label-schema.version=$version \
+    org.label-schema.schema-version='1.0' \
+    org.label-schema.build-date=$build_date
+
+COPY --from=builder /go/bin/mtail /usr/bin/mtail

--- a/README.md
+++ b/README.md
@@ -33,12 +33,29 @@ to write mtail programs.
 
 Mailing list: https://groups.google.com/forum/#!forum/mtail-users
 
-### Installation
+## Installation
 
-`mtail` uses a Makefile. To build `mtail`, type `make` at the commandline. See
-the [Build instructions](docs/Building.md) for more details.
+There are various ways of installing **mtail**.
 
-### Deployment
+### Precompiled binaries
+
+Precompiled binaries for released versions are available in the
+[Releases page](https://github.com/google/mtail/releases) on Github. Using the
+latest production release binary is the recommended way of installing **mtail**.
+
+Windows, OSX and Linux binaries are available.
+
+### Building from source
+
+To build **mtail** from the source code yourself you need to have a working
+Go environment with version 1.9 or greater installed.
+
+A `Dockerfile` is included in this repository for local development as an
+alternative to installing Go in your environment.
+
+See the [Build instructions](docs/Building.md) for more details.
+
+## Deployment
 
 `mtail` works best when it paired with a timeseries-based calculator and
 alerting tool, like [Prometheus](http://prometheus.io).

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -1,10 +1,10 @@
-# Introduction
+# Building mtail
 
 mtail is implemented in [Go](http://golang.org).
 
 You will need to install Go 1.7 or higher.
 
-# Details
+## Go
 
 [Clone](http://github.com/google/mtail) the source from GitHub into your `$GOPATH`.  If you don't have a `$GOPATH`, see the next section.
 
@@ -15,7 +15,7 @@ cd github.com/google/mtail
 make
 ```
 
-## For Go First-Timers
+### For Go First-Timers
 
 An excellent starting guide for people new to Go entirely is here: https://github.com/alco/gostart
 
@@ -28,7 +28,7 @@ on setting up the `$GOPATH` workspace:
 Finally, https://golang.org/doc/code.html is the original Go project
 documentation for the philosophy on Go workspaces.
 
-### No Really What's the TLDR
+#### No Really, What is the TLDR
 
 Put `export GOPATH=$HOME/go` in your `~/.profile`.
 
@@ -39,7 +39,7 @@ mkdir -p $GOPATH/src
 
 then back up to the Details above.
 
-## Building
+### Building
 
 Unlike the recommendation for Go projects, `mtail` uses a `Makefile` to build the source.
 
@@ -48,6 +48,44 @@ Having fetched the source, use `make` from the top of the source tree.  This wil
 The resulting binary will be in `$GOPATH/bin`.
 
 The unit tests can be run with `make test`, which invokes `go test`.  The slower race-detector tests can be run with `make testrace`.
+
+## No Go
+
+You can still build and develop with **mtail** with Docker.
+
+```
+docker build -t mtail .
+docker run -it --rm mtail --help
+```
+
+**mtail** is not much use without a configuration file or logs to parse, you will need to mount those in.
+
+```
+docker run -it --rm -v examples/linecount.mtail:/progs/linecount.mtail -v /var/log:/logs mtail -logtostderr -one_shot -progs /progs/linecount.mtail -logs /logs/messages.log
+```
+
+Or via a simple `docker-compose.yml` snippet example.
+
+```yaml
+service:
+  mtail:
+    image: mtail
+    command:
+      - -logtostderr
+      - -one_shot
+      - -progs
+      - /progs/linecount.mtail
+      - -logs
+      - /logs/messages.log
+    volume:
+      - type: bind
+        source: /var/log
+        target: /logs
+        readonly: true
+      - type: bind
+        source: examples/linecount.mtail
+        target: /progs/linecount.mtail
+```
 
 ## Contributing
 

--- a/hooks/build
+++ b/hooks/build
@@ -3,8 +3,6 @@
 # $IMAGE_NAME var is injected into the build so the tag is correct.
 echo "Build hook running"
 
-git fetch --tags --update-shallow --quiet
-
 docker build \
   --build-arg version=$(git describe --tags --always) \
   --build-arg commit_hash=$(git rev-parse HEAD) \

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# $IMAGE_NAME var is injected into the build so the tag is correct.
+echo "Build hook running"
+
+git fetch --tags --update-shallow --quiet
+
+docker build \
+  --build-arg version=$(git describe --tags --always) \
+  --build-arg commit_hash=$(git rev-parse HEAD) \
+  --build-arg vcs_url=$(git config --get remote.origin.url) \
+  --build-arg vcs_branch=$(git rev-parse --abbrev-ref HEAD) \
+  --build-arg build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+  -t $IMAGE_NAME .

--- a/hooks/post_checkout
+++ b/hooks/post_checkout
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Unshallowing to get correct tags to work."
+git fetch --tags --unshallow --quiet origin


### PR DESCRIPTION

* Automated Builds on Docker Hub!
* 96% Smaller Builds!
* Super Sexy Container Labelling!  (I heard that Google LOVES metadata!)

```
$ docker images mtail
REPOSITORY      TAG                IMAGE ID            CREATED             SIZE
mtail           before             a02800fe77ff        4 hours ago         369MB
mtail           docker-builder     3a0c3263d397        3 minutes ago       14.9MB

$ docker inspect mtail:docker-builder | jq .[0].Config.Labels
{
  "org.label-schema.build-date": "2018-04-17T17:22:47Z",
  "org.label-schema.description": "extract whitebox monitoring data from application logs for collection in a timeseries database",
  "org.label-schema.name": "mtail",
  "org.label-schema.schema-version": "1.0",
  "org.label-schema.url": "https://github.com/google/mtail",
  "org.label-schema.usage": "https://github.com/google/mtail/blob/master/docs/Programming-Guide.md",
  "org.label-schema.vcs-branch": "docker-builder",
  "org.label-schema.vcs-ref": "ab2d6d02ac659626dca756b399441002be82f9e4",
  "org.label-schema.vcs-url": "https://github.com/jnovack/mtail.git",
  "org.label-schema.vendor": "Google",
  "org.label-schema.version": "v3.0.0-rc10-62-gab2d6d0"
}

$ docker run -it --rm mtail:docker-builder --help
mtail version v3.0.0-rc10-62-gab2d6d0 git revision ab2d6d02ac659626dca756b399441002be82f9e4 go version go1.10.1
```

Notes:
* The `org.label-schema.version` will match the `mtail --help` version.
* The `org.label-schema.vcs-url` will show `google/mtail.git` once set up, it is generated dynamically and was pointing to my fork.

Action Required: The owner of the Google account on Docker Hub will need to set up an automated build for this repository.
