### PR TITLE
Minor typo in example "five nines" vs "nine fives"

### DIFF
--- a/docs/Programming-Guide.md
+++ b/docs/Programming-Guide.md
@@ -323,5 +323,5 @@ ANNOTATIONS {
 
 In this example, prometheus computes a service level indicator of the ratio of
 requests at or below the target of 200ms against the total count, and then
-fires an alert if the indicator drops below five nines.
+fires an alert if the indicator drops below nine fives.
 


### PR DESCRIPTION
The example walks through an example where the request time SLI is 0.555555555 (nine fives), but the last sentence confuses the SLI and wording reverts to five nines.