### PR TITLE
Fix: gitlab-ci stage test failing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,7 @@ test:
   stage: test
   allow_failure: true
   script:
+    - make install_deps
     - make test
 
 build:


### PR DESCRIPTION
Fix: gitlab-ci stage test failing because of missing step ( installing dependencies ).