### PR TITLE
Correctly handle duplicated metrics

### DIFF
--- a/metrics/store.go
+++ b/metrics/store.go
@@ -51,11 +51,15 @@ func (s *Store) Add(m *Metric) error {
 			if v.Source != m.Source {
 				continue
 			}
-			glog.V(2).Infof("v keys: %v m.keys: %v", v.Keys, m.Keys)
-			if len(v.Keys) > 0 && len(m.Keys) > 0 && reflect.DeepEqual(v.Keys, m.Keys) {
-				continue
-			}
 			dupeIndex = i
+			glog.V(2).Infof("v keys: %v m.keys: %v", v.Keys, m.Keys)
+			// If a set of label keys has changed, discard
+			// old metric completely, w/o even copying old
+			// data, as they are now incompatible.
+			if len(v.Keys) != len(m.Keys) || !reflect.DeepEqual(v.Keys, m.Keys) {
+				break
+			}
+			// Otherwise, copy everything into the new metric
 			glog.V(2).Infof("Found duped metric: %d", dupeIndex)
 			for j, oldLabel := range v.LabelValues {
 				glog.V(2).Infof("Labels: %d %s", j, oldLabel.Labels)

--- a/metrics/store.go
+++ b/metrics/store.go
@@ -61,7 +61,9 @@ func (s *Store) Add(m *Metric) error {
 				glog.V(2).Infof("Labels: %d %s", j, oldLabel.Labels)
 				d, err := v.GetDatum(oldLabel.Labels...)
 				if err == nil {
-					m.LabelValues = append(m.LabelValues, &LabelValue{oldLabel.Labels, d})
+					if err = m.RemoveDatum(oldLabel.Labels...); err == nil {
+						m.LabelValues = append(m.LabelValues, &LabelValue{oldLabel.Labels, d})
+					}
 				}
 			}
 		}

--- a/mtail/mtail_test.go
+++ b/mtail/mtail_test.go
@@ -724,8 +724,9 @@ func TestProgramReloadNoDuplicateMetrics(t *testing.T) {
 	if !ok {
 		t.Fatal("program loads didn't increase")
 	}
-	if len(store.Metrics["foo"]) != 1 {
-		t.Errorf("Unexpected number of metrics: expected 1, but got all this %v", store.Metrics["foo"])
+	mfoo := store.Metrics["foo"]
+	if len(mfoo) != 1 || len(mfoo[0].LabelValues) != 1 {
+		t.Errorf("Unexpected metrics content: expected a single metric with no labels, but got all this %v", mfoo)
 	}
 
 	n, err := logFile.WriteString("foo\n")
@@ -786,8 +787,9 @@ func TestProgramReloadNoDuplicateMetrics(t *testing.T) {
 	if !ok {
 		t.Error("program loads didn't increase")
 	}
-	if len(store.Metrics["foo"]) != 1 {
-		t.Errorf("Unexpected number of metrics: expected 1, but got %d\n%v", len(store.Metrics["foo"]), store.Metrics["foo"])
+	mfoo = store.Metrics["foo"]
+	if len(mfoo) != 1 || len(mfoo[0].LabelValues) != 1 {
+		t.Errorf("Unexpected metrics content: expected a single metric with no labels, but got all this: %v", mfoo)
 	}
 
 }


### PR DESCRIPTION
The PR addresses two problems with duplicated metrics:
  - counters w/o labels weren't correctly handled, as even an empty new counter already contains a single value (zero);
  - metrics with labels weren't handled by dedup at all.