### PR TITLE
vm: load programs right after watcher.Create event

### DIFF
--- a/tests/new_prog_test.sh
+++ b/tests/new_prog_test.sh
@@ -13,6 +13,6 @@ expect_json_field_eq '{}' prog_loads_total "${DATA}"
 
 touch $PROGS/nocode.mtail
 uri_get /debug/vars
-expect_json_field_eq '{  "nocode.mtail": 1}' prog_loads_total "${DATA}"
+expect_json_field_eq '{  "nocode.mtail": 2}' prog_loads_total "${DATA}"
 
 pass

--- a/vm/mcp.go
+++ b/vm/mcp.go
@@ -386,6 +386,10 @@ func (l *MasterControl) processEvents(events <-chan watcher.Event) {
 		case watcher.Create:
 			if err := l.w.Add(event.Pathname, l.eventsHandle); err != nil {
 				glog.Info(err)
+				continue
+			}
+			if err := l.LoadProgram(event.Pathname); err != nil {
+				glog.Info(err)
 			}
 		default:
 			glog.V(1).Infof("Unexpected event type %+#v", event)


### PR DESCRIPTION
watcher.Update event might not be received when a new file is added into
progs directory. For example, when RPM is installing a package, it
doesn't change mtime on the files, thus watcher.Update event is never
received on the actual program file and the programs installed by RPM
are never loaded.

I0627 12:11:59.401242  840953 log_watcher.go:89] watcher event "/etc/mtail/messages.mtail;5b3354df": RENAME
I0627 12:11:59.401267  840953 log_watcher.go:89] watcher event "/etc/mtail/messages.mtail": CREATE

Fix this by loading programs right after watcher.Create event.