### PR TITLE
"event CREATE" happend before "event REMOVE" when used logrotate command.

### DIFF
--- a/tailer/tail.go
+++ b/tailer/tail.go
@@ -214,7 +214,11 @@ func (t *Tailer) handleLogUpdate(pathname string) {
 	err = t.read(fd, t.partials[absPath])
 	t.partialsMu.Unlock()
 	if err != nil && err != io.EOF {
-		glog.Info(err)
+		if e, ok := err.(*os.PathError); ok && e.Err == os.ErrClosed {
+			t.handleLogCreate(pathname)
+		} else {
+			glog.Info(err)
+		}
 	}
 }
 


### PR DESCRIPTION
Hello.

mtail didn't parse after logrotate command.
"event CREATE" happend before "event REMOVE".

memo: logrotate executed at 00:00 o'clock
```
> grep 'log_watcher.go:89' mtail.INFO | grep -v WRITE
I0808 00:00:01.955989   24622 log_watcher.go:89] watcher event "/var/log/a.log": RENAME
I0808 00:00:01.956446   24622 log_watcher.go:89] watcher event "/var/log/a.log": RENAME
I0808 00:00:01.956626   24622 log_watcher.go:89] watcher event "/var/log/a.log": CREATE
I0808 00:00:02.705517   24622 log_watcher.go:89] watcher event "/var/log/a.log": CHMOD
I0808 00:36:02.327719   24622 log_watcher.go:89] watcher event "/var/log/a.log": CHMOD
I0808 00:36:02.327882   24622 log_watcher.go:89] watcher event "/var/log/a.log": REMOVE
```

```
grep REMOVE mtail.INFO -A 30
I0808 00:36:02.327738   24622 log_watcher.go:89] watcher event "/var/log/a.log.1": REMOVE
I0808 00:36:02.327752   24622 tail.go:517] Event type watcher.Event{Op:1, Pathname:"/var/log/a.log"}
I0808 00:36:02.327769   24622 tail.go:198] handleLogUpdate /var/log/a.log
I0808 00:36:02.327789   24622 tail.go:255] Read: 0 EOF
I0808 00:36:02.327802   24622 tail.go:260] Suspected truncation.
I0808 00:36:02.327813   24622 tail.go:226] current seek position at 173305698
I0808 00:36:02.327824   24622 tail.go:236] File size is 173305698
I0808 00:36:02.327834   24622 tail.go:263] handletrunc with error 'no truncate appears to have occurred'
I0808 00:36:02.327849   24622 tail.go:517] Event type watcher.Event{Op:2, Pathname:"/var/log/a.log.1"}
I0808 00:36:02.327863   24622 tail.go:347] handleLogDelete /var/log/a.log.1
I0808 00:36:02.327872   24622 tail.go:350] Delete without fd for /var/log/a.log.1
I0808 00:36:02.327882   24622 log_watcher.go:89] watcher event "/var/log/a.log": REMOVE
I0808 00:36:02.327898   24622 tail.go:517] Event type watcher.Event{Op:2, Pathname:"/var/log/a.log"}
I0808 00:36:02.327910   24622 tail.go:347] handleLogDelete /var/log/a.log
I0808 00:36:02.327917   24622 tail.go:198] handleLogUpdate /var/log/a.log
I0808 00:36:02.327937   24622 tail.go:255] Read: 0 EOF
I0808 00:36:02.327947   24622 tail.go:260] Suspected truncation.
I0808 00:36:02.327955   24622 tail.go:226] current seek position at 173305698
I0808 00:36:02.327964   24622 tail.go:236] File size is 173305698
I0808 00:36:02.327972   24622 tail.go:263] handletrunc with error 'no truncate appears to have occurred'
I0808 00:36:02.345615   24622 log_watcher.go:89] watcher event "/var/log/a.log": WRITE
I0808 00:36:02.345685   24622 tail.go:517] Event type watcher.Event{Op:1, Pathname:"/var/log/a.log"}
I0808 00:36:02.345692   24622 tail.go:198] handleLogUpdate /var/log/a.log
I0808 00:36:02.345709   24622 tail.go:255] Read: 0 read /var/log/a.log: file already closed
I0808 00:36:02.345717   24622 tail.go:217] read /var/log/a.log: file already closed
I0808 00:36:02.346411   24622 tail.go:517] Event type watcher.Event{Op:1, Pathname:"/var/log/a.log"}
I0808 00:36:02.346420   24622 tail.go:198] handleLogUpdate /var/log/a.log
I0808 00:36:02.346428   24622 tail.go:255] Read: 0 read /var/log/a.log: file already closed
I0808 00:36:02.346434   24622 tail.go:217] read /var/log/a.log: file already closed
I0808 00:36:02.355508   24622 log_watcher.go:89] watcher event "/var/log/a.log": WRITE
```
