### PR TITLE
Update log_glob_test.sh

### DIFF
--- a/tests/log_glob_test.sh
+++ b/tests/log_glob_test.sh
@@ -15,11 +15,13 @@ sleep 1
 
 uri_get /debug/vars
 expect_json_field_eq "1" log_count "${DATA}"
+expect_json_field_eq "1" line_count "${DATA}"
 
 echo "line 1" >> $LOGS/log1
 sleep 2
 
 uri_get /debug/vars
-expect_json_field_eq "1" log_count "${DATA}"
+expect_json_field_eq "2" log_count "${DATA}"
+expect_json_field_eq "2" line_count "${DATA}"
 
 pass


### PR DESCRIPTION
The log_glob_test.sh test was incorrect causing a false positive pass for glob testing.  Additionally, the false positive had a side-effect that files created AFTER startup were not being properly monitored.

This only fixes the test, this does NOT fix the main issue as discussed in #176.

On line 19, when you create `log1`, the total number of logs should be "2", `log` and `log1`.  Additionally, this also tests that the line_counts are properly incremented, especially when a file that is being globbed was created post startup.

This fails because well, `tailer/tail.go` is incorrect and right now the fix is beyond my comprehension.