### PR TITLE
Fixing a typo in documentation

### DIFF
--- a/docs/Language.md
+++ b/docs/Language.md
@@ -249,7 +249,7 @@ The simplest `mtail` program merely counts lines read:
 ```
 /$/ {
   line_count++
-}`
+}
 ```
 
 This program instructs `mtail` to increment the `line_count` counter variable on


### PR DESCRIPTION
There was one too many `