### PR TITLE
Add PREFIX to make install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.10.1-alpine3.7 AS builder
 RUN apk add --update git make
 WORKDIR /go/src/github.com/google/mtail
 COPY . /go/src/github.com/google/mtail
-RUN make install_deps && make install
+RUN make install_deps && PREFIX=/go make install
 
 
 FROM alpine:3.7


### PR DESCRIPTION
Commit #3bfdc27 broke the Dockerfile. I.e. `COPY --from=builder /go/bin/mtail /usr/bin/mtail` is trying to copy from a non-existent file.