### PR TITLE
Microsecond to second conversion was wrong.

### DIFF
--- a/examples/apache_metrics.mtail
+++ b/examples/apache_metrics.mtail
@@ -26,7 +26,7 @@ histogram http_request_duration_seconds by server_port, handler, method, code, p
   ###
   # HTTP Requests with histogram buckets.
   #
-  http_request_duration_seconds[$server_port][$handler][$method][$code][$protocol] = $time_us * 1000000
+  http_request_duration_seconds[$server_port][$handler][$method][$code][$protocol] = $time_us / 1000000
 
   ###
   # Sent/Received bytes.


### PR DESCRIPTION
Please check the conversion. Ideally it should be ,
 $time_us / 1000000 or $time_us * 0.000001