### PR TITLE
Use base units for metrics

### DIFF
--- a/examples/rails.mtail
+++ b/examples/rails.mtail
@@ -9,7 +9,7 @@ counter rails_requests_started by verb
 counter rails_requests_completed_total
 counter rails_requests_completed by status
 
-histogram rails_requests_completed_milliseconds by status buckets 5, 10, 50, 100, 250, 500, 1000, 2500, 5000, 15000
+histogram rails_requests_completed_seconds by status buckets 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 15.0
 
 /^Started (?P<verb>[A-Z]+) .*/ {
   ###
@@ -19,7 +19,7 @@ histogram rails_requests_completed_milliseconds by status buckets 5, 10, 50, 100
   rails_requests_started[$verb]++
 }
 
-/^Completed (?P<status>\d{3}) .+ in (?P<request_milliseconds>\d+)ms .*$/ {
+/^Completed (?P<status>\d{3}) .+ in (?P<request_seconds>\d+)ms .*$/ {
   ###
   # Total numer of completed requests by status
   #
@@ -33,5 +33,5 @@ histogram rails_requests_completed_milliseconds by status buckets 5, 10, 50, 100
   # collecting system can compute the percentile bands by taking the ratio of
   # each bucket value over the final bucket.
 
-  rails_requests_completed_milliseconds[$status] = $request_milliseconds
+  rails_requests_completed_seconds[$status] = $request_seconds / 1000.0
 }

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -32,9 +32,9 @@ var (
 	lineProcessingDurations = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "mtail",
 		Subsystem: "vm",
-		Name:      "line_processing_duration_milliseconds",
-		Help:      "VM line processing time distribution in milliseconds.",
-		Buckets:   prometheus.DefBuckets,
+		Name:      "line_processing_duration_seconds",
+		Help:      "VM line processing time distribution in seconds.",
+		Buckets:   prometheus.ExponentialBuckets(0.00002, 2.0, 10),
 	}, []string{"prog"})
 )
 
@@ -731,7 +731,7 @@ func (v *VM) execute(t *thread, i code.Instr) {
 func (v *VM) processLine(line *logline.LogLine) {
 	start := time.Now()
 	defer func() {
-		lineProcessingDurations.WithLabelValues(v.name).Observe(float64(time.Since(start).Nanoseconds()) / 1.e6)
+		lineProcessingDurations.WithLabelValues(v.name).Observe(time.Since(start).Seconds())
 	}()
 	t := new(thread)
 	t.matched = false


### PR DESCRIPTION
Prometheus best practice[0] is to use base units. Use seconds
instead of milliseconds.

[0]: https://prometheus.io/docs/practices/naming/#base-units