### PR TITLE
add regex pattern to ignore file and ignore subfolder

### DIFF
--- a/cmd/mtail/main.go
+++ b/cmd/mtail/main.go
@@ -33,9 +33,10 @@ func (f *seqStringFlag) Set(value string) error {
 var logs seqStringFlag
 
 var (
-	port    = flag.String("port", "3903", "HTTP port to listen on.")
-	address = flag.String("address", "", "Host or IP address on which to bind HTTP listener")
-	progs   = flag.String("progs", "", "Name of the directory containing mtail programs")
+	port               = flag.String("port", "3903", "HTTP port to listen on.")
+	address            = flag.String("address", "", "Host or IP address on which to bind HTTP listener")
+	progs              = flag.String("progs", "", "Name of the directory containing mtail programs")
+	ignoreRegexPattern = flag.String("ignore_filename_regex_pattern", "", "")
 
 	version = flag.Bool("version", false, "Print mtail version information.")
 
@@ -124,6 +125,7 @@ func main() {
 	opts := []func(*mtail.Server) error{
 		mtail.ProgramPath(*progs),
 		mtail.LogPathPatterns(logs...),
+		mtail.IgnoreRegexPattern(*ignoreRegexPattern),
 		mtail.BindAddress(*address, *port),
 		mtail.SetBuildInfo(buildInfo),
 		mtail.OverrideLocation(loc),

--- a/internal/mtail/mtail.go
+++ b/internal/mtail/mtail.go
@@ -69,10 +69,11 @@ type Server struct {
 	closeQuit chan struct{} // Channel to signal shutdown from code.
 	closeOnce sync.Once     // Ensure shutdown happens only once.
 
-	bindAddress     string    // address to bind HTTP server
-	buildInfo       BuildInfo // go build information
-	programPath     string    // path to programs to load
-	logPathPatterns []string  // list of patterns to watch for log files to tail
+	bindAddress        string    // address to bind HTTP server
+	buildInfo          BuildInfo // go build information
+	programPath        string    // path to programs to load
+	logPathPatterns    []string  // list of patterns to watch for log files to tail
+	ignoreRegexPattern string
 
 	oneShot      bool // if set, mtail reads log files from the beginning, once, then exits
 	compileOnly  bool // if set, mtail compiles programs then exits
@@ -92,6 +93,9 @@ type Server struct {
 // StartTailing adds each log path pattern to the tailer.
 func (m *Server) StartTailing() error {
 	var err error
+	if err = m.t.SetIgnorePattern(m.ignoreRegexPattern); err != nil {
+		glog.Warning(err)
+	}
 	for _, pattern := range m.logPathPatterns {
 		glog.V(1).Infof("Tail pattern %q", pattern)
 		if err = m.t.TailPattern(pattern); err != nil {

--- a/internal/mtail/options.go
+++ b/internal/mtail/options.go
@@ -24,6 +24,14 @@ func LogPathPatterns(patterns ...string) func(*Server) error {
 	}
 }
 
+// IgnoreRegexPattern sets the regex pattern to ignore files.
+func IgnoreRegexPattern(pattern string) func(*Server) error {
+	return func(m *Server) error {
+		m.ignoreRegexPattern = pattern
+		return nil
+	}
+}
+
 // BindAddress sets the HTTP server address in Server.
 func BindAddress(address, port string) func(*Server) error {
 	return func(m *Server) error {

--- a/internal/tailer/tail.go
+++ b/internal/tailer/tail.go
@@ -12,10 +12,12 @@ package tailer
 
 import (
 	"expvar"
+	"fmt"
 	"html/template"
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sync"
 	"time"
 
@@ -41,8 +43,9 @@ type Tailer struct {
 	handlesMu sync.RWMutex     // protects `handles'
 	handles   map[string]*File // File handles for each pathname.
 
-	globPatternsMu sync.RWMutex        // protects `globPatterns'
-	globPatterns   map[string]struct{} // glob patterns to match newly created files in dir paths against
+	globPatternsMu     sync.RWMutex        // protects `globPatterns'
+	globPatterns       map[string]struct{} // glob patterns to match newly created files in dir paths against
+	ignoreRegexPattern *regexp.Regexp
 
 	runDone chan struct{} // Signals termination of the run goroutine.
 
@@ -158,11 +161,50 @@ func (t *Tailer) TailPattern(pattern string) error {
 		return errors.Errorf("No matches for pattern %q", pattern)
 	}
 	for _, pathname := range matches {
-		err := t.TailPath(pathname)
+		ignore, err := t.Ignore(pathname)
+		if err != nil {
+			return err
+		}
+		if ignore {
+			continue
+		}
+		err = t.TailPath(pathname)
 		if err != nil {
 			return errors.Wrapf(err, "attempting to tail %q", pathname)
 		}
 	}
+	return nil
+}
+
+func (t *Tailer) Ignore(pathname string) (bool, error) {
+	absPath, err := filepath.Abs(pathname)
+	if err != nil {
+		return false, err
+	}
+	fi, err := os.Stat(absPath)
+	if err != nil {
+		return false, err
+	}
+	if fi.Mode().IsDir() {
+		// do directory stuff
+		glog.V(2).Infof("ignore path %q because it is a folder", pathname)
+		return true, nil
+	}
+	return t.ignoreRegexPattern != nil && t.ignoreRegexPattern.MatchString(fi.Name()), nil
+}
+
+func (t *Tailer) SetIgnorePattern(pattern string) error {
+	if len(pattern) == 0 {
+		return nil
+	}
+	glog.V(2).Infof("Set filename ignore regex pattern %q", pattern)
+	ignoreRegexPattern, err := regexp.Compile(pattern)
+	if err != nil {
+		glog.V(2).Infof("Couldn't compile regex %q: %s", pattern, err)
+		fmt.Println(fmt.Sprintf("error: %v", err))
+		return err
+	}
+	t.ignoreRegexPattern = ignoreRegexPattern
 	return nil
 }
 
@@ -261,6 +303,15 @@ func (t *Tailer) handleCreateGlob(pathname string) {
 		}
 		if !matched {
 			glog.V(2).Infof("%q did not match pattern %q", pathname, pattern)
+			continue
+		}
+		ignore, err := t.Ignore(pathname)
+		if err != nil {
+			glog.Warningf("Unexpected bad pathname %q", pathname)
+			continue
+		}
+		if ignore {
+			glog.V(2).Infof("%q is ignored", pathname)
 			continue
 		}
 		glog.V(1).Infof("New file %q matched existing glob %q", pathname, pattern)


### PR DESCRIPTION
This PR is related to this issue https://github.com/google/mtail/issues/219. Our log file directory structure is like this:
log_dir/
     log1
     log2.gz
     log_archive_folder/
Currently, with log pattern "/tmp/logs/*" , mtail cannot ignore the log2.gz and subfolder log_archive_folder. Therefore I implemented the feature to ignore any subfolder and files whose filenames are matched by regex  pattern. Tests are added.