### PR TITLE
Use consistent naming for internal metrics

### DIFF
--- a/internal/mtail/mtail.go
+++ b/internal/mtail/mtail.go
@@ -244,10 +244,10 @@ func New(store *metrics.Store, w watcher.Watcher, options ...func(*Server) error
 		// internal/vm/loader.go
 		"line_count":          prometheus.NewDesc("line_count", "number of lines received by the program loader", nil, nil),
 		"prog_loads_total":    prometheus.NewDesc("prog_loads_total", "number of program load events by program source filename", []string{"prog"}, nil),
-		"prog_load_errors":    prometheus.NewDesc("prog_load_errors", "number of errors encountered when loading per program source filename", []string{"prog"}, nil),
-		"prog_runtime_errors": prometheus.NewDesc("prog_runtime_errors", "number of errors encountered when executing programs per source filename", []string{"prog"}, nil),
+		"prog_load_errors_total":    prometheus.NewDesc("prog_load_errors_total", "number of errors encountered when loading per program source filename", []string{"prog"}, nil),
+		"prog_runtime_errors_total": prometheus.NewDesc("prog_runtime_errors_total", "number of errors encountered when executing programs per source filename", []string{"prog"}, nil),
 		// internal/watcher/log_watcher.go
-		"log_watcher_error_count": prometheus.NewDesc("log_watcher_error_count", "number of errors received from fsnotify", nil, nil),
+		"log_watcher_errors_total": prometheus.NewDesc("log_watcher_errors_total", "number of errors received from fsnotify", nil, nil),
 	}
 	m.reg.MustRegister(
 		prometheus.NewGoCollector(),

--- a/internal/vm/loader.go
+++ b/internal/vm/loader.go
@@ -41,8 +41,8 @@ var (
 	// ProgLoads counts the number of program load events.
 	ProgLoads = expvar.NewMap("prog_loads_total")
 	// ProgLoadErrors counts the number of program load errors.
-	ProgLoadErrors    = expvar.NewMap("prog_load_errors")
-	progRuntimeErrors = expvar.NewMap("prog_runtime_errors")
+	ProgLoadErrors    = expvar.NewMap("prog_load_errors_total")
+	progRuntimeErrors = expvar.NewMap("prog_runtime_errors_total")
 )
 
 const (

--- a/internal/vm/vm_integration_test.go
+++ b/internal/vm/vm_integration_test.go
@@ -211,7 +211,7 @@ func TestVmEndToEnd(t *testing.T) {
 			l.Close()
 
 			// This is not good; can the loader abort on error?
-			if m := expvar.Get("prog_runtime_errors"); m != nil {
+			if m := expvar.Get("prog_runtime_errors_total"); m != nil {
 				if val := m.(*expvar.Map).Get(tc.name); val != nil && val.String() != "0" {
 					t.Errorf("Nonzero runtime errors from program: got %s", val)
 				}

--- a/internal/watcher/log_watcher.go
+++ b/internal/watcher/log_watcher.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	errorCount = expvar.NewInt("log_watcher_error_count")
+	errorCount = expvar.NewInt("log_watcher_errors_total")
 )
 
 type watch struct {

--- a/internal/watcher/log_watcher_test.go
+++ b/internal/watcher/log_watcher_test.go
@@ -246,9 +246,9 @@ func TestWatcherErrors(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping log watcher test in short mode")
 	}
-	orig, err := strconv.ParseInt(expvar.Get("log_watcher_error_count").String(), 10, 64)
+	orig, err := strconv.ParseInt(expvar.Get("log_watcher_errors_total").String(), 10, 64)
 	if err != nil {
-		t.Fatalf("couldn't convert expvar %q", expvar.Get("log_watcher_error_count").String())
+		t.Fatalf("couldn't convert expvar %q", expvar.Get("log_watcher_errors_total").String())
 	}
 	w, err := NewLogWatcher(0, true)
 	if err != nil {
@@ -259,7 +259,7 @@ func TestWatcherErrors(t *testing.T) {
 		t.Fatalf("watcher close failed: %q", err)
 	}
 	expected := strconv.FormatInt(orig+1, 10)
-	if diff := testutil.Diff(expected, expvar.Get("log_watcher_error_count").String()); diff != "" {
+	if diff := testutil.Diff(expected, expvar.Get("log_watcher_errors_total").String()); diff != "" {
 		t.Errorf("log watcher error count not increased:\n%s", diff)
 	}
 }


### PR DESCRIPTION
Make the internal metric names consistent, follow Prometheus/OpenMetrics
naming conventions.