### PR TITLE
Add missing filter to container workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,6 +187,7 @@ workflows:
             - build-go1.10-2
             - build-go1.10-1
       - container:
+          <<: *tag-filter
           requires:
             - coverage
       - delivery:


### PR DESCRIPTION
The `container` phase of the workflow was missing tags so it was never
run, which causes the release to not be published.