### PR TITLE
Make line count consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ The extraction is controlled by [mtail programs](docs/Programming-Guide.md)
 which define patterns and actions:
 
     # simple line counter
-    counter line_count
+    counter lines_total
     /$/ {
-      line_count++
+      lines_total++
     }
 
 Metrics are exported for scraping by a collector as JSON or Prometheus format

--- a/docs/Language.md
+++ b/docs/Language.md
@@ -52,7 +52,7 @@ Variables, which have type `counter` or `gauge`, must be declared before their
 use.
 
 ```
-counter line_count
+counter lines_total
 gauge queue_length
 ```
 
@@ -61,7 +61,7 @@ to use characters that would cause a parse error. This example causes the metric
 to be named `line-count` in the collecting monitoring system.
 
 ```
-counter line_count as "line-count"
+counter lines_total as "line-count"
 ```
 
 Variables can be dimensioned with one or more axes, with the `by` keyword,
@@ -248,11 +248,11 @@ The simplest `mtail` program merely counts lines read:
 
 ```
 /$/ {
-  line_count++
+  lines_total++
 }
 ```
 
-This program instructs `mtail` to increment the `line_count` counter variable on
+This program instructs `mtail` to increment the `lines_total` counter variable on
 every line received (specifically anytime an end-of-line is matched.)
 
 #### Capture Groups

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@ It aims to fill a niche between applications that do not export their own intern
 The extraction is controlled by `mtail` programs which define patterns and actions:
 
     # simple line counter
-    counter line_count
+    counter lines_total
     /$/ {
-      line_count++
+      lines_total++
     }
 
 Metrics are exported for scraping by a collector as JSON or Prometheus format

--- a/examples/linecount.mtail
+++ b/examples/linecount.mtail
@@ -1,8 +1,8 @@
 # Copyright 2011 Google Inc. All Rights Reserved.
 # This file is available under the Apache license.
 
-counter line_count
+counter lines_total
 
 /$/ {
-  line_count++
+  lines_total++
 }

--- a/internal/mtail/basic_tail_integration_test.go
+++ b/internal/mtail/basic_tail_integration_test.go
@@ -33,7 +33,7 @@ func TestBasicTail(t *testing.T) {
 			m, stopM := mtail.TestStartServer(t, test.pollInterval, test.enableFsNotify, mtail.LogPathPatterns(logDir+"/*"), mtail.ProgramPath("../../examples/linecount.mtail"))
 			defer stopM()
 
-			startLineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+			startLineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 
 			time.Sleep(1 * time.Second)
 
@@ -46,12 +46,12 @@ func TestBasicTail(t *testing.T) {
 				time.Sleep(1 * time.Second)
 			}
 
-			endLineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+			endLineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 
 			lineCount := endLineCount.(float64) - startLineCount.(float64)
 			if lineCount != 3. {
 				t.Errorf("output didn't have expected line count increase: want 3 got %#v", lineCount)
-				t.Logf("Line Count, and log lines total: %s, %s", mtail.TestGetMetric(t, m.Addr(), "line_count"), mtail.TestGetMetric(t, m.Addr(), "log_lines_total"))
+				t.Logf("Line Count, and log lines total: %s, %s", mtail.TestGetMetric(t, m.Addr(), "lines_total"), mtail.TestGetMetric(t, m.Addr(), "log_lines_total"))
 			}
 		})
 	}

--- a/internal/mtail/glob_relative_after_start_integration_test.go
+++ b/internal/mtail/glob_relative_after_start_integration_test.go
@@ -35,7 +35,7 @@ func TestGlobRelativeAfterStart(t *testing.T) {
 	defer stopM()
 
 	startLogCount := mtail.TestGetMetric(t, m.Addr(), "log_count")
-	startLineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+	startLineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 
 	logFile := path.Join(logDir, "log.1.txt")
 	f := testutil.TestOpenFile(t, logFile)
@@ -49,7 +49,7 @@ func TestGlobRelativeAfterStart(t *testing.T) {
 
 	{
 		logCount := mtail.TestGetMetric(t, m.Addr(), "log_count")
-		lineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+		lineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 
 		if logCount.(float64)-startLogCount.(float64) != 1. {
 			t.Errorf("Unexpected log count: got %g, want 1", logCount.(float64)-startLogCount.(float64))
@@ -71,7 +71,7 @@ func TestGlobRelativeAfterStart(t *testing.T) {
 		time.Sleep(time.Second)
 
 		logCount := mtail.TestGetMetric(t, m.Addr(), "log_count")
-		lineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+		lineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 
 		if logCount.(float64)-startLogCount.(float64) != 2. {
 			t.Errorf("Unexpected log count: got %g, want 2", logCount.(float64)-startLogCount.(float64))
@@ -92,7 +92,7 @@ func TestGlobRelativeAfterStart(t *testing.T) {
 		time.Sleep(time.Second)
 
 		logCount := mtail.TestGetMetric(t, m.Addr(), "log_count")
-		lineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+		lineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 
 		if logCount.(float64)-startLogCount.(float64) != 2 {
 			t.Errorf("Unexpected log count: got %g, want 2", logCount.(float64)-startLogCount.(float64))

--- a/internal/mtail/log_glob_integration_test.go
+++ b/internal/mtail/log_glob_integration_test.go
@@ -32,7 +32,7 @@ func TestLogGlobMatchesAfterStartupWithPollInterval(t *testing.T) {
 			defer stopM()
 
 			startLogCount := mtail.TestGetMetric(t, m.Addr(), "log_count")
-			startLineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+			startLineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 
 			{
 				logFile := path.Join(logDir, "log")
@@ -43,7 +43,7 @@ func TestLogGlobMatchesAfterStartupWithPollInterval(t *testing.T) {
 				time.Sleep(time.Second)
 
 				logCount := mtail.TestGetMetric(t, m.Addr(), "log_count")
-				lineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+				lineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 
 				if logCount.(float64)-startLogCount.(float64) != 1. {
 					t.Errorf("Unexpected log count: got %g, want 1", logCount.(float64)-startLogCount.(float64))
@@ -63,7 +63,7 @@ func TestLogGlobMatchesAfterStartupWithPollInterval(t *testing.T) {
 				time.Sleep(time.Second)
 
 				logCount := mtail.TestGetMetric(t, m.Addr(), "log_count")
-				lineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+				lineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 
 				if logCount.(float64)-startLogCount.(float64) != 2. {
 					t.Errorf("Unexpected log count: got %g, want 2", logCount.(float64)-startLogCount.(float64))

--- a/internal/mtail/mtail.go
+++ b/internal/mtail/mtail.go
@@ -242,8 +242,8 @@ func New(store *metrics.Store, w watcher.Watcher, options ...func(*Server) error
 		"log_truncates_total": prometheus.NewDesc("log_truncates_total", "number of log truncation events log file", []string{"logfile"}, nil),
 		"log_lines_total":     prometheus.NewDesc("log_lines_total", "number of lines read per log file", []string{"logfile"}, nil),
 		// internal/vm/loader.go
-		"line_count":          prometheus.NewDesc("line_count", "number of lines received by the program loader", nil, nil),
-		"prog_loads_total":    prometheus.NewDesc("prog_loads_total", "number of program load events by program source filename", []string{"prog"}, nil),
+		"lines_total":               prometheus.NewDesc("lines_total", "number of lines received by the program loader", nil, nil),
+		"prog_loads_total":          prometheus.NewDesc("prog_loads_total", "number of program load events by program source filename", []string{"prog"}, nil),
 		"prog_load_errors_total":    prometheus.NewDesc("prog_load_errors_total", "number of errors encountered when loading per program source filename", []string{"prog"}, nil),
 		"prog_runtime_errors_total": prometheus.NewDesc("prog_runtime_errors_total", "number of errors encountered when executing programs per source filename", []string{"prog"}, nil),
 		// internal/watcher/log_watcher.go

--- a/internal/mtail/mtail_test.go
+++ b/internal/mtail/mtail_test.go
@@ -38,7 +38,7 @@ func removeTempDir(t *testing.T, workdir string) {
 }
 
 func startMtailServer(t *testing.T, options ...func(*Server) error) *Server {
-	expvar.Get("line_count").(*expvar.Int).Set(0)
+	expvar.Get("lines_total").(*expvar.Int).Set(0)
 	expvar.Get("log_count").(*expvar.Int).Set(0)
 	expvar.Get("log_rotations_total").(*expvar.Map).Init()
 	expvar.Get("prog_loads_total").(*expvar.Map).Init()
@@ -82,7 +82,7 @@ func TestHandleLogUpdates(t *testing.T) {
 		// check log line count increase
 		expected := fmt.Sprintf("%d", i+1)
 		check := func() (bool, error) {
-			if expvar.Get("line_count").String() != expected {
+			if expvar.Get("lines_total").String() != expected {
 				return false, nil
 			}
 			return true, nil
@@ -92,7 +92,7 @@ func TestHandleLogUpdates(t *testing.T) {
 			t.Fatal(err)
 		}
 		if !ok {
-			t.Errorf("Line count not increased\n\texpected: %s\n\treceived: %s", expected, expvar.Get("line_count").String())
+			t.Errorf("Line count not increased\n\texpected: %s\n\treceived: %s", expected, expvar.Get("lines_total").String())
 			buf := make([]byte, 1<<16)
 			count := runtime.Stack(buf, true)
 			fmt.Println(string(buf[:count]))
@@ -165,8 +165,8 @@ Loop:
 		t.Fatal(err)
 	}
 	expected := "10"
-	if diff := testutil.Diff(expected, expvar.Get("line_count").String()); diff != "" {
-		t.Errorf("line_count metric didn't match\n%s", diff)
+	if diff := testutil.Diff(expected, expvar.Get("lines_total").String()); diff != "" {
+		t.Errorf("lines_total metric didn't match\n%s", diff)
 	}
 	rotationsMap := expvar.Get("log_rotations_total").(*expvar.Map)
 	v := rotationsMap.Get(logFilepath)
@@ -206,7 +206,7 @@ func TestHandleNewLogAfterStart(t *testing.T) {
 		if expvar.Get("log_count").String() != expectedLogCount {
 			return false, nil
 		}
-		if expvar.Get("line_count").String() != expectedLineCount {
+		if expvar.Get("lines_total").String() != expectedLineCount {
 			return false, nil
 		}
 		return true, nil
@@ -217,7 +217,7 @@ func TestHandleNewLogAfterStart(t *testing.T) {
 	}
 	if !ok {
 		t.Errorf("Log count\n\texpected: %s\n\treceived: %s", expectedLogCount, expvar.Get("log_count").String())
-		t.Errorf("Line count\n\texpected: %s\n\treceived: %s", expectedLineCount, expvar.Get("line_count").String())
+		t.Errorf("Line count\n\texpected: %s\n\treceived: %s", expectedLineCount, expvar.Get("lines_total").String())
 	}
 }
 
@@ -520,7 +520,7 @@ func TestHandleLogTruncate(t *testing.T) {
 	testutil.WriteString(t, logFile, "x\n")
 	glog.Info("Write")
 	check := func() (bool, error) {
-		if expvar.Get("line_count").String() != "1" {
+		if expvar.Get("lines_total").String() != "1" {
 			return false, nil
 		}
 		return true, nil
@@ -537,7 +537,7 @@ func TestHandleLogTruncate(t *testing.T) {
 	testutil.WriteString(t, logFile, "x\n")
 	glog.Info("Write")
 	check2 := func() (bool, error) {
-		if expvar.Get("line_count").String() != "2" {
+		if expvar.Get("lines_total").String() != "2" {
 			return false, nil
 		}
 		return true, nil
@@ -590,7 +590,7 @@ func TestHandleRelativeLogAppend(t *testing.T) {
 		// check log line count increase
 		expected := fmt.Sprintf("%d", i+1)
 		check := func() (bool, error) {
-			if expvar.Get("line_count").String() != expected {
+			if expvar.Get("lines_total").String() != expected {
 				return false, nil
 			}
 			return true, nil
@@ -600,7 +600,7 @@ func TestHandleRelativeLogAppend(t *testing.T) {
 			t.Fatal(err)
 		}
 		if !ok {
-			t.Errorf("Line count not increased\n\texpected: %s\n\treceived: %s", expected, expvar.Get("line_count").String())
+			t.Errorf("Line count not increased\n\texpected: %s\n\treceived: %s", expected, expvar.Get("lines_total").String())
 			buf := make([]byte, 1<<16)
 			count := runtime.Stack(buf, true)
 			fmt.Println(string(buf[:count]))

--- a/internal/mtail/multiple_lines_integration_test.go
+++ b/internal/mtail/multiple_lines_integration_test.go
@@ -45,7 +45,7 @@ func TestMultipleLinesInOneWrite(t *testing.T) {
 		glog.Infof("Wrote %d bytes", n)
 		time.Sleep(time.Second)
 	}
-	startLineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+	startLineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 
 	{
 
@@ -56,7 +56,7 @@ func TestMultipleLinesInOneWrite(t *testing.T) {
 		glog.Infof("Wrote %d bytes", n)
 		time.Sleep(time.Second)
 
-		lineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+		lineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 
 		mtail.ExpectMetricDelta(t, lineCount, startLineCount, 2)
 	}

--- a/internal/mtail/partial_line_integration_test.go
+++ b/internal/mtail/partial_line_integration_test.go
@@ -37,7 +37,7 @@ func TestPartialLineRead(t *testing.T) {
 	m, stopM := mtail.TestStartServer(t, 0, false, mtail.ProgramPath(progDir), mtail.LogPathPatterns(logDir+"/log"))
 	defer stopM()
 
-	startLineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+	startLineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 
 	{
 		n, err := f.WriteString("line 1\n")
@@ -47,7 +47,7 @@ func TestPartialLineRead(t *testing.T) {
 		glog.Infof("Wrote %d bytes", n)
 		time.Sleep(time.Second)
 
-		lineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+		lineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 
 		mtail.ExpectMetricDelta(t, lineCount, startLineCount, 1)
 	}
@@ -61,7 +61,7 @@ func TestPartialLineRead(t *testing.T) {
 		glog.Infof("Wrote %d bytes", n)
 		time.Sleep(time.Second)
 
-		lineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+		lineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 
 		mtail.ExpectMetricDelta(t, lineCount, startLineCount, 1)
 	}
@@ -74,7 +74,7 @@ func TestPartialLineRead(t *testing.T) {
 		glog.Infof("Wrote %d bytes", n)
 		time.Sleep(time.Second)
 
-		lineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+		lineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 
 		mtail.ExpectMetricDelta(t, lineCount, startLineCount, 2)
 	}

--- a/internal/mtail/read_pipe_integration_test.go
+++ b/internal/mtail/read_pipe_integration_test.go
@@ -56,7 +56,7 @@ func TestReadFromPipe(t *testing.T) {
 	defer stopM()
 	time.Sleep(time.Second)
 
-	startLineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+	startLineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 	time.Sleep(1 * time.Second)
 
 	n, err := f.WriteString("1\n2\n3\n")
@@ -66,7 +66,7 @@ func TestReadFromPipe(t *testing.T) {
 	glog.Infof("Wrote %d bytes", n)
 	time.Sleep(1 * time.Second)
 
-	endLineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+	endLineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 	lineCount := endLineCount.(float64) - startLineCount.(float64)
 	if lineCount != 3. {
 		t.Errorf("output didn't have expected line count increase: want 3 got %#v", lineCount)

--- a/internal/mtail/truncate_integration_test.go
+++ b/internal/mtail/truncate_integration_test.go
@@ -33,7 +33,7 @@ func TestTruncatedLogRead(t *testing.T) {
 	m, stopM := mtail.TestStartServer(t, 0, false, mtail.ProgramPath(progDir), mtail.LogPathPatterns(logDir+"/log"))
 	defer stopM()
 
-	startLineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+	startLineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 	startLogCount := mtail.TestGetMetric(t, m.Addr(), "log_count")
 
 	logFile := path.Join(logDir, "log")
@@ -62,7 +62,7 @@ func TestTruncatedLogRead(t *testing.T) {
 	glog.Infof("Wrote %d bytes", n)
 	time.Sleep(time.Second)
 
-	endLineCount := mtail.TestGetMetric(t, m.Addr(), "line_count")
+	endLineCount := mtail.TestGetMetric(t, m.Addr(), "lines_total")
 	endLogCount := mtail.TestGetMetric(t, m.Addr(), "log_count")
 
 	mtail.ExpectMetricDelta(t, endLineCount, startLineCount, 2)

--- a/internal/vm/codegen/codegen_test.go
+++ b/internal/vm/codegen/codegen_test.go
@@ -22,7 +22,7 @@ var testCodeGenPrograms = []struct {
 }{
 	// Composite literals require too many explicit conversions.
 	{"simple line counter",
-		"counter line_count\n/$/ { line_count++\n }\n",
+		"counter lines_total\n/$/ { lines_total++\n }\n",
 		[]code.Instr{
 			{code.Match, 0},
 			{code.Jnm, 7},

--- a/internal/vm/loader.go
+++ b/internal/vm/loader.go
@@ -37,7 +37,7 @@ import (
 
 var (
 	// LineCount counts the number of lines read by the program loader.
-	LineCount = expvar.NewInt("line_count")
+	LineCount = expvar.NewInt("lines_total")
 	// ProgLoads counts the number of program load events.
 	ProgLoads = expvar.NewMap("prog_loads_total")
 	// ProgLoadErrors counts the number of program load errors.

--- a/internal/vm/parser/lexer_test.go
+++ b/internal/vm/parser/lexer_test.go
@@ -148,14 +148,14 @@ var lexerTests = []lexerTest{
 		{FLOATLITERAL, "123.456e7", position.Position{"numbers", 0, 65, 73}},
 		{EOF, "", position.Position{"numbers", 0, 74, 74}},
 	}},
-	{"identifier", "a be foo\nquux line_count", []Token{
+	{"identifier", "a be foo\nquux lines_total", []Token{
 		{ID, "a", position.Position{"identifier", 0, 0, 0}},
 		{ID, "be", position.Position{"identifier", 0, 2, 3}},
 		{ID, "foo", position.Position{"identifier", 0, 5, 7}},
 		{NL, "\n", position.Position{"identifier", 1, 8, -1}},
 		{ID, "quux", position.Position{"identifier", 1, 0, 3}},
-		{ID, "line_count", position.Position{"identifier", 1, 5, 14}},
-		{EOF, "", position.Position{"identifier", 1, 15, 15}}}},
+		{ID, "lines_total", position.Position{"identifier", 1, 5, 15}},
+		{EOF, "", position.Position{"identifier", 1, 16, 16}}}},
 	{"regex", "/asdf/", []Token{
 		{DIV, "/", position.Position{"regex", 0, 0, 0}},
 		{REGEX, "asdf", position.Position{"regex", 0, 1, 4}},

--- a/internal/vm/parser/parser_test.go
+++ b/internal/vm/parser/parser_test.go
@@ -23,10 +23,10 @@ var parserTests = []struct {
 		"\n"},
 
 	{"declare counter",
-		"counter line_count\n"},
+		"counter lines_total\n"},
 
 	{"declare counter string name",
-		"counter line_count as \"line-count\"\n"},
+		"counter lines_total as \"line-count\"\n"},
 
 	{"declare dimensioned counter",
 		"counter foo by bar\n"},
@@ -59,9 +59,9 @@ var parserTests = []struct {
 		"/foo/ {}\n"},
 
 	{"more complex action, increment counter",
-		"counter line_count\n" +
+		"counter lines_total\n" +
 			"/foo/ {\n" +
-			"  line_count++\n" +
+			"  lines_total++\n" +
 			"}\n"},
 
 	{"decrement counter",
@@ -236,12 +236,12 @@ foo = 3.14
 		"otherwise {}\n"},
 
 	{"pattern action then otherwise action",
-		`counter line_count by type
+		`counter lines_total by type
 		/foo/ {
-			line_count["foo"]++
+			lines_total["foo"]++
 		}
 		otherwise {
-			line_count["misc"] += 10
+			lines_total["misc"] += 10
 		}`},
 
 	{"simple else clause",


### PR DESCRIPTION
Make `line_count` into `lines_total` to be consistent with naming
convention.