### PR TITLE
doc: fix date format layout

### DIFF
--- a/docs/Programming-Guide.md
+++ b/docs/Programming-Guide.md
@@ -87,7 +87,7 @@ def syslog {
         }
         # If the RFC3339 style matched, parse it this way.
         len($rfc3339_date) > 0 {
-            strptime($rfc3339_date, "2006-01-02T15:04:05-0700")
+            strptime($rfc3339_date, "2006-01-02T15:04:05-07:00")
         }
         # Call into the decorated block
         next


### PR DESCRIPTION
Fix the RFC3339 time parsing layout. The regexp correctly matched the time zone offset (07:00), but the time parsing layout incorrectly left out the colon (0700).