### PR TITLE
make timestamp() return float64

### DIFF
--- a/internal/vm/types/types.go
+++ b/internal/vm/types/types.go
@@ -202,7 +202,7 @@ var Builtins = map[string]Type{
 	"bool":        Function(NewVariable(), Bool),
 	"float":       Function(NewVariable(), Float),
 	"string":      Function(NewVariable(), String),
-	"timestamp":   Function(Int),
+	"timestamp":   Function(Float),
 	"len":         Function(String, Int),
 	"settime":     Function(Int, None),
 	"strptime":    Function(String, String, None),


### PR DESCRIPTION
This changes the return type of the built-in timestamp() function to
float64 instead of int64. The unit remains the same, that is seconds
since the Unix epoch. Before this change, timestamps were truncated to
integer seconds, which made it impossible to measure durations less than
a second. Unix seconds as a float64 has better than microsecond
resolution.

Fixes #263