### PR TITLE
make timestamp() return float64

### DIFF
--- a/internal/mtail/testdata/rsyncd.golden
+++ b/internal/mtail/testdata/rsyncd.golden
@@ -1,6 +1,6 @@
 counter bytes_total {operation=sent} 62793673 2011-02-23T05:54:10Z
 counter bytes_total {operation=received} 975017 2011-02-23T05:54:10Z
 counter connections_total 52 2011-02-22T21:54:13Z
-counter connection-time_total 1181011 2011-02-23T05:54:10Z
+counter connection-time_total 1181011.0 2011-02-23T05:54:10Z
 counter transfers_total {operation=send,module=module} 2 2011-02-23T05:50:32Z
 counter transfers_total {operation=send,module=repo} 25 2011-02-23T05:51:14Z

--- a/internal/vm/types/types.go
+++ b/internal/vm/types/types.go
@@ -202,7 +202,7 @@ var Builtins = map[string]Type{
 	"bool":        Function(NewVariable(), Bool),
 	"float":       Function(NewVariable(), Float),
 	"string":      Function(NewVariable(), String),
-	"timestamp":   Function(Int),
+	"timestamp":   Function(Float),
 	"len":         Function(String, Int),
 	"settime":     Function(Int, None),
 	"strptime":    Function(String, String, None),

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -116,6 +116,18 @@ func (v *VM) errorf(format string, args ...interface{}) {
 	v.terminate = true
 }
 
+// unixFloat returns t as a Unix time, the number of seconds elapsed
+// since January 1, 1970 UTC.
+func unixFloat(t time.Time) float64 {
+	return float64(t.Unix()) + float64(t.Nanosecond())/1e9
+}
+
+// timeFloat returns the time.Time corresponding to the given Unix time.
+func timeFloat(unix float64) time.Time {
+	sec, frac := math.Modf(unix)
+	return time.Unix(int64(sec), int64(frac*1e9))
+}
+
 func (t *thread) PopInt() (int64, error) {
 	val := t.Pop()
 	switch n := val.(type) {
@@ -143,6 +155,8 @@ func (t *thread) PopFloat() (float64, error) {
 	case float64:
 		return n, nil
 	case int:
+		return float64(n), nil
+	case int64:
 		return float64(n), nil
 	case string:
 		r, err := strconv.ParseFloat(n, 64)
@@ -499,16 +513,19 @@ func (v *VM) execute(t *thread, i code.Instr) {
 
 	case code.Timestamp:
 		// Put the time register onto the stack, unless it's zero in which case use system time.
-		if t.time.IsZero() {
-			t.Push(time.Now().Unix())
-		} else {
-			// Put the time register onto the stack
-			t.Push(t.time.Unix())
+		ts := t.time
+		if ts.IsZero() {
+			ts = time.Now()
 		}
+		t.Push(unixFloat(ts))
 
 	case code.Settime:
 		// Pop TOS and store in time register
-		t.time = time.Unix(t.Pop().(int64), 0).UTC()
+		f, err := t.PopFloat()
+		if err != nil {
+			v.errorf("%v", err)
+		}
+		t.time = timeFloat(f).UTC()
 
 	case code.Capref:
 		// Put a capture group reference onto the stack.


### PR DESCRIPTION
This changes the return type of the built-in timestamp() function to
float64 instead of int64. The unit remains the same, that is seconds
since the Unix epoch. Before this change, timestamps were truncated to
integer seconds, which made it impossible to measure durations less than
a second. Unix seconds as a float64 give better than microsecond
resolution.

Fixes #263