### PR TITLE
Fix fuzzit badge trailing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/google/mtail)](https://goreportcard.com/report/github.com/google/mtail)
 [![GolangCI](https://golangci.com/badges/github.com/google/mtail.svg)](https://golangci.com/r/github.com/google/mtail)
 [![fuzzit](https://app.fuzzit.dev/badge?org_id=mtail)](https://app.fuzzit.dev/orgs/mtail/dashboard)
-https://app.fuzzit.dev/orgs/mtail/)
 
 `mtail` is a tool for extracting metrics from application logs to be exported
 into a timeseries database or timeseries calculator for alerting and


### PR DESCRIPTION
Noticed a small issue introduced with commit  https://github.com/google/mtail/commit/395e1a328c4db3699301129176194953eb9db693