### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /go/src/github.com/google/mtail
 RUN  make depclean && make install_deps && PREFIX=/go make -B install
 
 
-FROM alpine:3.7
+FROM alpine:3.9
 
 ARG version=0.0.0-local
 ARG build_date=unknown
@@ -16,16 +16,17 @@ ARG vcs_branch=unknown
 EXPOSE 3903
 ENTRYPOINT ["/usr/bin/mtail"]
 
-LABEL org.label-schema.vendor='Google' \
-    org.label-schema.name='mtail' \
-    org.label-schema.description='extract whitebox monitoring data from application logs for collection in a timeseries database' \
-    org.label-schema.usage='https://github.com/google/mtail/blob/master/docs/Programming-Guide.md' \
-    org.label-schema.url='https://github.com/google/mtail' \
-    org.label-schema.vcs-url=$vcs_url \
-    org.label-schema.vcs-branch=$vcs_branch \
-    org.label-schema.vcs-ref=$commit_hash \
-    org.label-schema.version=$version \
-    org.label-schema.schema-version='1.0' \
-    org.label-schema.build-date=$build_date
+LABEL org.opencontainers.image.ref.name="google/mtail" \
+      org.opencontainers.image.vendor="Google" \
+      org.opencontainers.image.title="mtail" \
+      org.opencontainers.image.description="extract whitebox monitoring data from application logs for collection in a timeseries database" \
+      org.opencontainers.image.authors="Jamie Wilkinson (@jaqx0r)" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version=$version \
+      org.opencontainers.image.revision=$commit_hash \
+      org.opencontainers.image.source=$vcs_url \
+      org.opencontainers.image.documentation="https://github.com/google/mtail/tree/master/docs" \
+      org.opencontainers.image.created=$build_date \
+      org.opencontainers.image.url="https://github.com/google/mtail"
 
 COPY --from=builder /go/bin/mtail /usr/bin/mtail


### PR DESCRIPTION
Changes:
* [label-schema](http://label-schema.org/rc1/) has been deprecated in favor of [OCI image spec.](https://github.com/opencontainers/image-spec/blob/master/annotations.md)
* if you are building in alpine 3.9, you should run in alpine 3.9 for consistency.

I added your name (with @github tag) to the `org.opencontainers.image.authors` line, I was not sure if you wanted to keep it as such.

When this runs on Dockerhub (whenever we get that coveted https://hub.docker.com/google/mtail URL with autobuilding, **ahem** **wink** **wink**), the output of the `docker inspect` labels should look something like this:

```
"Labels": {
  "org.opencontainers.image.authors": "Jamie Wilkinson (@jaqx0r)",
  "org.opencontainers.image.created": "2019-09-10T13:39:38Z",
  "org.opencontainers.image.description": "extract whitebox monitoring data from application logs for collection in a timeseries database",
  "org.opencontainers.image.documentation": "https://github.com/google/mtail/tree/master/docs",
  "org.opencontainers.image.licenses": "Apache-2.0",
  "org.opencontainers.image.ref.name": "google/mtail",
  "org.opencontainers.image.revision": "fa5bab186d6d32634421e973c644b5fa0a3997dd",
  "org.opencontainers.image.source": "git@github.com:google/mtail.git",
  "org.opencontainers.image.title": "mtail",
  "org.opencontainers.image.url": "https://github.com/google/mtail",
  "org.opencontainers.image.vendor": "Google",
  "org.opencontainers.image.version": "v3.0.0-rc33-47-gfa5bab1"
}
```