### PR TITLE
Set exit code to 0 when outputting version info.

### DIFF
--- a/cmd/mtail/main.go
+++ b/cmd/mtail/main.go
@@ -95,7 +95,7 @@ func main() {
 	flag.Parse()
 	if *version {
 		fmt.Println(buildInfo.String())
-		os.Exit(1)
+		os.Exit(0)
 	}
 	glog.Info(buildInfo.String())
 	glog.Infof("Commandline: %q", os.Args)


### PR DESCRIPTION
Fixes #295 