### PR TITLE
MarshalJSON bucket bounds as strings

### DIFF
--- a/internal/exporter/json_test.go
+++ b/internal/exporter/json_test.go
@@ -5,6 +5,7 @@ package exporter
 
 import (
 	"io/ioutil"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -81,6 +82,48 @@ var handleJSONTests = []struct {
           "Value": 1,
           "Time": 0
         }
+      }
+    ]
+  }
+]`,
+	},
+	{"histogram",
+		[]*metrics.Metric{
+			{
+				Name:        "foo",
+				Program:     "test",
+				Kind:        metrics.Histogram,
+				Keys:        []string{"a", "b"},
+				LabelValues: []*metrics.LabelValue{{Labels: []string{"1", "2"}, Value: datum.MakeInt(1, time.Unix(0, 0))}},
+				Buckets:     []datum.Range{datum.Range{Min: 0, Max: math.Inf(1)}},
+			},
+		},
+		`[
+  {
+    "Name": "foo",
+    "Program": "test",
+    "Kind": 5,
+    "Type": 0,
+    "Keys": [
+      "a",
+      "b"
+    ],
+    "LabelValues": [
+      {
+        "Labels": [
+          "1",
+          "2"
+        ],
+        "Value": {
+          "Value": 1,
+          "Time": 0
+        }
+      }
+    ],
+    "Buckets": [
+      {
+        "Min": "0",
+        "Max": "+Inf"
       }
     ]
   }

--- a/internal/metrics/datum/buckets.go
+++ b/internal/metrics/datum/buckets.go
@@ -104,3 +104,12 @@ func (d *Buckets) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(j)
 }
+
+func (r *Range) MarshalJSON() ([]byte, error) {
+	j := struct {
+		Min string
+		Max string
+	}{fmt.Sprintf("%v", r.Min), fmt.Sprintf("%v", r.Max)}
+
+	return json.Marshal(j)
+}


### PR DESCRIPTION
When outputting JSON (with -one_shot for example), the +Inf bucket bound
could not be marshaled as a JSON number and caused mtail to crash.

This stringifies the buckets bounds and solves this issue.
Resolves: https://github.com/google/mtail/issues/273