### PR TITLE
Fix dockerfile - /tmp needs to exist for logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN  make depclean && make install_deps && PREFIX=/go make STATIC=y -B install
 
 FROM scratch
 COPY --from=builder /go/bin/mtail /usr/bin/mtail
+WORKDIR /tmp
 ENTRYPOINT ["/usr/bin/mtail"]
 EXPOSE 3903
 


### PR DESCRIPTION
Containers based on the Dockerfile failed to start due to a crash attempting to write to the log file under /tmp.  The /tmp directory doesn't exist in scratch.  The proper fix might be to have the logger ensure to create the directory, but this fix at least allows the Dockerfile to be used.