### PR TITLE
Switch mtail to use native go-fuzz for OSS-Fuzz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,8 @@ $(GOFUZZBUILD):
 
 GOFUZZ = $(GOBIN)/go-fuzz
 $(GOFUZZ):
-	go get $(GOGETFLAGS) github.com/dvyukov/go-fuzz/go-fuzz
+	go get $(GOGETFLAGS) github.com/mdempsky/go114-fuzz-build
+	ln -s $(GOPATH)/bin/go114-fuzz-build $(GOPATH)/bin/go-fuzz
 
 GOVERALLS = $(GOBIN)/goveralls
 $(GOVERALLS):
@@ -236,8 +237,8 @@ CXXFLAGS ?=
 LIB_FUZZING_ENGINE ?= -libfuzzer
 OUT ?= .
 
-$(OUT)/vm-fuzzer: $(GOFILES) | $(GOFUZZBUILD)
-	$(GOFUZZBUILD) -libfuzzer -o fuzzer.a ./internal/vm
+$(OUT)/vm-fuzzer: $(GOFILES) | $(GOFUZZ)
+	$(GOFUZZ) -o fuzzer.a github.com/google/mtail/internal/vm
 	$(CXX) $(CXXFLAGS) $(LIB_FUZZING_ENGINE) fuzzer.a -lpthread -o $(OUT)/vm-fuzzer
 
 $(OUT)/vm-fuzzer.dict: mgen


### PR DESCRIPTION
Ref: https://github.com/google/oss-fuzz/pull/3638