### PR TITLE
small comment fix in examples/apache_combined.mtail

### DIFF
--- a/examples/apache_combined.mtail
+++ b/examples/apache_combined.mtail
@@ -10,7 +10,7 @@ counter apache_http_bytes_total by request_method, http_version, request_status
 /(?P<hostname>[0-9A-Za-z\.:-]+) / + # %h
 /(?P<remote_logname>[0-9A-Za-z-]+) / + # %l
 /(?P<remote_username>[0-9A-Za-z-]+) / + # %u
-/\[(?P<timestamp>\d{2}\/\w{3}\/\d{4}:\d{2}:\d{2}:\d{2} (\+|-)\d{4})\] / + # %u
+/\[(?P<timestamp>\d{2}\/\w{3}\/\d{4}:\d{2}:\d{2}:\d{2} (\+|-)\d{4})\] / + # %t
 /"(?P<request_method>[A-Z]+) (?P<URI>\S+) (?P<http_version>HTTP\/[0-9\.]+)" / + # \"%r\"
 /(?P<request_status>\d{3}) / + # %>s
 /((?P<response_size>\d+)|-) / + # %b


### PR DESCRIPTION
The 4th field is %t, not %u.