### PR TITLE
Makefile: Add linux/arm and linux/arm64 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ $(PREFIX)/bin/%: %
 	install -m 755 $< $@
 
 
-GOX_OSARCH ?= "linux/amd64 windows/amd64 darwin/amd64 linux/ppc64"
+GOX_OSARCH ?= "linux/amd64 windows/amd64 darwin/amd64 linux/arm linux/arm64 linux/ppc64"
 #GOX_OSARCH := ""
 
 .PHONY: crossbuild


### PR DESCRIPTION
I'd like to run this on arm64 machines, can we have released binaries for it as well?

See also: 49d933dff0ed9cebb6f6a1f98bf63ade823a9953