### PR TITLE
Refactor the timeout test.

### DIFF
--- a/internal/testutil/timeout.go
+++ b/internal/testutil/timeout.go
@@ -8,12 +8,13 @@ import (
 
 func DoOrTimeout(do func() (bool, error), deadline, interval time.Duration) (bool, error) {
 	timeout := time.After(deadline)
-	ticker := time.Tick(interval)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-timeout:
 			return false, nil
-		case <-ticker:
+		case <-ticker.C:
 			glog.V(2).Infof("tick")
 			ok, err := do()
 			glog.V(2).Infof("ok, err: %v %v", ok, err)

--- a/internal/testutil/timeout_test.go
+++ b/internal/testutil/timeout_test.go
@@ -3,36 +3,59 @@ package testutil
 import (
 	"testing"
 	"time"
+
+	"github.com/google/mtail/internal/vm/errors"
 )
 
-func TestDoOrTimeout(t *testing.T) {
+func TestDoOrTimeoutNeverOK(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
 
+	// Never return OK so timeout at 10ms.
 	ok, err := DoOrTimeout(func() (bool, error) {
 		return false, nil
 	}, 10*time.Millisecond, time.Millisecond)
 	if ok || err != nil {
 		t.Errorf("Expected timeout (false, nil), got %v, %v", ok, err)
 	}
+}
 
+func TestDoOrTimeoutAlwaysOK(t *testing.T) {
+	// Always return OK.
+	ok, err := DoOrTimeout(func() (bool, error) {
+		return true, nil
+	}, 10*time.Millisecond, time.Millisecond)
+	if !ok || err != nil {
+		t.Errorf("Expected OK, got %v, %v", ok, err)
+	}
+}
+
+func TestDoOrTimeoutStallThenOK(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	// Stall for 5 ticks (50ms) and then return OK; timeout at 1s.
 	i := 5
-	ok, err = DoOrTimeout(func() (bool, error) {
+	ok, err := DoOrTimeout(func() (bool, error) {
 		i--
 		if i > 0 {
 			return false, nil
 		}
 		return true, nil
-	}, 100*time.Millisecond, time.Millisecond)
+	}, time.Second, 10*time.Millisecond)
 	if !ok || err != nil {
 		t.Errorf("Expected OK, got %v, %v", ok, err)
 	}
+}
 
-	ok, err = DoOrTimeout(func() (bool, error) {
-		return true, nil
+func TestDoOrTimeoutAlwaysErr(t *testing.T) {
+	// Return an error
+	ok, err := DoOrTimeout(func() (bool, error) {
+		return false, errors.Errorf("oh no")
 	}, 10*time.Millisecond, time.Millisecond)
-	if !ok || err != nil {
-		t.Errorf("Expected OK, got %v, %v", ok, err)
+	if ok || err == nil {
+		t.Errorf("Expected !ok and an error, got %v %v", ok, err)
 	}
 }


### PR DESCRIPTION
Attempt to deflake the timeout test by breaking it into separate test methods
to identify the regular flaker.

Also increase the deadline for the flake.

Add a test for always returning an error.