### PR TITLE
Improve tailer setup and teardown.

### DIFF
--- a/cmd/mtail/main.go
+++ b/cmd/mtail/main.go
@@ -147,6 +147,7 @@ func main() {
 		mtail.OverrideLocation(loc),
 		mtail.ExpiredMetricGcTickInterval(*expiredMetricGcTickInterval),
 		mtail.StaleLogGcTickInterval(*staleLogGcTickInterval),
+		mtail.LogPatternPollTickInterval(*pollInterval),
 	}
 	if *unixSocket == "" {
 		opts = append(opts, mtail.BindAddress(*address, *port))

--- a/internal/mtail/mtail.go
+++ b/internal/mtail/mtail.go
@@ -191,9 +191,7 @@ func (m *Server) initExporter() (err error) {
 
 // initTailer sets up a Tailer for this Server.
 func (m *Server) initTailer() (err error) {
-	opts := []tailer.Option{
-		tailer.Context(context.Background()),
-	}
+	opts := []tailer.Option{}
 	if m.oneShot {
 		opts = append(opts, tailer.OneShot())
 	}
@@ -203,7 +201,7 @@ func (m *Server) initTailer() (err error) {
 	if len(m.logPathPatterns) > 0 {
 		opts = append(opts, tailer.LogPatterns(m.logPathPatterns))
 	}
-	m.t, err = tailer.New(m.l, m.w, opts...)
+	m.t, err = tailer.New(context.Background(), m.l, m.w, opts...)
 	return
 }
 

--- a/internal/mtail/mtail.go
+++ b/internal/mtail/mtail.go
@@ -95,9 +95,6 @@ type Server struct {
 // StartTailing adds each log path pattern to the tailer.
 func (m *Server) StartTailing() error {
 	var err error
-	if err = m.t.SetIgnorePattern(m.ignoreRegexPattern); err != nil {
-		glog.Warning(err)
-	}
 	for _, pattern := range m.logPathPatterns {
 		glog.V(1).Infof("Tail pattern %q", pattern)
 		if err = m.t.TailPattern(pattern); err != nil {
@@ -198,7 +195,13 @@ func (m *Server) initTailer() (err error) {
 		tailer.Context(context.Background()),
 	}
 	if m.oneShot {
-		opts = append(opts, tailer.OneShot)
+		opts = append(opts, tailer.OneShot())
+	}
+	if m.ignoreRegexPattern != "" {
+		opts = append(opts, tailer.IgnoreRegex(m.ignoreRegexPattern))
+	}
+	if len(m.logPathPatterns) > 0 {
+		opts = append(opts, tailer.LogPatterns(m.logPathPatterns))
 	}
 	m.t, err = tailer.New(m.l, m.w, opts...)
 	return

--- a/internal/mtail/mtail.go
+++ b/internal/mtail/mtail.go
@@ -194,8 +194,9 @@ func (m *Server) initExporter() (err error) {
 
 // initTailer sets up a Tailer for this Server.
 func (m *Server) initTailer() (err error) {
-	opts := []func(*tailer.Tailer) error{
-		tailer.Context(context.Background())}
+	opts := []tailer.Option{
+		tailer.Context(context.Background()),
+	}
 	if m.oneShot {
 		opts = append(opts, tailer.OneShot)
 	}

--- a/internal/mtail/options.go
+++ b/internal/mtail/options.go
@@ -87,6 +87,13 @@ func StaleLogGcTickInterval(interval time.Duration) func(*Server) error {
 	}
 }
 
+func LogPatternPollTickInterval(interval time.Duration) func(*Server) error {
+	return func(m *Server) error {
+		m.logPatternPollTickInterval = interval
+		return nil
+	}
+}
+
 // OneShot sets one-shot mode in the Server.
 func OneShot(m *Server) error {
 	m.oneShot = true

--- a/internal/tailer/tail.go
+++ b/internal/tailer/tail.go
@@ -66,14 +66,6 @@ func OneShot() Option {
 	}
 }
 
-// Context sets the context of the tailer
-func Context(ctx context.Context) Option {
-	return func(t *Tailer) error {
-		t.ctx = ctx
-		return nil
-	}
-}
-
 // LogPatterns sets the glob patterns to use to match pathnames.
 func LogPatterns(patterns []string) Option {
 	return func(t *Tailer) error {
@@ -95,13 +87,14 @@ func IgnoreRegex(regex string) Option {
 }
 
 // New creates a new Tailer.
-func New(llp logline.Processor, w watcher.Watcher, options ...Option) (*Tailer, error) {
+func New(ctx context.Context, llp logline.Processor, w watcher.Watcher, options ...Option) (*Tailer, error) {
 	if w == nil {
 		return nil, errors.New("can't create tailer without W")
 	}
 	t := &Tailer{
-		llp:          llp,
 		w:            w,
+		ctx:          ctx,
+		llp:          llp,
 		handles:      make(map[string]Log),
 		globPatterns: make(map[string]struct{}),
 	}

--- a/internal/tailer/tail.go
+++ b/internal/tailer/tail.go
@@ -41,9 +41,10 @@ var (
 // lines from files. It also handles new log file creation events and log
 // rotations.
 type Tailer struct {
-	w   watcher.Watcher
-	ctx context.Context
-	llp logline.Processor
+	w      watcher.Watcher
+	ctx    context.Context
+	cancel context.CancelFunc
+	llp    logline.Processor
 
 	handlesMu sync.RWMutex   // protects `handles'
 	handles   map[string]Log // Log handles for each pathname.
@@ -115,11 +116,12 @@ func New(ctx context.Context, llp logline.Processor, w watcher.Watcher, options 
 	}
 	t := &Tailer{
 		w:            w,
-		ctx:          ctx,
 		llp:          llp,
 		handles:      make(map[string]Log),
 		globPatterns: make(map[string]struct{}),
 	}
+	// At the moment we do our own cancellation, so save it here.
+	t.ctx, t.cancel = context.WithCancel(ctx)
 	if err := t.SetOption(options...); err != nil {
 		return nil, err
 	}
@@ -404,6 +406,7 @@ func (t *Tailer) Close() error {
 	if err := t.w.Close(); err != nil {
 		return err
 	}
+	t.cancel()
 	return nil
 }
 

--- a/internal/tailer/tail.go
+++ b/internal/tailer/tail.go
@@ -58,16 +58,38 @@ type Tailer struct {
 // Option defines a new type for setting constructor options in the Tailer.
 type Option func(*Tailer) error
 
-// OneShot puts the tailer in one-shot mode.
-func OneShot(t *Tailer) error {
-	t.oneShot = true
-	return nil
+// OneShot option puts the tailer in one-shot mode, where sources are read once from the start and then closed.
+func OneShot() Option {
+	return func(t *Tailer) error {
+		t.oneShot = true
+		return nil
+	}
 }
 
 // Context sets the context of the tailer
 func Context(ctx context.Context) Option {
 	return func(t *Tailer) error {
 		t.ctx = ctx
+		return nil
+	}
+}
+
+// LogPatterns sets the glob patterns to use to match pathnames.
+func LogPatterns(patterns []string) Option {
+	return func(t *Tailer) error {
+		for _, p := range patterns {
+			if err := t.AddPattern(p); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// IgnoreRegex sets the regular expression to use to filter away pathnames that match the LogPatterns glob
+func IgnoreRegex(regex string) Option {
+	return func(t *Tailer) error {
+		t.SetIgnorePattern(regex)
 		return nil
 	}
 }

--- a/internal/tailer/tail.go
+++ b/internal/tailer/tail.go
@@ -55,6 +55,9 @@ type Tailer struct {
 	oneShot bool
 }
 
+// Option defines a new type for setting constructor options in the Tailer.
+type Option func(*Tailer) error
+
 // OneShot puts the tailer in one-shot mode.
 func OneShot(t *Tailer) error {
 	t.oneShot = true
@@ -62,7 +65,7 @@ func OneShot(t *Tailer) error {
 }
 
 // Context sets the context of the tailer
-func Context(ctx context.Context) func(*Tailer) error {
+func Context(ctx context.Context) Option {
 	return func(t *Tailer) error {
 		t.ctx = ctx
 		return nil
@@ -70,7 +73,7 @@ func Context(ctx context.Context) func(*Tailer) error {
 }
 
 // New creates a new Tailer.
-func New(llp logline.Processor, w watcher.Watcher, options ...func(*Tailer) error) (*Tailer, error) {
+func New(llp logline.Processor, w watcher.Watcher, options ...Option) (*Tailer, error) {
 	if w == nil {
 		return nil, errors.New("can't create tailer without W")
 	}
@@ -87,7 +90,7 @@ func New(llp logline.Processor, w watcher.Watcher, options ...func(*Tailer) erro
 }
 
 // SetOption takes one or more option functions and applies them in order to Tailer.
-func (t *Tailer) SetOption(options ...func(*Tailer) error) error {
+func (t *Tailer) SetOption(options ...Option) error {
 	for _, option := range options {
 		if err := option(t); err != nil {
 			return err

--- a/internal/tailer/tail_test.go
+++ b/internal/tailer/tail_test.go
@@ -21,7 +21,7 @@ func makeTestTail(t *testing.T) (*Tailer, *stubProcessor, *watcher.FakeWatcher, 
 
 	w := watcher.NewFakeWatcher()
 	llp := NewStubProcessor()
-	ta, err := New(llp, w, Context(context.Background()))
+	ta, err := New(context.Background(), llp, w)
 	testutil.FatalIfErr(t, err)
 	return ta, llp, w, tmpDir, rmTmpDir
 }
@@ -205,20 +205,20 @@ func TestTailerInitErrors(t *testing.T) {
 		t.Error("expected error")
 	}
 	lines := &stubProcessor{}
-	_, err = New(lines, nil, nil)
+	_, err = New(context.Background(), lines, nil, nil)
 	if err == nil {
 		t.Error("expected error")
 	}
-	_, err = New(lines, nil)
+	_, err = New(context.Background(), lines, nil)
 	if err == nil {
 		t.Error("expected error")
 	}
 	w := watcher.NewFakeWatcher()
-	_, err = New(lines, w)
+	_, err = New(context.Background(), lines, w)
 	if err != nil {
 		t.Errorf("unexpected error %s", err)
 	}
-	_, err = New(lines, w, OneShot())
+	_, err = New(context.Background(), lines, w, OneShot())
 	if err != nil {
 		t.Errorf("unexpected error %s", err)
 	}

--- a/internal/tailer/tail_test.go
+++ b/internal/tailer/tail_test.go
@@ -218,7 +218,7 @@ func TestTailerInitErrors(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error %s", err)
 	}
-	_, err = New(lines, w, OneShot)
+	_, err = New(lines, w, OneShot())
 	if err != nil {
 		t.Errorf("unexpected error %s", err)
 	}


### PR DESCRIPTION
Move all filesystem polling out of mtail.Server and into the Tailer.  This centralises that work in the obvious place, and as a result the Tailer startup and shutdown code is simpler and less leaky back into the server.

Plumb a cancellable context through and use that for cleanup assistance, so we don't need to store internal config like the tick intervals.