### PR TITLE
Don't need to pass the name of the prog to the prog dumper.

### DIFF
--- a/internal/vm/loader.go
+++ b/internal/vm/loader.go
@@ -209,7 +209,7 @@ func (l *Loader) CompileAndRun(name string, input io.Reader) error {
 	}
 
 	if l.dumpBytecode {
-		glog.Info("Dumping program objects and bytecode\n", v.DumpByteCode(name))
+		glog.Info("Dumping program objects and bytecode\n", v.DumpByteCode())
 	}
 
 	// Load the metrics from the compilation into the global metric storage for export.
@@ -425,7 +425,7 @@ func (l *Loader) ProgzHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "No program found", http.StatusNotFound)
 			return
 		}
-		fmt.Fprintf(w, v.DumpByteCode(prog))
+		fmt.Fprintf(w, v.DumpByteCode())
 		fmt.Fprintf(w, "\nLast runtime error:\n%s", v.RuntimeErrorString())
 		return
 	}

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -118,7 +118,7 @@ func (v *VM) errorf(format string, args ...interface{}) {
 		glog.Infof(" Matches %v", v.t.matches)
 		glog.Infof(" Timestamp %v", v.t.time)
 		glog.Infof(" Stack %v", v.t.stack)
-		glog.Infof(v.DumpByteCode(v.name))
+		glog.Infof(v.DumpByteCode())
 	}
 	v.runtimeErrorMu.Unlock()
 	v.terminate = true
@@ -940,9 +940,9 @@ func New(name string, obj *object.Object, syslogUseCurrentYear bool, loc *time.L
 }
 
 // DumpByteCode emits the program disassembly and program objects to a string.
-func (v *VM) DumpByteCode(name string) string {
+func (v *VM) DumpByteCode() string {
 	b := new(bytes.Buffer)
-	fmt.Fprintf(b, "Prog: %s\n", name)
+	fmt.Fprintf(b, "Prog: %s\n", v.name)
 	fmt.Fprintln(b, "Metrics")
 	for i, m := range v.m {
 		if m.Program == v.name {


### PR DESCRIPTION
It already knows what the name is, and CodeQL thinks this is an XSS.