### PR TITLE
Mark golangci-lint continue on error.

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
+        continue-on-error: true
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.29


### PR DESCRIPTION
This is in the step, not the job, per discussion in
https://github.com/actions/toolkit/issues/399 which indicates that a
continue-on-error at the job level would cause the icon to still be a cross,
but at the step level is totally ignored.  Right now golangci-lint doesn't work
for mtail due to https://github.com/golangci/golangci-lint/issues/1559 so let's
leave it running but ignore it totally with the former setup.