### PR TITLE
Skip the log watcher test as it's flaky.

### DIFF
--- a/internal/watcher/log_watcher_test.go
+++ b/internal/watcher/log_watcher_test.go
@@ -26,6 +26,7 @@ func newStubProcessor() *testStubProcessor {
 }
 
 func TestLogWatcher(t *testing.T) {
+	t.Skip("flaky")
 	testutil.SkipIfShort(t)
 
 	workdir, rmWorkdir := testutil.TestTempDir(t)


### PR DESCRIPTION
The order of events is unstable.