### PR TITLE
Use pull_request, not pull_request_target to trigger workflows.

### DIFF
--- a/.github/workflows/benchmark-done.yml
+++ b/.github/workflows/benchmark-done.yml
@@ -1,0 +1,44 @@
+name: Comment benchmark results on a PR
+on:
+  workflow_run:
+    workflows: ["benchmark"]
+    types:
+      - completed
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >-
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "benchmark-comment"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/benchmark-comment.zip', Buffer.from(download.data));
+      - name: unpack
+        run: |
+          mkdir -p benchmark-comment
+          unzip -d benchmark-comment benchmark-comment.zip
+          echo "::set-output pr-number=$(cat benchmark-comment/pr-number)"
+      - name: post benchmark results
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          header: Benchmark Results
+          path: benchmark-comment.md
+          number: ${{ steps.unpack.outputs.pr-number }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,12 +42,11 @@ jobs:
           # but last part of GITHUB_REF (i.e. on a push to branch)
           BENCH_COUNT=5 HEAD_REF=${GITHUB_HEAD_REF:-${GITHUB_REF##*/}} make bench
           ls -la test-results/benchmark-*
-          echo "## Benchmark Results" > benchmark-comment.md
-          sed -n -e '/<table/,/<\/table>/p' test-results/benchstat.html >> benchmark-comment.md
-      # # This one doesn't work yet.
-      # - name: post benchmark results
-      #   uses: marocchino/sticky-pull-request-comment@v2
-      #   with:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     header: Benchmark Results
-      #     path: benchmark-comment.md
+          mkdir -p benchmark-comment
+          echo "## Benchmark Results" > benchmark-comment/comment.md
+          sed -n -e '/<table/,/<\/table>/p' test-results/benchstat.html >> benchmark-comment/comment.md
+          echo ${{ github.event.number }} > benchmark-comment/pr-number
+      - uses: actions/upload-artifact@v2
+        with:
+          name: benchmark-comment
+          path: benchmark-comment/

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
       - main
-  pull_request_target:
+  pull_request:
 env:
   GO111MODULE: "on"
   GOPROXY: https://proxy.golang.org

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -44,9 +44,10 @@ jobs:
           ls -la test-results/benchmark-*
           echo "## Benchmark Results" > benchmark-comment.md
           sed -n -e '/<table/,/<\/table>/p' test-results/benchstat.html >> benchmark-comment.md
-      - name: post benchmark results
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          header: Benchmark Results
-          path: benchmark-comment.md
+      # # This one doesn't work yet.
+      # - name: post benchmark results
+      #   uses: marocchino/sticky-pull-request-comment@v2
+      #   with:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     header: Benchmark Results
+      #     path: benchmark-comment.md

--- a/.github/workflows/ci-done.yml
+++ b/.github/workflows/ci-done.yml
@@ -1,0 +1,44 @@
+name: Comment CI test results on PR
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >-
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "test-results"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/test-results.zip', Buffer.from(download.data));
+      - name: unpack
+        run: |
+          mkdir -p test-results
+          unzip -d test-results test-results.zip
+          echo "::set-output workflow_pr=$(cat test-results/pr-number)"
+          echo "::set-output workflow_sha=$(cat test-results/sha-number)"
+      - uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
+        with:
+          commit_sha: ${{ steps.unpack.outputs.workflow_sha }}
+          check_name: Unit Test Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: "**/test-results/**/*.xml"

--- a/.github/workflows/ci-done.yml
+++ b/.github/workflows/ci-done.yml
@@ -34,11 +34,10 @@ jobs:
         run: |
           mkdir -p test-results
           unzip -d test-results test-results.zip
-          echo "::set-output workflow_pr=$(cat test-results/pr-number)"
-          echo "::set-output workflow_sha=$(cat test-results/sha-number)"
+          echo "::set-output sha=$(cat test-results/sha-number)"
       - uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
         with:
-          commit_sha: ${{ steps.unpack.outputs.workflow_sha }}
+          commit_sha: ${{ steps.unpack.outputs.sha }}
           check_name: Unit Test Results
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: "**/test-results/**/*.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,12 @@ jobs:
         if: always()
         with:
           file: coverprofile
-      # This one won't work yet, move to workflow_run
-      # - uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
-      #   if: always()
-      #   with:
-      #     check_name: Unit Test Results
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     files: "**/test-results/**/*.xml"
+      - run: echo ${{ github.event.number }} > test-results/pr-number
+      - run: echo $GITHUB_SHA > test-results/sha-number
+      - uses: actions/upload-artifact@v2
+        with:
+          name: test-results
+          path: test-results/
 
   container:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,13 @@ jobs:
         if: always()
         with:
           file: coverprofile
-      - uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
-        if: always()
-        with:
-          check_name: Unit Test Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: "**/test-results/**/*.xml"
+      # This one won't work yet, move to workflow_run
+      # - uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
+      #   if: always()
+      #   with:
+      #     check_name: Unit Test Results
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     files: "**/test-results/**/*.xml"
 
   container:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 name: CI
-on: [push, pull_request_target]
+on: [push, pull_request]
 env:
   GOPROXY: "https://proxy.golang.org"
 jobs:
   test:
     if: >
       github.event_name == 'push' ||
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
+      github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I've misunderstood how the latter works, until reading
https://securitylab.github.com/research/github-actions-preventing-pwn-requests.
The parts that comment on PRs need to run in a workflow_run event after saving
artifacts.