### PR TITLE
Remove condition from CI test job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ env:
   GOPROXY: "https://proxy.golang.org"
 jobs:
   test:
-    if: >
-      github.event_name == 'push' ||
-      github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This test was a leftover from when the test publish action was running from pull_request_target, now it's preventing tests from running on in-repo branches.