### PR TITLE
Switch the store RWMutex to a pair of categorical mutices.

### DIFF
--- a/internal/exporter/export.go
+++ b/internal/exporter/export.go
@@ -156,8 +156,8 @@ func formatLabels(name string, m map[string]string, ksep, sep, rep string) strin
 type formatter func(string, *metrics.Metric, *metrics.LabelSet, time.Duration) string
 
 func (e *Exporter) writeSocketMetrics(c io.Writer, f formatter, exportTotal *expvar.Int, exportSuccess *expvar.Int) error {
-	e.store.RLock()
-	defer e.store.RUnlock()
+	e.store.SearchMu.RLock()
+	defer e.store.SearchMu.RUnlock()
 
 	for _, ml := range e.store.Metrics {
 		for _, m := range ml {

--- a/internal/exporter/prometheus.go
+++ b/internal/exporter/prometheus.go
@@ -30,8 +30,8 @@ func (e *Exporter) Describe(c chan<- *prometheus.Desc) {
 
 // Collect implements the prometheus.Collector interface.
 func (e *Exporter) Collect(c chan<- prometheus.Metric) {
-	e.store.RLock()
-	defer e.store.RUnlock()
+	e.store.SearchMu.RLock()
+	defer e.store.SearchMu.RUnlock()
 
 	for _, ml := range e.store.Metrics {
 		lastSource := ""

--- a/internal/exporter/varz.go
+++ b/internal/exporter/varz.go
@@ -21,8 +21,8 @@ const varzFormat = "%s{%s} %s\n"
 
 // HandleVarz exports the metrics in Varz format via HTTP.
 func (e *Exporter) HandleVarz(w http.ResponseWriter, r *http.Request) {
-	e.store.RLock()
-	defer e.store.RUnlock()
+	e.store.SearchMu.RLock()
+	defer e.store.SearchMu.RUnlock()
 
 	w.Header().Add("Content-type", "text/plain")
 

--- a/internal/metrics/store_bench_test.go
+++ b/internal/metrics/store_bench_test.go
@@ -75,10 +75,10 @@ func BenchmarkStore(b *testing.B) {
 				addToStore(b, items, *m, s)
 			},
 			b: func(b *testing.B, items int, m []*Metric, s *Store) {
-				s.RLock()
+				s.SearchMu.RLock()
 				for _ = range s.Metrics {
 				}
-				s.RUnlock()
+				s.SearchMu.RUnlock()
 			},
 		},
 	}

--- a/internal/mtail/examples_integration_test.go
+++ b/internal/mtail/examples_integration_test.go
@@ -178,7 +178,7 @@ func TestExamplePrograms(t *testing.T) {
 			goldenStore := metrics.NewStore()
 			golden.ReadTestData(g, tc.programfile, goldenStore)
 
-			testutil.ExpectNoDiff(t, goldenStore, store, testutil.IgnoreUnexported(sync.RWMutex{}, datum.String{}))
+			testutil.ExpectNoDiff(t, goldenStore, store, testutil.IgnoreUnexported(sync.RWMutex{}, sync.Mutex{}, datum.String{}))
 		})
 	}
 }
@@ -301,7 +301,7 @@ func TestFilePipeStreamComparison(t *testing.T) {
 			cancel()
 
 			// Ignore the usual field and the datum.Time field as well, as the results will be unstable otherwise.
-			testutil.ExpectNoDiff(t, fileStore, pipeStore, testutil.IgnoreUnexported(sync.RWMutex{}, datum.String{}), testutil.IgnoreFields(datum.BaseDatum{}, "Time"))
+			testutil.ExpectNoDiff(t, fileStore, pipeStore, testutil.IgnoreUnexported(sync.RWMutex{}, sync.Mutex{}, datum.String{}), testutil.IgnoreFields(datum.BaseDatum{}, "Time"))
 		})
 	}
 }

--- a/internal/mtail/golden/reader.go
+++ b/internal/mtail/golden/reader.go
@@ -21,8 +21,8 @@ var varRe = regexp.MustCompile(`^(counter|gauge|timer|text|histogram) ([^ ]+)(?:
 
 // FindMetricOrNil returns a metric in a store, or returns nil if not found.
 func FindMetricOrNil(store *metrics.Store, name string) *metrics.Metric {
-	store.RLock()
-	defer store.RUnlock()
+	store.SearchMu.RLock()
+	defer store.SearchMu.RUnlock()
 	for n, ml := range store.Metrics {
 		if n == name {
 			return ml[0]


### PR DESCRIPTION
The post in The Little Go Book of Semaphores
https://blog.ksub.org/bytes/2016/04/10/the-search-insert-delete-problem/ is a
fascinating read -- well, the whole thing is really -- and suggests a solution
to the general case here.  I think this is actually overkill -- we don't delete
anyuthing from the store except in initialisation (which is probably also
unnecessary) so we don't need the inserter lock as well -- the problem is
probably just that Add took the wrong lock during the search part.  However it
was fun to figure out how to apply this pattern and if we can't have fun, why
are we even here?

Benchmarks shows a massive reduction in time for the new Store/Add and
Store/Iterate families.

Issue #341