### PR TITLE
Move the metrics store dump to the main function.

### DIFF
--- a/cmd/mtail/main.go
+++ b/cmd/mtail/main.go
@@ -216,4 +216,11 @@ func main() {
 		glog.Error(err)
 		os.Exit(1)
 	}
+	if *oneShot {
+		err = store.WriteMetrics(os.Stdout)
+		if err != nil {
+			glog.Error(err)
+		}
+		os.Exit(1)
+	}
 }

--- a/internal/mtail/examples_integration_test.go
+++ b/internal/mtail/examples_integration_test.go
@@ -92,7 +92,7 @@ func TestExamplePrograms(t *testing.T) {
 			waker, _ := waker.NewTest(ctx, 0) // oneshot means we should never need to wake the stream
 			store := metrics.NewStore()
 			programFile := filepath.Join("../..", tc.programfile)
-			mtail, err := mtail.New(ctx, store, mtail.ProgramPath(programFile), mtail.LogPathPatterns(tc.logfile), mtail.OneShot, mtail.OmitMetricSource, mtail.DumpAstTypes, mtail.DumpBytecode, mtail.OmitDumpMetricStore, mtail.LogPatternPollWaker(waker), mtail.LogstreamPollWaker(waker))
+			mtail, err := mtail.New(ctx, store, mtail.ProgramPath(programFile), mtail.LogPathPatterns(tc.logfile), mtail.OneShot, mtail.OmitMetricSource, mtail.DumpAstTypes, mtail.DumpBytecode, mtail.LogPatternPollWaker(waker), mtail.LogstreamPollWaker(waker))
 			testutil.FatalIfErr(t, err)
 
 			var wg sync.WaitGroup
@@ -128,7 +128,7 @@ func TestCompileExamplePrograms(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			s := metrics.NewStore()
-			mtail, err := mtail.New(ctx, s, mtail.ProgramPath(tc), mtail.CompileOnly, mtail.OmitMetricSource, mtail.DumpAstTypes, mtail.DumpBytecode, mtail.OmitDumpMetricStore)
+			mtail, err := mtail.New(ctx, s, mtail.ProgramPath(tc), mtail.CompileOnly, mtail.OmitMetricSource, mtail.DumpAstTypes, mtail.DumpBytecode)
 			testutil.FatalIfErr(t, err)
 			// Ensure that run shuts down for CompileOnly
 			testutil.FatalIfErr(t, mtail.Run())
@@ -213,7 +213,7 @@ func TestFilePipeStreamComparison(t *testing.T) {
 
 			go func() {
 				defer wg.Done()
-				fileMtail, err := mtail.New(ctx, fileStore, mtail.ProgramPath(programFile), mtail.LogPathPatterns(tc.logfile), mtail.OneShot, mtail.OmitMetricSource, mtail.OmitDumpMetricStore, mtail.LogPatternPollWaker(waker), mtail.LogstreamPollWaker(waker))
+				fileMtail, err := mtail.New(ctx, fileStore, mtail.ProgramPath(programFile), mtail.LogPathPatterns(tc.logfile), mtail.OneShot, mtail.OmitMetricSource, mtail.LogPatternPollWaker(waker), mtail.LogstreamPollWaker(waker))
 				if err != nil {
 					t.Error(err)
 				}
@@ -221,7 +221,7 @@ func TestFilePipeStreamComparison(t *testing.T) {
 					t.Error(err)
 				}
 			}()
-			pipeMtail, err := mtail.New(ctx, pipeStore, mtail.ProgramPath(programFile), mtail.LogPathPatterns(pipeName), mtail.OneShot, mtail.OmitMetricSource, mtail.OmitDumpMetricStore, mtail.LogPatternPollWaker(waker), mtail.LogstreamPollWaker(waker))
+			pipeMtail, err := mtail.New(ctx, pipeStore, mtail.ProgramPath(programFile), mtail.LogPathPatterns(pipeName), mtail.OneShot, mtail.OmitMetricSource, mtail.LogPatternPollWaker(waker), mtail.LogstreamPollWaker(waker))
 			testutil.FatalIfErr(t, err)
 			go func() {
 				defer wg.Done()

--- a/internal/mtail/mtail.go
+++ b/internal/mtail/mtail.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
-	"os"
 	"sync"
 	"time"
 
@@ -62,7 +61,6 @@ type Server struct {
 	omitMetricSource     bool           // if set, do not link the source program to a metric
 	omitProgLabel        bool           // if set, do not put the program name in the metric labels
 	emitMetricTimestamp  bool           // if set, emit the metric's recorded timestamp
-	omitDumpMetricsStore bool           // if set, do not print the metric store; useful in test
 }
 
 // initLoader constructs a new program loader and performs the initial load of program files in the program directory.
@@ -284,16 +282,6 @@ func (m *Server) Run() error {
 	m.wg.Wait()
 	if m.compileOnly {
 		glog.Info("compile-only is set, exiting")
-		return nil
-	}
-	if m.oneShot {
-		if m.omitDumpMetricsStore {
-			glog.Info("Store dump disabled, exiting")
-			return nil
-		}
-		if err := m.store.WriteMetrics(os.Stdout); err != nil {
-			return err
-		}
 		return nil
 	}
 	return nil

--- a/internal/mtail/options.go
+++ b/internal/mtail/options.go
@@ -229,13 +229,6 @@ func (opt JaegerReporter) apply(m *Server) error {
 	return nil
 }
 
-// OmitDumpMetricStore disables dumping of the metric store... somewhere.
-var OmitDumpMetricStore = &niladicOption{
-	func(m *Server) error {
-		m.omitDumpMetricsStore = true
-		return nil
-	}}
-
 // MetricPushInterval sets the interval between metrics pushes to passive collectors.
 type MetricPushInterval time.Duration
 


### PR DESCRIPTION
We don't need to do it in mtail because it happens after shutdown.  The option
can be removed because it only gets set in tests.