### PR TITLE
fix SIGHUP handler: check for non-empty path to programs

### DIFF
--- a/internal/vm/loader.go
+++ b/internal/vm/loader.go
@@ -430,7 +430,7 @@ func NewLoader(lines <-chan *logline.LogLine, wg *sync.WaitGroup, programPath st
 	go func() {
 		defer l.wg.Done()
 		<-initDone
-		if l.programPath != "" {
+		if l.programPath == "" {
 			glog.Info("no program reload on SIGHUP without programPath")
 			return
 		}


### PR DESCRIPTION
Current build is unable to reload programs on HUP, logging that

```
I0127 23:04:43.886579   13546 loader.go:434] no program reload on SIGHUP without programPath
```

apparently there is a trivial typo in path check.