### PR TITLE
Downgrade the timed out message from pipestream as it's expected.

### DIFF
--- a/internal/tailer/logstream/pipestream.go
+++ b/internal/tailer/logstream/pipestream.go
@@ -92,11 +92,11 @@ func (ps *pipeStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wake
 
 			var perr *os.PathError
 			if errors.As(err, &perr) && perr.Timeout() && n == 0 {
-				glog.Info("timed out")
+				glog.V(2).Info("timed out")
 				timedout = true
-				// Named Pipes EOF when the writer has closed, so we look for a
-				// timeout on read to detect a writer stall and thus let us check
-				// below for cancellation.
+				// Named Pipes EOF only when the writer has closed, so we look
+				// for a timeout on read to detect a writer stall and thus let
+				// us check below for cancellation.
 				goto Sleep
 			}
 			// Per pipe(7): If all file descriptors referring to the write end


### PR DESCRIPTION
This is a normal condition so we should not be logging this at info level, it's
debugging information.  Otherwise we'll fill the mtail logs!

Fixes #462