### PR TITLE
Added a UDP socket log stream type.

### DIFF
--- a/internal/mtail/mtail.go
+++ b/internal/mtail/mtail.go
@@ -43,6 +43,7 @@ type Server struct {
 
 	buildInfo          BuildInfo // go build information
 	programPath        string    // path to programs to load
+	logSockets         []string  // list of sockets to watch for logs
 	logPathPatterns    []string  // list of patterns to watch for log files to tail
 	ignoreRegexPattern string
 
@@ -135,6 +136,7 @@ func (m *Server) initExporter() (err error) {
 func (m *Server) initTailer() (err error) {
 	opts := []tailer.Option{
 		tailer.IgnoreRegex(m.ignoreRegexPattern),
+		tailer.LogSockets(m.logSockets),
 		tailer.LogPatterns(m.logPathPatterns),
 		tailer.LogPatternPollWaker(m.logPatternPollWaker),
 		tailer.StaleLogGcWaker(m.staleLogGcWaker),

--- a/internal/mtail/options.go
+++ b/internal/mtail/options.go
@@ -26,6 +26,18 @@ func (opt ProgramPath) apply(m *Server) error {
 	return nil
 }
 
+// LogSockets sets the urls to bind to listen for log events on the Server.
+func LogSockets(sockets ...string) Option {
+	return logSockets(sockets)
+}
+
+type logSockets []string
+
+func (opt logSockets) apply(m *Server) error {
+	m.logSockets = opt
+	return nil
+}
+
 // LogPathPatterns sets the patterns to find log paths in the Server.
 func LogPathPatterns(patterns ...string) Option {
 	return logPathPatterns(patterns)

--- a/internal/tailer/logstream/decode.go
+++ b/internal/tailer/logstream/decode.go
@@ -22,6 +22,10 @@ func decodeAndSend(ctx context.Context, lines chan<- *logline.LogLine, pathname 
 		rune  rune
 		width int
 	)
+	if partial == nil {
+		sendLine(ctx, pathname, bytes.NewBuffer(b), lines)
+		return
+	}
 	for i := 0; i < len(b) && i < n; i += width {
 		rune, width = utf8.DecodeRune(b[i:])
 		switch {

--- a/internal/tailer/logstream/udpsocketstream_test.go
+++ b/internal/tailer/logstream/udpsocketstream_test.go
@@ -1,0 +1,96 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+// This file is available under the Apache license.
+
+package logstream_test
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/google/mtail/internal/logline"
+	"github.com/google/mtail/internal/tailer/logstream"
+	"github.com/google/mtail/internal/testutil"
+	"github.com/google/mtail/internal/waker"
+)
+
+func TestUdpSocketStreamReadBsdSyslog(t *testing.T) {
+	var wg sync.WaitGroup
+
+	name := "udp:localhost:65111"
+
+	lines := make(chan *logline.LogLine, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	waker, awaken := waker.NewTest(ctx, 1)
+
+	ss, err := logstream.New(ctx, &wg, waker, name, lines, false)
+	testutil.FatalIfErr(t, err)
+	awaken(1) // Synchronise past socket creation
+
+	s, err := net.Dial("udp", "localhost:65111")
+	testutil.FatalIfErr(t, err)
+
+	// BSD syslog observed to trail with a space character
+	_, err = s.Write([]byte("1 "))
+	testutil.FatalIfErr(t, err)
+	awaken(1)
+
+	ss.Stop()
+	wg.Wait()
+	close(lines)
+
+	received := testutil.LinesReceived(lines)
+	expected := []*logline.LogLine{
+		// BSD syslog set to ignore trailing spaces
+		{context.TODO(), name, "1"},
+	}
+	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context", "Filename"))
+
+	cancel()
+	wg.Wait()
+
+	if !ss.IsComplete() {
+		t.Errorf("expecting socketstream to be complete because cancellation")
+	}
+}
+
+func TestUdpSocketStreamRead(t *testing.T) {
+	var wg sync.WaitGroup
+
+	name := "udp:localhost:65111"
+
+	lines := make(chan *logline.LogLine, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	waker, awaken := waker.NewTest(ctx, 1)
+
+	ss, err := logstream.New(ctx, &wg, waker, name, lines, false)
+	testutil.FatalIfErr(t, err)
+	awaken(1) // Synchronise past socket creation
+
+	s, err := net.Dial("udp", "localhost:65111")
+	testutil.FatalIfErr(t, err)
+
+	_, err = s.Write([]byte("1\n"))
+	testutil.FatalIfErr(t, err)
+	awaken(1)
+
+	ss.Stop()
+	wg.Wait()
+	close(lines)
+
+	received := testutil.LinesReceived(lines)
+	expected := []*logline.LogLine{
+		// Datagrams are our delimiters here, newline is unexpected,
+		// but possible.
+		{context.TODO(), name, "1\n"},
+	}
+	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context", "Filename"))
+
+	cancel()
+	wg.Wait()
+
+	if !ss.IsComplete() {
+		t.Errorf("expecting socketstream to be complete because cancellation")
+	}
+}


### PR DESCRIPTION
Wondering what the appetite is to include something like this?  

Use "udp://host:port" as the argument to the new flag `-logurls`, and this will bind to the address and port, listening for lines.  Helpful when sending syslog directly to mtail, based on the socketstream type.

I used a new flag instead of overloading `-logs`, because the assumption in the codebase of logs being log-patterns, and since there's no globs, that code isn't strictly necessary.

With the url scheme, it would be extendable to other types, e.g. "tcp:, relp:, etc".

My use-case is to broadcast syslog over a private subnet with multiple mtail instances listening, for a cheap "clustering" for redundancy.