### PR TITLE
Export histogram buckets and total count for Graphite

### DIFF
--- a/internal/exporter/export_test.go
+++ b/internal/exporter/export_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -129,6 +130,26 @@ func TestMetricToGraphite(t *testing.T) {
 	expected = []string{
 		"prog.bar.host.quux_com 37 1343124840\n",
 		"prog.bar.host.snuh_teevee 37 1343124840\n"}
+	testutil.ExpectNoDiff(t, expected, r)
+
+	histogramMetric := metrics.NewMetric("hist", "prog", metrics.Histogram, metrics.Buckets, "xxx")
+	histogramMetric.LabelValues = []*metrics.LabelValue{{Labels: []string{"bar"}, Value: datum.MakeBuckets([]datum.Range{{0, 10}, {10, 20}}, time.Unix(0, 0))}}
+	d, _ = histogramMetric.GetDatum("bar")
+	datum.SetFloat(d, 1, ts)
+	datum.SetFloat(d, 5, ts)
+	datum.SetFloat(d, 15, ts)
+	datum.SetFloat(d, 12, ts)
+	datum.SetFloat(d, 19, ts)
+	datum.SetFloat(d, 1000, ts)
+	r = FakeSocketWrite(metricToGraphite, histogramMetric)
+	r = strings.Split(strings.TrimSuffix(r[0], "\n"), "\n")
+	sort.Strings(r)
+	expected = []string{
+		"prog.hist.xxx.bar 1052 1343124840",
+		"prog.hist.xxx.bar.bin_10 2 1343124840",
+		"prog.hist.xxx.bar.bin_20 3 1343124840",
+		"prog.hist.xxx.bar.bin_inf 1 1343124840",
+		"prog.hist.xxx.bar.count 6 1343124840"}
 	testutil.ExpectNoDiff(t, expected, r)
 
 	*graphitePrefix = prefix

--- a/internal/exporter/graphite.go
+++ b/internal/exporter/graphite.go
@@ -7,10 +7,13 @@ import (
 	"expvar"
 	"flag"
 	"fmt"
+	"math"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/mtail/internal/metrics"
+	"github.com/google/mtail/internal/metrics/datum"
 )
 
 var (
@@ -48,10 +51,37 @@ func (e *Exporter) HandleGraphite(w http.ResponseWriter, r *http.Request) {
 // metricToGraphite encodes a metric in the graphite text protocol format.  The
 // metric lock is held before entering this function.
 func metricToGraphite(hostname string, m *metrics.Metric, l *metrics.LabelSet, _ time.Duration) string {
-	return fmt.Sprintf("%s%s.%s %v %v\n",
+	var b strings.Builder
+	if (m.Kind == metrics.Histogram && m.Type == metrics.Buckets) {
+		d := m.LabelValues[0].Value
+		buckets := datum.GetBuckets(d)
+		for r, c := range buckets.GetBuckets() {
+			var binName string
+			if math.IsInf(r.Max, 1) {
+				binName = "inf"
+			} else {
+				binName = fmt.Sprintf("%v", r.Max)
+			}
+			fmt.Fprintf(&b, "%s%s.%s.bin_%s %v %v\n",
+				*graphitePrefix,
+				m.Program,
+				formatLabels(m.Name, l.Labels, ".", ".", "_"),
+				binName,
+				c,
+				l.Datum.TimeString())
+		}
+		fmt.Fprintf(&b, "%s%s.%s.count %v %v\n",
+			*graphitePrefix,
+			m.Program,
+			formatLabels(m.Name, l.Labels, ".", ".", "_"),
+			buckets.GetCount(),
+			l.Datum.TimeString())
+	}
+	fmt.Fprintf(&b, "%s%s.%s %v %v\n",
 		*graphitePrefix,
 		m.Program,
 		formatLabels(m.Name, l.Labels, ".", ".", "_"),
 		l.Datum.ValueString(),
 		l.Datum.TimeString())
+	return b.String()
 }

--- a/internal/exporter/graphite_test.go
+++ b/internal/exporter/graphite_test.go
@@ -1,0 +1,68 @@
+// Copyright 2021 Adam Romanek <romanek.adam@gmail.com>
+// This file is available under the Apache license.
+
+package exporter
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/mtail/internal/metrics"
+	"github.com/google/mtail/internal/metrics/datum"
+	"github.com/google/mtail/internal/testutil"
+)
+
+var handleGraphiteTests = []struct {
+	name     string
+	metrics  []*metrics.Metric
+	expected string
+}{
+	{"empty",
+		[]*metrics.Metric{},
+		"",
+	},
+	{"single",
+		[]*metrics.Metric{
+			{
+				Name:        "foo",
+				Program:     "test",
+				Kind:        metrics.Counter,
+				LabelValues: []*metrics.LabelValue{{Labels: []string{}, Value: datum.MakeInt(1, time.Unix(0, 0))}},
+			},
+		},
+		"foobar.test.foo 1 0\n",
+	},
+}
+
+func TestHandleGraphite(t *testing.T) {
+	*graphitePrefix = "foobar."
+	for _, tc := range handleGraphiteTests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			var wg sync.WaitGroup
+			ms := metrics.NewStore()
+			for _, metric := range tc.metrics {
+				testutil.FatalIfErr(t, ms.Add(metric))
+			}
+			e, err := New(ctx, &wg, ms, Hostname("gunstar"))
+			testutil.FatalIfErr(t, err)
+			response := httptest.NewRecorder()
+			e.HandleGraphite(response, &http.Request{})
+			if response.Code != 200 {
+				t.Errorf("response code not 200: %d", response.Code)
+			}
+			b, err := ioutil.ReadAll(response.Body)
+			if err != nil {
+				t.Errorf("failed to read response %s", err)
+			}
+			testutil.ExpectNoDiff(t, tc.expected, string(b), testutil.IgnoreUnexported(sync.RWMutex{}))
+			cancel()
+			wg.Wait()
+		})
+	}
+}

--- a/internal/mtail/httpstatus.go
+++ b/internal/mtail/httpstatus.go
@@ -18,7 +18,7 @@ const statusTemplate = `
 <body>
 <h1>mtail on {{.BindAddress}}</h1>
 <p>Build: {{.BuildInfo}}</p>
-<p>Metrics: <a href="/json">json</a>, <a href="/metrics">prometheus</a>, <a href="/varz">varz</a></p>
+<p>Metrics: <a href="/json">json</a>, <a href="/graphite">graphite</a>, <a href="/metrics">prometheus</a>, <a href="/varz">varz</a></p>
 <p>Debug: <a href="/debug/pprof">debug/pprof</a>, <a href="/debug/vars">debug/vars</a>, <a href="/tracez">tracez</a>, <a href="/progz">progz</a></p>
 `
 

--- a/internal/mtail/mtail.go
+++ b/internal/mtail/mtail.go
@@ -163,6 +163,7 @@ func (m *Server) initHttpServer() error {
 	mux.Handle("/progz", http.HandlerFunc(m.l.ProgzHandler))
 	mux.HandleFunc("/json", http.HandlerFunc(m.e.HandleJSON))
 	mux.Handle("/metrics", promhttp.HandlerFor(m.reg, promhttp.HandlerOpts{}))
+	mux.HandleFunc("/graphite", http.HandlerFunc(m.e.HandleGraphite))
 	mux.HandleFunc("/varz", http.HandlerFunc(m.e.HandleVarz))
 	mux.Handle("/debug/vars", expvar.Handler())
 	mux.HandleFunc("/debug/pprof/", pprof.Index)


### PR DESCRIPTION
Up until now when exporting histograms for Graphite only the sum of the values was being exported as one metric. From now on the counts of values in distinct buckets along with the total count is exported too, as separate metrics, so histograms are now usable in Graphite too.
    
Perhaps similar code should be added to collectd, statsd and varz metricTo* converters too...

Additionally Graphite metrics are now exported via HTTP which can sometimes ease debugging.