### PR TITLE
Correct TestTestWakerTwoWakeups by waiting for the actual wakeup.

### DIFF
--- a/internal/waker/testwaker.go
+++ b/internal/waker/testwaker.go
@@ -48,7 +48,7 @@ func NewTest(ctx context.Context, n int) (Waker, wakeFunc) {
 	}()
 	wakeFunc := func(after int) {
 		<-initDone
-		glog.InfoDepth(1, "test yielding to Wakee")
+		glog.InfoDepth(1, "TestWaker yielding to Wakee")
 		for i := 0; i < t.n; i++ {
 			t.wait <- struct{}{}
 		}
@@ -63,7 +63,7 @@ func NewTest(ctx context.Context, n int) (Waker, wakeFunc) {
 			<-t.wakeeDone
 		}
 		t.n = after
-		glog.InfoDepth(1, "Wakee yielding to test")
+		glog.InfoDepth(1, "Wakee yielding to TestWaker")
 	}
 	return t, wakeFunc
 }


### PR DESCRIPTION
There was a race where we'd skip ahead in the `Wake()` and accidentally wait on
the same wake channel a second time, which would get the wrong result when that
occurs because it would have been `awaken()`d by then.  Forcing the first
iteration to block on `Wake()` ensures the second one gets a new channel.