### PR TITLE
Fix the name substitution of the benchmark results filename.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ GO_TEST_FLAGS ?=
 BENCH_COUNT ?= 1
 BASE_REF ?= master
 HEAD_REF ?= $(shell git symbolic-ref HEAD -q --short)
+BASE_REF := $(subst /,-,$(BASE_REF))
+HEAD_REF := $(subst /,-,$(HEAD_REF))
 
 all: $(TARGETS)
 
@@ -184,15 +186,15 @@ $(TESTRESULTS)/test-output.xml $(TESTCOVERPROFILE): $(GOFILES) $(GOGENFILES) $(G
 	gotestsum --debug --junitfile $(TESTRESULTS)/test-output.xml -- $(GO_TEST_FLAGS) -cpu 1,2,4 -race -parallel 1 -coverprofile=$(TESTCOVERPROFILE) --covermode=atomic -v -timeout=${timeout} -gcflags "$(GO_GCFLAGS)" ./...
 
 .PHONY: bench
-bench: $(TESTRESULTS)/benchmark-results-$(HEAD_REF:/=-).txt
-$(TESTRESULTS)/benchmark-results-$(HEAD_REF:/=-).txt: $(GOFILES) $(GOGENFILES) $(GOTESTFILES) | print-version .dep-stamp
+bench: $(TESTRESULTS)/benchmark-results-$(HEAD_REF).txt
+$(TESTRESULTS)/benchmark-results-$(HEAD_REF).txt: $(GOFILES) $(GOGENFILES) $(GOTESTFILES) | print-version .dep-stamp
 	mkdir -p $(TESTRESULTS)
 	go test -cpu 1,2,4 -bench=. -count=$(BENCH_COUNT) -timeout=${benchtimeout} -run=^a ./... | tee $@
 
 .PHONY: benchstat
 benchstat: $(TESTRESULTS)/benchstat.txt
-$(TESTRESULTS)/benchstat.txt: $(TESTRESULTS)/benchmark-results-$(HEAD_REF:/=-).txt | print-version $(BENCHSTAT)
-	(test -s $(TESTRESULTS)/benchmark-results-$(BASE_REF:/=-).txt && benchstat $(TESTRESULTS)/benchmark-results-$(BASE_REF:/=-).txt $< || benchstat $<) | tee $@
+$(TESTRESULTS)/benchstat.txt: $(TESTRESULTS)/benchmark-results-$(HEAD_REF).txt | print-version $(BENCHSTAT)
+	(test -s $(TESTRESULTS)/benchmark-results-$(BASE_REF).txt && benchstat $(TESTRESULTS)/benchmark-results-$(BASE_REF).txt $< || benchstat $<) | tee $@
 
 
 PACKAGES := $(shell go list -f '{{.Dir}}' ./... | grep -v /vendor/ | grep -v /cmd/ | sed -e "s@$$(pwd)@.@")


### PR DESCRIPTION
When the branch name contains slashes, the file fails to be created.  Previous
attempt to rewrite the file with a substitution reference was not working
because substitution references are equivalent to `patsubst`.  This time use
simple expansion and a `subst` call.