### PR TITLE
Implement string substitution function

### DIFF
--- a/docs/Language.md
+++ b/docs/Language.md
@@ -441,6 +441,7 @@ program state.
     string argument `x`.
 *   `tolower(x)`, a function of one string argument, which returns the input `x`
     in all lowercase.
+*   `subst(old, new, val)`, a function of three arguments which returns the input `val` with all substrings `old` replaced by `new`.  It is a direct proxy of the Go [strings.ReplaceAll](https://golang.org/pkg/strings/#ReplaceAll) function.
 
 There are type coercion functions, useful for overriding the type inference made
 by the compiler if it chooses badly. (If the choice is egregious, please file a

--- a/docs/Programming-Guide.md
+++ b/docs/Programming-Guide.md
@@ -374,6 +374,20 @@ counter total
 
 `mtail` does not presently have a way to test if a capture group is defined or not.
 
+## Parsing numbers with extra characters
+
+Some programs will make their numbers human readable, by inserting thousands-separators (comma or full stop depending on your locale.)  You can remove them with the `subst` function:
+
+```
+/sent (?P<sent>[\d,]+) bytes  received (?P<received>[\d,]+) bytes/ {
+    # Sum total bytes across all sessions for this process
+    bytes_total["sent"] += int(subst(",", "", $sent))
+    bytes_total["received"] += int(subst(",", "", $received))
+}
+```
+
+As `subst` is of type String, the type inference will assign a Text type to bytes total, so here we must explicitly instruct `mtail` that we are expecting this to be an Int by using the `int` cast function.
+
 # Avoiding unnecessary work
 
 You can stop the program if it's fed data from a log file you know you want to ignore:

--- a/docs/Programming-Guide.md
+++ b/docs/Programming-Guide.md
@@ -113,6 +113,19 @@ This can be used around any blocks later in the program.
 Both the foo and bar pattern actions will have the syslog timestamp parsed from
 them before being called.
 
+### Timestamps with strange characters in them
+
+Go's [time.Parse](https://golang.org/pkg/time/#Parse) does not like underscores in the format string, which may happen when one is attempting to parse a timestamp that does have underscores in the format.  Go treats the underscore as placeholding an optional digit.
+
+To work around this, you can use `subst()` to rewrite the timestamp before parsing:
+
+```
+/(\d{4}-\d{2}-\d{2}_\d{2}:\d{2}:\d{2}) / {
+  strptime(subst("_", " ", $1, "2006-01-02 15:04:05")
+}
+```
+
+Note the position of the underscore in the regular expression match.
 
 ## Conditional structures
 

--- a/internal/vm/checker/checker_test.go
+++ b/internal/vm/checker/checker_test.go
@@ -460,6 +460,11 @@ gauge foo
 /(?P<value_ms>-?\d+)/ {
   foo += $value_ms / 1000.0
 }`},
+	{"substitution", `
+gauge foo
+/(\d,\d)/ {
+foo = subst(",", "", $1)
+}`},
 }
 
 func TestCheckValidPrograms(t *testing.T) {

--- a/internal/vm/code/opcodes.go
+++ b/internal/vm/code/opcodes.go
@@ -74,6 +74,9 @@ const (
 	Fcmp // floating point compare
 	Scmp // string compare
 
+	// String opcodes
+	Subst
+
 	lastOpcode
 )
 
@@ -134,6 +137,7 @@ var opNames = map[Opcode]string{
 	Icmp:        "icmp",
 	Fcmp:        "fcmp",
 	Scmp:        "scmp",
+	Subst:       "subst",
 }
 
 func (o Opcode) String() string {

--- a/internal/vm/codegen/codegen.go
+++ b/internal/vm/codegen/codegen.go
@@ -400,6 +400,7 @@ var builtin = map[string]code.Opcode{
 	"settime":     code.Settime,
 	"strptime":    code.Strptime,
 	"strtol":      code.S2i,
+	"subst":       code.Subst,
 	"timestamp":   code.Timestamp,
 	"tolower":     code.Tolower,
 }

--- a/internal/vm/codegen/codegen_test.go
+++ b/internal/vm/codegen/codegen_test.go
@@ -900,6 +900,25 @@ foo += $value_ms / 1000.0
 		{code.Fset, nil, 3},
 		{code.Setmatched, true, 2},
 	}},
+	{"substitution", `
+gauge foo
+/(\d+,\d)/ {
+  foo = int(subst(",", "", $1))
+}`, []code.Instr{
+		{code.Match, 0, 2},
+		{code.Jnm, 13, 2},
+		{code.Setmatched, false, 2},
+		{code.Mload, 0, 3},
+		{code.Dload, 0, 3},
+		{code.Str, 0, 3},
+		{code.Str, 1, 3},
+		{code.Push, 0, 3},
+		{code.Capref, 1, 3},
+		{code.Subst, 3, 3},
+		{code.S2i, nil, 3},
+		{code.Iset, nil, 3},
+		{code.Setmatched, true, 2},
+	}},
 }
 
 func TestCodeGenFromSource(t *testing.T) {

--- a/internal/vm/parser/lexer.go
+++ b/internal/vm/parser/lexer.go
@@ -47,6 +47,7 @@ var builtins = []string{
 	"string",
 	"strptime",
 	"strtol",
+	"subst",
 	"timestamp",
 	"tolower",
 }

--- a/internal/vm/parser/lexer_test.go
+++ b/internal/vm/parser/lexer_test.go
@@ -104,7 +104,7 @@ var lexerTests = []lexerTest{
 			{NL, "\n", position.Position{"keywords", 17, 7, -1}},
 			{EOF, "", position.Position{"keywords", 17, 0, 0}}}},
 	{"builtins",
-		"strptime\ntimestamp\ntolower\nlen\nstrtol\nsettime\ngetfilename\nint\nbool\nfloat\nstring\n", []Token{
+		"strptime\ntimestamp\ntolower\nlen\nstrtol\nsettime\ngetfilename\nint\nbool\nfloat\nstring\nsubst\n", []Token{
 			{BUILTIN, "strptime", position.Position{"builtins", 0, 0, 7}},
 			{NL, "\n", position.Position{"builtins", 1, 8, -1}},
 			{BUILTIN, "timestamp", position.Position{"builtins", 1, 0, 8}},
@@ -127,7 +127,9 @@ var lexerTests = []lexerTest{
 			{NL, "\n", position.Position{"builtins", 10, 5, -1}},
 			{BUILTIN, "string", position.Position{"builtins", 10, 0, 5}},
 			{NL, "\n", position.Position{"builtins", 11, 6, -1}},
-			{EOF, "", position.Position{"builtins", 11, 0, 0}}}},
+			{BUILTIN, "subst", position.Position{"builtins", 11, 0, 4}},
+			{NL, "\n", position.Position{"builtins", 12, 5, -1}},
+			{EOF, "", position.Position{"builtins", 12, 0, 0}}}},
 	{"numbers", "1 23 3.14 1.61.1 -1 -1.0 1h 0d 3d -1.5h 15m 24h0m0s 1e3 1e-3 .11 123.456e7", []Token{
 		{INTLITERAL, "1", position.Position{"numbers", 0, 0, 0}},
 		{INTLITERAL, "23", position.Position{"numbers", 0, 2, 3}},

--- a/internal/vm/parser/parser_test.go
+++ b/internal/vm/parser/parser_test.go
@@ -328,6 +328,11 @@ $foo =~ X {
 // {
   stop
 }`},
+
+	{"substitution", `
+/(\d,\d)/ {
+  subst(",", ",", $1)
+}`},
 }
 
 func TestParserRoundTrip(t *testing.T) {

--- a/internal/vm/types/types.go
+++ b/internal/vm/types/types.go
@@ -209,6 +209,7 @@ var Builtins = map[string]Type{
 	"strtol":      Function(String, Int, Int),
 	"tolower":     Function(String, String),
 	"getfilename": Function(String),
+	"subst":       Function(String, String, String, String),
 }
 
 // FreshType returns a new type from the provided type scheme, replacing any

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -891,6 +891,24 @@ func (v *VM) execute(t *thread, i code.Instr) {
 		}
 		t.Push(a + b)
 
+	case code.Subst:
+		val, verr := t.PopString()
+		if verr != nil {
+			v.errorf("%+v", verr)
+			return
+		}
+		new, nerr := t.PopString()
+		if nerr != nil {
+			v.errorf("%+v", nerr)
+			return
+		}
+		old, oerr := t.PopString()
+		if oerr != nil {
+			v.errorf("%+v", oerr)
+			return
+		}
+		t.Push(strings.Replace(val, old, new, -1))
+
 	default:
 		v.errorf("illegal instruction: %d", i.Opcode)
 	}

--- a/internal/vm/vm_integration_test.go
+++ b/internal/vm/vm_integration_test.go
@@ -962,6 +962,37 @@ a
 			},
 		},
 	},
+	{
+		name: "subst integer",
+		prog: `counter bytes_total by dir
+/sent (?P<sent>[\d,]+) bytes  received (?P<received>[\d,]+) bytes/ {
+    # Sum total bytes across all sessions for this process
+    bytes_total["sent"] += int(subst(",", "", $sent))
+    bytes_total["received"] += int(subst(",", "", $received))
+}`,
+		log: `Jun 28 20:44:32 backup rsync[3996]: sent 642,410,725 bytes  received 14,998,522,122 bytes  497,002.00 bytes/sec
+`,
+		errs: 0,
+		metrics: metrics.MetricSlice{
+			{
+				Name:    "bytes_total",
+				Program: "subst integer",
+				Kind:    metrics.Counter,
+				Type:    metrics.Int,
+				Keys:    []string{"dir"},
+				LabelValues: []*metrics.LabelValue{
+					{
+						Labels: []string{"sent"},
+						Value:  &datum.Int{Value: 642410725},
+					},
+					{
+						Labels: []string{"received"},
+						Value:  &datum.Int{Value: 14998522122},
+					},
+				},
+			},
+		},
+	},
 }
 
 func TestVmEndToEnd(t *testing.T) {

--- a/internal/vm/vm_test.go
+++ b/internal/vm/vm_test.go
@@ -513,8 +513,8 @@ func makeVM(i code.Instr, m []*metrics.Metric) *VM {
 
 }
 
-// code.Instructions with datum store side effects
-func TestDatumSetInstrs(t *testing.T) {
+// makeMetrics returns a few useful metrics for observing under test
+func makeMetrics() []*metrics.Metric {
 	var m []*metrics.Metric
 	m = append(m,
 		metrics.NewMetric("a", "tst", metrics.Counter, metrics.Int),
@@ -522,158 +522,138 @@ func TestDatumSetInstrs(t *testing.T) {
 		metrics.NewMetric("c", "tst", metrics.Gauge, metrics.String),
 		metrics.NewMetric("d", "tst", metrics.Histogram, metrics.Float),
 	)
+	return m
+}
 
-	// simple inc
-	v := makeVM(code.Instr{code.Inc, nil, 0}, m)
-	d, err := m[0].GetDatum()
-	testutil.FatalIfErr(t, err)
-	v.t.Push(d)
-	v.execute(v.t, v.prog[0])
-	if v.terminate {
-		t.Fatalf("Execution failed, see info log.")
-	}
-	d, err = m[0].GetDatum()
-	testutil.FatalIfErr(t, err)
-	if d.ValueString() != "1" {
-		t.Errorf("Unexpected value %v", d)
-	}
-	// inc by int
-	v = makeVM(code.Instr{code.Inc, 0, 0}, m)
-	d, err = m[0].GetDatum()
-	testutil.FatalIfErr(t, err)
-	v.t.Push(d)
-	v.t.Push(2)
-	v.execute(v.t, v.prog[0])
-	if v.terminate {
-		t.Fatalf("Execution failed, see info log.")
-	}
-	d, err = m[0].GetDatum()
-	testutil.FatalIfErr(t, err)
-	if d.ValueString() != "3" {
-		t.Errorf("Unexpected value %v", d)
-	}
-	// inc by str
-	v = makeVM(code.Instr{code.Inc, 0, 0}, m)
-	d, err = m[0].GetDatum()
-	testutil.FatalIfErr(t, err)
-	v.t.Push(d)
-	v.t.Push("1")
-	v.execute(v.t, v.prog[0])
-	if v.terminate {
-		t.Fatalf("Execution failed, see info log.")
-	}
-	d, err = m[0].GetDatum()
-	testutil.FatalIfErr(t, err)
-	if d.ValueString() != "4" {
-		t.Errorf("Unexpected value %v", d)
-	}
-	// iset
-	v = makeVM(code.Instr{code.Iset, nil, 0}, m)
-	d, err = m[0].GetDatum()
-	testutil.FatalIfErr(t, err)
-	v.t.Push(d)
-	v.t.Push(2)
-	v.execute(v.t, v.prog[0])
-	if v.terminate {
-		t.Fatalf("Execution failed, see info log.")
-	}
-	d, err = m[0].GetDatum()
-	testutil.FatalIfErr(t, err)
-	if d.ValueString() != "2" {
-		t.Errorf("Unexpected value %v", d)
-	}
-	// iset str
-	v = makeVM(code.Instr{code.Iset, nil, 0}, m)
-	d, err = m[0].GetDatum()
-	testutil.FatalIfErr(t, err)
-	v.t.Push(d)
-	v.t.Push("3")
-	v.execute(v.t, v.prog[0])
-	if v.terminate {
-		t.Fatalf("Execution failed, see info log.")
-	}
-	d, err = m[0].GetDatum()
-	testutil.FatalIfErr(t, err)
-	if d.ValueString() != "3" {
-		t.Errorf("Unexpected value %v", d)
-	}
-	// fset
-	v = makeVM(code.Instr{code.Fset, nil, 0}, m)
-	d, err = m[1].GetDatum()
-	testutil.FatalIfErr(t, err)
-	v.t.Push(d)
-	v.t.Push(3.1)
-	v.execute(v.t, v.prog[0])
-	if v.terminate {
-		t.Fatalf("Execution failed, see info log.")
-	}
-	d, err = m[1].GetDatum()
-	testutil.FatalIfErr(t, err)
-	if d.ValueString() != "3.1" {
-		t.Errorf("Unexpected value %v", d)
-	}
-	// fset str
-	v = makeVM(code.Instr{code.Fset, nil, 0}, m)
-	d, err = m[1].GetDatum()
-	testutil.FatalIfErr(t, err)
-	v.t.Push(d)
-	v.t.Push("4.1")
-	v.execute(v.t, v.prog[0])
-	if v.terminate {
-		t.Fatalf("Execution failed, see info log.")
-	}
-	d, err = m[1].GetDatum()
-	testutil.FatalIfErr(t, err)
-	if d.ValueString() != "4.1" {
-		t.Errorf("Unexpected value %v", d)
-	}
+type datumStoreTests struct {
+	name     string
+	i        code.Instr
+	d        int // index of a metric in makeMetrics
+	setup    func(t *thread, d datum.Datum)
+	expected string
+}
 
-	// sset
-	v = makeVM(code.Instr{code.Sset, nil, 0}, m)
-	d, err = m[2].GetDatum()
-	testutil.FatalIfErr(t, err)
-	v.t.Push(d)
-	v.t.Push("4.1")
-	v.execute(v.t, v.prog[0])
-	if v.terminate {
-		t.Fatalf("Execution failed, see info log.")
-	}
-	d, err = m[1].GetDatum()
-	testutil.FatalIfErr(t, err)
-	if d.ValueString() != "4.1" {
-		t.Errorf("Unexpected value %v", d)
-	}
+// code.Instructions with datum store side effects
+func TestDatumSetInstrs(t *testing.T) {
 
-	// dec
-	v = makeVM(code.Instr{code.Dec, nil, 0}, m)
-	d, err = m[0].GetDatum()
-	testutil.FatalIfErr(t, err)
-	datum.SetInt(d, 1, time.Now())
-	v.t.Push(d)
-	v.execute(v.t, v.prog[0])
-	if v.terminate {
-		t.Fatalf("Execution failed, see info log.")
+	tests := []datumStoreTests{
+		{
+			name: "simple inc",
+			i:    code.Instr{code.Inc, nil, 0},
+			d:    0,
+			setup: func(t *thread, d datum.Datum) {
+				t.Push(d)
+			},
+			expected: "1",
+		},
+		{
+			name: "inc by int",
+			i:    code.Instr{code.Inc, 0, 0},
+			d:    0,
+			setup: func(t *thread, d datum.Datum) {
+				t.Push(d)
+				t.Push(2)
+			},
+			expected: "2",
+		},
+		{
+			name: "inc by str",
+			i:    code.Instr{code.Inc, 0, 0},
+			d:    0,
+			setup: func(t *thread, d datum.Datum) {
+				t.Push(d)
+				t.Push("4")
+			},
+			expected: "4",
+		},
+		{
+			name: "iset",
+			i:    code.Instr{code.Iset, nil, 0},
+			d:    0,
+			setup: func(t *thread, d datum.Datum) {
+				t.Push(d)
+				t.Push(2)
+			},
+			expected: "2",
+		},
+		{
+			name: "iset str",
+			i:    code.Instr{code.Iset, nil, 0},
+			d:    0,
+			setup: func(t *thread, d datum.Datum) {
+				t.Push(d)
+				t.Push("3")
+			},
+			expected: "3",
+		},
+		{
+			name: "fset",
+			i:    code.Instr{code.Fset, nil, 0},
+			d:    1,
+			setup: func(t *thread, d datum.Datum) {
+				t.Push(d)
+				t.Push(3.1)
+			},
+			expected: "3.1",
+		},
+		{
+			name: "fset str",
+			i:    code.Instr{code.Fset, nil, 0},
+			d:    1,
+			setup: func(t *thread, d datum.Datum) {
+				t.Push(d)
+				t.Push("4.1")
+			},
+			expected: "4.1",
+		},
+		{
+			name: "sset",
+			i:    code.Instr{code.Sset, nil, 0},
+			d:    2,
+			setup: func(t *thread, d datum.Datum) {
+				t.Push(d)
+				t.Push("4.1")
+			},
+			expected: "4.1",
+		},
+		{
+			name: "dec",
+			i:    code.Instr{code.Dec, nil, 0},
+			d:    0,
+			setup: func(t *thread, d datum.Datum) {
+				datum.SetInt(d, 1, time.Now())
+				t.Push(d)
+			},
+			expected: "0",
+		},
+		{
+			name: "set hist",
+			i:    code.Instr{code.Fset, nil, 0},
+			d:    3,
+			setup: func(t *thread, d datum.Datum) {
+				t.Push(d)
+				t.Push(3.1)
+			},
+			expected: "3.1",
+		},
 	}
-	d, err = m[0].GetDatum()
-	testutil.FatalIfErr(t, err)
-	if d.ValueString() != "0" {
-		t.Errorf("Unexpected value %v", d)
-	}
-
-	// set hist
-	v = makeVM(code.Instr{code.Fset, nil, 0}, m)
-	d, err = m[3].GetDatum()
-	testutil.FatalIfErr(t, err)
-	v.t.Push(d)
-	v.t.Push(3.1)
-	v.execute(v.t, v.prog[0])
-	if v.terminate {
-		t.Fatalf("Execution failed, see info log.")
-	}
-	d, err = m[3].GetDatum()
-	testutil.FatalIfErr(t, err)
-	if d.ValueString() != "3.1" {
-		t.Errorf("Unexpected value %v", d)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := makeMetrics()
+			v := makeVM(test.i, m)
+			d, err := m[test.d].GetDatum()
+			testutil.FatalIfErr(t, err)
+			test.setup(v.t, d)
+			v.execute(v.t, v.prog[0])
+			if v.terminate {
+				t.Fatalf("Execution failed, see INFO log.")
+			}
+			d, err = m[test.d].GetDatum()
+			testutil.FatalIfErr(t, err)
+			if d.ValueString() != test.expected {
+				t.Errorf("unexpected value for datum %#v, want: %s, got %s", d, test.expected, d.ValueString())
+			}
+		})
 	}
 }
 

--- a/internal/vm/vm_test.go
+++ b/internal/vm/vm_test.go
@@ -456,6 +456,13 @@ var instructions = []struct {
 		[]interface{}{"abc", "def"},
 		[]interface{}{false},
 		thread{pc: 0, matches: map[int][]string{}}},
+	{"subst",
+		code.Instr{code.Subst, 0, 0},
+		[]*regexp.Regexp{},
+		[]string{},
+		[]interface{}{"aa" /*old*/, "a" /*new*/, "caat"},
+		[]interface{}{"cat"},
+		thread{pc: 0, matches: map[int][]string{}}},
 }
 
 const testFilename = "test"


### PR DESCRIPTION
With the new `subst` function we can remove and convert bits from a capture group that we don't want, like stray commas and underscores.

Documented in the Programming Guide on the two patterns that showed up in the bug reports.

Fixes #254, fixes #326, fixes #424