### PR TITLE
Simplify pipestream by correctly interrupting a read on context cancellation.

### DIFF
--- a/internal/mtail/read_pipe_integration_test.go
+++ b/internal/mtail/read_pipe_integration_test.go
@@ -28,6 +28,7 @@ func TestReadFromPipe(t *testing.T) {
 
 	testutil.FatalIfErr(t, unix.Mkfifo(logFile, 0600))
 
+	// TODO: race if this openfile happens after teststartserver.
 	f, err := os.OpenFile(logFile, os.O_RDWR|syscall.O_NONBLOCK, 0600)
 	testutil.FatalIfErr(t, err)
 	defer func() {
@@ -40,7 +41,7 @@ func TestReadFromPipe(t *testing.T) {
 	lineCountCheck := m.ExpectExpvarDeltaWithDeadline("lines_total", 3)
 
 	testutil.WriteString(t, f, "1\n2\n3\n")
-	m.PollWatched(1)
+	m.PollWatched(0)
 
 	lineCountCheck()
 }

--- a/internal/tailer/logstream/cancel.go
+++ b/internal/tailer/logstream/cancel.go
@@ -1,0 +1,37 @@
+package logstream
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+type ReadDeadliner interface {
+	SetReadDeadline(t time.Time) error
+}
+
+func SetReadDeadlineOnDone(ctx context.Context, d ReadDeadliner) {
+	go func() {
+		<-ctx.Done()
+		glog.Info("cancelled, setting read deadline to interrupt read")
+		d.SetReadDeadline(time.Now())
+	}()
+}
+
+func IsEndOrCancel(err error) bool {
+	if err == io.EOF {
+		return true
+	}
+	if os.IsTimeout(err) {
+		return true
+	}
+	// https://github.com/golang/go/issues/4373
+	if strings.Contains(err.Error(), "use of closed network connection") {
+		return true
+	}
+	return false
+}

--- a/internal/tailer/logstream/pipestream_test.go
+++ b/internal/tailer/logstream/pipestream_test.go
@@ -29,11 +29,10 @@ func TestPipeStreamReadCompletedBecauseClosed(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	waker := waker.NewTestAlways()
 
-	// TODO(#486): Open the file WRONLY after the logstream starts.
-	f, err := os.OpenFile(name, os.O_RDWR, os.ModeNamedPipe)
+	ps, err := logstream.New(ctx, &wg, waker, name, lines, false)
 	testutil.FatalIfErr(t, err)
 
-	ps, err := logstream.New(ctx, &wg, waker, name, lines, false)
+	f, err := os.OpenFile(name, os.O_WRONLY, os.ModeNamedPipe)
 	testutil.FatalIfErr(t, err)
 
 	testutil.WriteString(t, f, "1\n")
@@ -70,11 +69,10 @@ func TestPipeStreamReadCompletedBecauseCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	waker := waker.NewTestAlways()
 
-	// TODO(#486): Open the file WRONLY after the logstream starts.
-	f, err := os.OpenFile(name, os.O_RDWR, os.ModeNamedPipe)
+	ps, err := logstream.New(ctx, &wg, waker, name, lines, false)
 	testutil.FatalIfErr(t, err)
 
-	ps, err := logstream.New(ctx, &wg, waker, name, lines, false)
+	f, err := os.OpenFile(name, os.O_WRONLY, os.ModeNamedPipe)
 	testutil.FatalIfErr(t, err)
 
 	testutil.WriteString(t, f, "1\n")


### PR DESCRIPTION

https://github.com/golang/go/issues/20280#issuecomment-655588450 has an
excellent example on how to interrupt a read on context cancellation, which
means we don't need to set a read deadline on every read attempt.  Then, the
error handling is simplified, and as a side effect we aren't having spurious
wakeups on idle fifos.

This also means we no longer have a race on first read when the write end of a
fifo isn't ready.

Issue: #486