### PR TITLE
Fix positions for builtins and other long expressions.

### DIFF
--- a/internal/runtime/compiler/checker/checker.go
+++ b/internal/runtime/compiler/checker/checker.go
@@ -724,13 +724,13 @@ func (c *checker) VisitAfter(node ast.Node) ast.Node {
 	case *ast.DelStmt:
 		if ix, ok := n.N.(*ast.IndexedExpr); ok {
 			if len(ix.Index.(*ast.ExprList).Children) == 0 {
-				c.errors.Add(n.Pos(), fmt.Sprintf("Cannot delete this.\n\tTry deleting an index from this dimensioned metric."))
+				c.errors.Add(n.N.Pos(), fmt.Sprintf("Cannot delete this.\n\tTry deleting an index from this dimensioned metric."))
 				return n
 			}
 			ix.Lhs.(*ast.IdTerm).Lvalue = true
 			return n
 		}
-		c.errors.Add(n.Pos(), fmt.Sprintf("Cannot delete this.\n\tTry deleting from a dimensioned metric with this as an index."))
+		c.errors.Add(n.N.Pos(), fmt.Sprintf("Cannot delete this.\n\tTry deleting from a dimensioned metric with this as an index."))
 	}
 
 	return node

--- a/internal/runtime/compiler/checker/checker_test.go
+++ b/internal/runtime/compiler/checker/checker_test.go
@@ -106,7 +106,7 @@ counter bar by a, b
 	  timestamp()
 	}
 	`,
-		[]string{"builtin parameter mismatch:2:13: call to `strptime': type mismatch; expected String→String→None received incomplete type"}},
+		[]string{"builtin parameter mismatch:2:4-13: call to `strptime': type mismatch; expected String→String→None received incomplete type"}},
 
 	{"bad strptime format",
 		`strptime("2017-10-16 06:50:25", "2017-10-16 06:50:25")
@@ -191,7 +191,7 @@ next
 		`/(.*)/ {
 del $0
 }`,
-		[]string{"delete incorrect object:3:7: Cannot delete this.", "\tTry deleting from a dimensioned metric with this as an index."}},
+		[]string{"delete incorrect object:2:5-6: Cannot delete this.", "\tTry deleting from a dimensioned metric with this as an index."}},
 
 	{"pattern fragment plus anything",
 		`gauge e
@@ -208,7 +208,7 @@ del $0
 		`histogram#
 m del#
 m`,
-		[]string{"delete a histogram:3:2: Cannot delete this.", "\tTry deleting an index from this dimensioned metric."}},
+		[]string{"delete a histogram:3:7: Cannot delete this.", "\tTry deleting an index from this dimensioned metric."}},
 
 	{"int as bool",
 		`1 {}`,
@@ -244,7 +244,7 @@ l++=l
 
 	{"dec non var",
 		`strptime("", "")--
-`, []string{"dec non var:1:16: Expecting a variable here."}},
+`, []string{"dec non var:1:1-16: Expecting a variable here."}},
 
 	// TODO(jaq): This is an instance of bug #190, the capref is ambiguous.
 	// 	{"regexp with no zero capref",
@@ -253,7 +253,7 @@ l++=l
 
 	{"cmp to None",
 		`strptime("","")<5{}
-`, []string{"cmp to None:1:15-17: Can't compare LHS of type None with RHS of type Int."}},
+`, []string{"cmp to None:1:1-17: Can't compare LHS of type None with RHS of type Int."}},
 }
 
 func TestCheckInvalidPrograms(t *testing.T) {

--- a/internal/runtime/compiler/codegen/codegen_test.go
+++ b/internal/runtime/compiler/codegen/codegen_test.go
@@ -358,13 +358,13 @@ otherwise {
 }
 `,
 		[]code.Instr{
-			{code.Otherwise, nil, 4},
-			{code.Jnm, 7, 4},
-			{code.Setmatched, false, 4},
+			{code.Otherwise, nil, 2},
+			{code.Jnm, 7, 2},
+			{code.Setmatched, false, 2},
 			{code.Mload, 0, 3},
 			{code.Dload, 0, 3},
 			{code.Inc, nil, 3},
-			{code.Setmatched, true, 4}}},
+			{code.Setmatched, true, 2}}},
 	{"cond else",
 		`counter foo
 counter bar

--- a/internal/runtime/compiler/parser/parser.go
+++ b/internal/runtime/compiler/parser/parser.go
@@ -168,7 +168,7 @@ const mtailEofCode = 1
 const mtailErrCode = 2
 const mtailInitialStackSize = 16
 
-//line parser.y:716
+//line parser.y:713
 
 //  tokenpos returns the position of the current token.
 func tokenpos(mtaillex mtailLexer) position.Position {
@@ -181,6 +181,13 @@ func markedpos(mtaillex mtailLexer) position.Position {
 	return mtaillex.(*parser).pos
 }
 
+// positionFromMark returns a position spanning from the last mark to the current position.
+func positionFromMark(mtaillex mtailLexer) position.Position {
+	tp := tokenpos(mtaillex)
+	mp := markedpos(mtaillex)
+	return *position.Merge(&mp, &tp)
+}
+
 //line yacctab:1
 var mtailExca = [...]int{
 	-1, 1,
@@ -188,79 +195,85 @@ var mtailExca = [...]int{
 	-2, 0,
 	-1, 2,
 	1, 1,
-	15, 121,
-	28, 121,
-	34, 121,
-	-2, 93,
-	-1, 24,
+	5, 93,
+	6, 93,
+	7, 93,
+	8, 93,
+	9, 93,
+	-2, 121,
+	-1, 22,
 	65, 24,
 	-2, 68,
-	-1, 108,
-	15, 121,
-	28, 121,
-	34, 121,
-	-2, 93,
+	-1, 106,
+	5, 93,
+	6, 93,
+	7, 93,
+	8, 93,
+	9, 93,
+	-2, 121,
 }
 
 const mtailPrivate = 57344
 
-const mtailLast = 239
+const mtailLast = 242
 
 var mtailAct = [...]int{
-	165, 127, 30, 92, 45, 47, 29, 128, 129, 42,
-	22, 21, 28, 117, 49, 161, 126, 118, 159, 175,
-	43, 32, 27, 63, 31, 158, 159, 96, 52, 174,
-	51, 90, 48, 50, 71, 89, 63, 88, 24, 106,
-	26, 13, 19, 65, 66, 79, 80, 91, 77, 76,
-	11, 25, 130, 20, 10, 15, 62, 12, 172, 44,
-	59, 38, 36, 37, 46, 46, 40, 41, 65, 66,
-	44, 146, 38, 36, 37, 46, 115, 40, 41, 94,
-	95, 119, 73, 75, 74, 120, 121, 114, 33, 105,
-	122, 123, 124, 99, 98, 125, 137, 39, 144, 33,
-	69, 70, 16, 178, 177, 168, 2, 131, 39, 132,
-	107, 134, 29, 133, 135, 113, 22, 21, 102, 103,
-	101, 1, 136, 104, 63, 147, 169, 156, 63, 145,
-	153, 154, 149, 155, 63, 157, 160, 63, 63, 163,
-	162, 151, 148, 152, 24, 150, 13, 140, 19, 82,
-	83, 84, 85, 86, 87, 11, 25, 108, 20, 10,
-	15, 173, 12, 68, 44, 78, 38, 36, 37, 46,
-	100, 40, 41, 116, 44, 176, 38, 36, 37, 46,
-	97, 40, 41, 44, 72, 38, 36, 37, 46, 93,
-	40, 41, 60, 33, 67, 69, 70, 171, 170, 81,
-	18, 164, 39, 33, 138, 61, 167, 16, 139, 166,
-	112, 59, 39, 111, 142, 141, 64, 53, 35, 110,
-	9, 39, 8, 7, 143, 54, 55, 56, 57, 58,
-	109, 6, 34, 23, 17, 5, 14, 4, 3,
+	168, 88, 127, 28, 15, 91, 42, 44, 27, 129,
+	26, 41, 19, 30, 118, 126, 86, 40, 164, 22,
+	54, 160, 177, 45, 128, 29, 176, 20, 89, 25,
+	159, 160, 62, 63, 108, 87, 47, 85, 68, 46,
+	165, 131, 76, 77, 74, 73, 2, 104, 50, 36,
+	34, 35, 43, 166, 38, 39, 43, 87, 13, 62,
+	63, 24, 90, 70, 72, 71, 170, 11, 23, 169,
+	112, 10, 93, 94, 12, 49, 31, 110, 36, 34,
+	35, 43, 139, 38, 39, 37, 137, 50, 107, 171,
+	117, 130, 111, 49, 106, 97, 96, 36, 34, 35,
+	43, 116, 38, 39, 115, 31, 105, 103, 15, 109,
+	130, 1, 27, 136, 37, 172, 19, 66, 67, 16,
+	180, 179, 104, 22, 138, 87, 130, 144, 157, 87,
+	150, 20, 152, 37, 156, 153, 87, 87, 87, 161,
+	163, 162, 148, 158, 65, 135, 151, 154, 155, 149,
+	140, 100, 101, 99, 75, 119, 102, 174, 173, 120,
+	121, 98, 130, 175, 122, 123, 124, 95, 64, 125,
+	69, 13, 92, 36, 34, 35, 43, 178, 38, 39,
+	11, 23, 78, 132, 10, 18, 133, 12, 61, 134,
+	141, 36, 34, 35, 43, 167, 38, 39, 142, 143,
+	31, 79, 80, 81, 82, 83, 84, 51, 53, 37,
+	48, 55, 66, 67, 49, 146, 145, 33, 31, 114,
+	52, 9, 8, 7, 113, 147, 50, 37, 6, 32,
+	21, 17, 16, 56, 57, 58, 59, 60, 5, 14,
+	4, 3,
 }
 
 var mtailPact = [...]int{
-	-1000, -1000, 142, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	-1000, 38, -1000, -1000, -25, -25, -1000, -37, 220, 177,
-	161, 16, 16, -1000, 68, -1000, -4, 34, -1000, -6,
-	-11, -1000, 107, 152, -31, -1000, -1000, -1000, -1000, 152,
-	-1000, -1000, 39, -1000, -33, 56, -1000, 84, -1000, 91,
-	-1000, -1000, -1000, 186, -1000, -1000, -1000, -1000, -1000, -1000,
-	60, -25, 163, -1000, -48, -1000, -1000, -48, -1000, -1000,
-	-1000, -48, -48, -1000, -1000, -1000, -48, -48, -48, -1000,
-	-1000, -48, -1000, -1000, -1000, -1000, -1000, -1000, -1000, 68,
-	152, -9, -1000, -48, -1000, -1000, 48, -48, -1000, -1000,
-	-48, -1000, -1000, -1000, -1000, -4, 26, -25, 37, 203,
-	-1000, -1000, -1000, 75, -25, -1000, 40, 152, -1000, 152,
-	38, 152, 152, 152, 161, 152, -38, -1000, 16, -1000,
-	-1000, 152, -1000, -46, 152, 152, -1000, -1000, -1000, -1000,
-	-1000, 182, 81, 168, 24, -1000, -1000, 16, 34, -1000,
-	-1000, -1000, 107, 16, 16, -1000, -1000, 39, -1000, 152,
-	56, -1000, 84, -1000, -35, -1000, -1000, -1000, -1000, -45,
-	-1000, -1000, -1000, -1000, 182, 74, -1000, -1000, -1000,
+	-1000, -1000, 167, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
+	-1000, 29, -1000, -1000, -22, 192, -1000, -45, 228, 7,
+	7, -1000, 85, -1000, 0, 15, -1000, -10, -14, -1000,
+	159, 149, -34, -1000, -1000, -1000, -1000, 149, -1000, -1000,
+	32, -1000, 58, -1000, 117, -1000, 87, -1000, -22, -26,
+	-1000, 50, -22, 73, -1000, 77, -1000, -1000, -1000, -1000,
+	-1000, -51, -1000, -1000, -51, -1000, -1000, -1000, -51, -51,
+	-1000, -1000, -1000, -51, -51, -51, -1000, -1000, -51, -1000,
+	-1000, -1000, -1000, -1000, -1000, -1000, 85, -1000, 71, 149,
+	-20, -1000, -51, -1000, -1000, -51, -1000, -1000, -51, -1000,
+	-1000, -1000, -1000, 0, 14, -22, 54, -1000, 25, 59,
+	-22, -1000, 180, 204, -1000, -1000, -1000, 149, -1000, 149,
+	29, 149, 149, 149, 73, 149, -33, -1000, 7, -1000,
+	53, -1000, 149, 149, 149, -1000, -1000, -1000, -43, 6,
+	-1000, 22, -1000, -1000, -1000, 42, 65, 128, 7, 15,
+	-1000, -1000, -1000, 159, 7, 7, -1000, -1000, 32, -1000,
+	149, 58, 117, -1000, -1000, -1000, -1000, -38, -1000, -1000,
+	-1000, -1000, -42, -1000, -1000, -1000, 42, 91, -1000, -1000,
+	-1000,
 }
 
 var mtailPgo = [...]int{
-	0, 106, 238, 16, 14, 237, 236, 235, 234, 2,
-	5, 4, 35, 3, 233, 21, 9, 22, 7, 232,
-	20, 40, 8, 231, 230, 223, 222, 24, 12, 220,
-	219, 218, 1, 217, 208, 0, 204, 201, 200, 199,
-	189, 184, 194, 180, 170, 165, 163, 147, 126, 121,
-	13, 39, 115,
+	0, 46, 241, 15, 39, 240, 239, 238, 231, 3,
+	7, 6, 16, 5, 230, 13, 17, 29, 24, 229,
+	11, 61, 9, 228, 224, 223, 222, 25, 10, 221,
+	219, 217, 2, 211, 199, 0, 198, 195, 185, 182,
+	172, 170, 168, 167, 161, 154, 144, 127, 115, 111,
+	1, 90, 109,
 }
 
 var mtailR1 = [...]int{
@@ -276,65 +289,67 @@ var mtailR1 = [...]int{
 	32, 27, 23, 38, 38, 24, 24, 24, 24, 30,
 	30, 33, 33, 33, 33, 33, 36, 37, 37, 34,
 	47, 48, 48, 48, 48, 25, 26, 29, 29, 35,
-	35, 51, 52, 50, 50,
+	35, 50, 52, 51, 51,
 }
 
 var mtailR2 = [...]int{
 	0, 1, 0, 2, 1, 1, 1, 1, 1, 1,
-	1, 3, 1, 1, 4, 2, 2, 1, 4, 1,
+	1, 3, 1, 1, 4, 2, 3, 1, 4, 1,
 	1, 2, 3, 1, 1, 4, 4, 1, 1, 4,
 	4, 1, 1, 1, 4, 1, 1, 1, 1, 4,
 	1, 1, 1, 1, 1, 1, 1, 4, 1, 1,
 	1, 4, 1, 1, 4, 4, 1, 1, 1, 1,
 	4, 4, 1, 4, 1, 1, 1, 1, 1, 2,
 	1, 2, 1, 1, 1, 1, 1, 1, 1, 3,
-	1, 1, 1, 4, 1, 3, 4, 1, 3, 1,
+	1, 1, 1, 4, 1, 4, 5, 1, 3, 1,
 	1, 5, 3, 0, 1, 2, 2, 2, 1, 1,
 	1, 1, 1, 1, 1, 1, 2, 1, 3, 2,
-	2, 1, 1, 3, 3, 4, 3, 4, 2, 1,
+	2, 1, 1, 3, 3, 4, 3, 5, 3, 1,
 	1, 0, 0, 0, 1,
 }
 
 var mtailChk = [...]int{
 	-1000, -49, -1, -2, -5, -7, -23, -25, -26, -29,
-	17, 13, 20, 4, -6, 18, 65, -8, -38, -51,
-	16, -22, -18, -14, -12, 14, -21, -17, -28, -13,
-	-9, -27, -15, 51, -19, -31, 25, 26, 24, 60,
-	29, 30, -16, -20, 22, -11, 27, -10, -20, -4,
-	58, -4, 65, -33, 5, 6, 7, 8, 9, 34,
-	15, 28, -12, -9, -42, 52, 53, -42, -46, 32,
-	33, 38, -41, 48, 50, 49, 55, 54, -45, 56,
-	57, -39, 42, 43, 44, 45, 46, 47, -13, -12,
-	62, -18, -13, -40, 40, 41, 60, -43, 38, 37,
-	-44, 36, 34, 35, 39, -21, -51, 19, -1, -24,
-	-30, 27, 24, -52, 27, -4, 10, -50, 65, -50,
-	-50, -50, -50, -50, -50, -50, -3, -32, -18, -22,
-	61, -50, 61, -3, -50, -50, -4, 59, -36, -34,
-	-47, 12, 11, 21, 23, -4, 31, -18, -17, -28,
-	-27, -20, -15, -18, -18, -22, -9, -16, 63, 64,
-	-11, 61, -10, -13, -37, -35, 27, 24, 24, -48,
-	30, 29, 34, -32, 64, 64, -35, 30, 29,
+	17, 13, 20, 4, -6, -50, 65, -8, -38, -22,
+	-18, -14, -12, 14, -21, -17, -28, -13, -9, -27,
+	-15, 51, -19, -31, 25, 26, 24, 60, 29, 30,
+	-16, -20, -11, 27, -10, -20, -4, 58, 18, 22,
+	34, 15, 28, 16, 65, -33, 5, 6, 7, 8,
+	9, -42, 52, 53, -42, -46, 32, 33, 38, -41,
+	48, 50, 49, 55, 54, -45, 56, 57, -39, 42,
+	43, 44, 45, 46, 47, -13, -12, -9, -50, 62,
+	-18, -13, -40, 40, 41, -43, 38, 37, -44, 36,
+	34, 35, 39, -21, -50, 19, -1, -4, 60, -52,
+	27, -4, -12, -24, -30, 27, 24, -51, 65, -51,
+	-51, -51, -51, -51, -51, -51, -3, -32, -18, -22,
+	-50, 61, -51, -51, -51, -4, 59, 61, -3, 23,
+	-4, 10, -36, -34, -47, 12, 11, 21, -18, -17,
+	-28, -27, -20, -15, -18, -18, -22, -9, -16, 63,
+	64, -11, -10, -13, 61, 34, 31, -37, -35, 27,
+	24, 24, -48, 30, 29, -32, 64, 64, -35, 30,
+	29,
 }
 
 var mtailDef = [...]int{
 	2, -2, -2, 3, 4, 5, 6, 7, 8, 9,
-	10, 0, 12, 13, 0, 0, 20, 0, 0, 0,
-	0, 17, 19, 23, -2, 94, 58, 27, 28, 62,
-	70, 59, 33, 0, 74, 75, 76, 77, 78, 0,
-	80, 81, 38, 82, 0, 46, 84, 50, 121, 15,
-	2, 16, 21, 0, 101, 102, 103, 104, 105, 122,
-	0, 0, 118, 70, 123, 31, 32, 123, 71, 72,
-	73, 123, 123, 35, 36, 37, 123, 123, 123, 56,
-	57, 123, 40, 41, 42, 43, 44, 45, 69, 68,
-	121, 0, 62, 123, 48, 49, 121, 123, 52, 53,
-	123, 64, 65, 66, 67, 11, 0, 0, -2, 92,
-	98, 99, 100, 0, 0, 116, 0, 0, 124, 0,
-	121, 0, 0, 0, 121, 0, 0, 87, 89, 90,
-	79, 0, 85, 0, 0, 0, 14, 22, 95, 96,
-	97, 0, 0, 0, 0, 115, 117, 18, 29, 30,
-	60, 61, 34, 25, 26, 54, 55, 39, 83, 121,
-	47, 86, 51, 63, 106, 107, 119, 120, 109, 110,
-	111, 112, 91, 88, 0, 0, 108, 113, 114,
+	10, 0, 12, 13, 0, 0, 20, 0, 0, 17,
+	19, 23, -2, 94, 58, 27, 28, 62, 70, 59,
+	33, 121, 74, 75, 76, 77, 78, 121, 80, 81,
+	38, 82, 46, 84, 50, 121, 15, 2, 0, 0,
+	122, 0, 0, 121, 21, 0, 101, 102, 103, 104,
+	105, 123, 31, 32, 123, 71, 72, 73, 123, 123,
+	35, 36, 37, 123, 123, 123, 56, 57, 123, 40,
+	41, 42, 43, 44, 45, 69, 68, 70, 0, 121,
+	0, 62, 123, 48, 49, 123, 52, 53, 123, 64,
+	65, 66, 67, 11, 0, 0, -2, 16, 121, 0,
+	0, 116, 118, 92, 98, 99, 100, 121, 124, 121,
+	121, 121, 121, 121, 121, 121, 0, 87, 89, 90,
+	0, 79, 121, 121, 121, 14, 22, 85, 0, 0,
+	115, 0, 95, 96, 97, 0, 0, 0, 18, 29,
+	30, 60, 61, 34, 25, 26, 54, 55, 39, 83,
+	121, 47, 51, 63, 86, 91, 117, 106, 107, 119,
+	120, 109, 110, 111, 112, 88, 0, 0, 108, 113,
+	114,
 }
 
 var mtailTok1 = [...]int{
@@ -360,10 +375,10 @@ var mtailErrorMessages = [...]struct {
 	token int
 	msg   string
 }{
-	{113, 4, "unexpected end of file, expecting '/' to end regex"},
-	{18, 1, "unexpected end of file, expecting '}' to end block"},
-	{18, 1, "unexpected end of file, expecting '}' to end block"},
-	{18, 1, "unexpected end of file, expecting '}' to end block"},
+	{109, 4, "unexpected end of file, expecting '/' to end regex"},
+	{15, 1, "unexpected end of file, expecting '}' to end block"},
+	{15, 1, "unexpected end of file, expecting '}' to end block"},
+	{15, 1, "unexpected end of file, expecting '}' to end block"},
 	{14, 62, "unexpected indexing of an expression"},
 	{14, 65, "statement with no effect, missing an assignment, `+' concatenation, or `{}' block?"},
 }
@@ -797,11 +812,11 @@ mtaildefault:
 			}
 		}
 	case 16:
-		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
+		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
 //line parser.y:158
 		{
-			o := &ast.OtherwiseStmt{tokenpos(mtaillex)}
-			mtailVAL.n = &ast.CondStmt{o, mtailDollar[2].n, nil, nil}
+			o := &ast.OtherwiseStmt{positionFromMark(mtaillex)}
+			mtailVAL.n = &ast.CondStmt{o, mtailDollar[3].n, nil, nil}
 		}
 	case 17:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
@@ -1219,16 +1234,16 @@ mtaildefault:
 			mtailVAL.n = &ast.IdTerm{tokenpos(mtaillex), mtailDollar[1].text, nil, false}
 		}
 	case 85:
-		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
+		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
 //line parser.y:466
 		{
-			mtailVAL.n = &ast.BuiltinExpr{P: tokenpos(mtaillex), Name: mtailDollar[1].text, Args: nil}
+			mtailVAL.n = &ast.BuiltinExpr{P: positionFromMark(mtaillex), Name: mtailDollar[2].text, Args: nil}
 		}
 	case 86:
-		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
+		mtailDollar = mtailS[mtailpt-5 : mtailpt+1]
 //line parser.y:470
 		{
-			mtailVAL.n = &ast.BuiltinExpr{P: tokenpos(mtaillex), Name: mtailDollar[1].text, Args: mtailDollar[3].n}
+			mtailVAL.n = &ast.BuiltinExpr{P: positionFromMark(mtaillex), Name: mtailDollar[2].text, Args: mtailDollar[4].n}
 		}
 	case 87:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
@@ -1260,14 +1275,11 @@ mtaildefault:
 		mtailDollar = mtailS[mtailpt-5 : mtailpt+1]
 //line parser.y:500
 		{
-			mp := markedpos(mtaillex)
-			tp := tokenpos(mtaillex)
-			pos := position.Merge(&mp, &tp)
-			mtailVAL.n = &ast.PatternLit{P: *pos, Pattern: mtailDollar[4].text}
+			mtailVAL.n = &ast.PatternLit{P: positionFromMark(mtaillex), Pattern: mtailDollar[4].text}
 		}
 	case 92:
 		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
-//line parser.y:511
+//line parser.y:508
 		{
 			mtailVAL.n = mtailDollar[3].n
 			d := mtailVAL.n.(*ast.VarDecl)
@@ -1276,191 +1288,191 @@ mtaildefault:
 		}
 	case 93:
 		mtailDollar = mtailS[mtailpt-0 : mtailpt+1]
-//line parser.y:522
+//line parser.y:519
 		{
 			mtailVAL.flag = false
 		}
 	case 94:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:526
+//line parser.y:523
 		{
 			mtailVAL.flag = true
 		}
 	case 95:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:534
+//line parser.y:531
 		{
 			mtailVAL.n = mtailDollar[1].n
 			mtailVAL.n.(*ast.VarDecl).Keys = mtailDollar[2].texts
 		}
 	case 96:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:539
+//line parser.y:536
 		{
 			mtailVAL.n = mtailDollar[1].n
 			mtailVAL.n.(*ast.VarDecl).ExportedName = mtailDollar[2].text
 		}
 	case 97:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:544
+//line parser.y:541
 		{
 			mtailVAL.n = mtailDollar[1].n
 			mtailVAL.n.(*ast.VarDecl).Buckets = mtailDollar[2].floats
 		}
 	case 98:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:549
+//line parser.y:546
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 99:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:557
+//line parser.y:554
 		{
 			mtailVAL.n = &ast.VarDecl{P: tokenpos(mtaillex), Name: mtailDollar[1].text}
 		}
 	case 100:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:561
+//line parser.y:558
 		{
 			mtailVAL.n = &ast.VarDecl{P: tokenpos(mtaillex), Name: mtailDollar[1].text}
 		}
 	case 101:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:569
+//line parser.y:566
 		{
 			mtailVAL.kind = metrics.Counter
 		}
 	case 102:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:573
+//line parser.y:570
 		{
 			mtailVAL.kind = metrics.Gauge
 		}
 	case 103:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:577
+//line parser.y:574
 		{
 			mtailVAL.kind = metrics.Timer
 		}
 	case 104:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:581
+//line parser.y:578
 		{
 			mtailVAL.kind = metrics.Text
 		}
 	case 105:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:585
+//line parser.y:582
 		{
 			mtailVAL.kind = metrics.Histogram
 		}
 	case 106:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:593
+//line parser.y:590
 		{
 			mtailVAL.texts = mtailDollar[2].texts
 		}
 	case 107:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:600
+//line parser.y:597
 		{
 			mtailVAL.texts = make([]string, 0)
 			mtailVAL.texts = append(mtailVAL.texts, mtailDollar[1].text)
 		}
 	case 108:
 		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
-//line parser.y:605
+//line parser.y:602
 		{
 			mtailVAL.texts = mtailDollar[1].texts
 			mtailVAL.texts = append(mtailVAL.texts, mtailDollar[3].text)
 		}
 	case 109:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:614
+//line parser.y:611
 		{
 			mtailVAL.text = mtailDollar[2].text
 		}
 	case 110:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:622
+//line parser.y:619
 		{
 			mtailVAL.floats = mtailDollar[2].floats
 		}
 	case 111:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:628
+//line parser.y:625
 		{
 			mtailVAL.floats = make([]float64, 0)
 			mtailVAL.floats = append(mtailVAL.floats, mtailDollar[1].floatVal)
 		}
 	case 112:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:633
+//line parser.y:630
 		{
 			mtailVAL.floats = make([]float64, 0)
 			mtailVAL.floats = append(mtailVAL.floats, float64(mtailDollar[1].intVal))
 		}
 	case 113:
 		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
-//line parser.y:638
+//line parser.y:635
 		{
 			mtailVAL.floats = mtailDollar[1].floats
 			mtailVAL.floats = append(mtailVAL.floats, mtailDollar[3].floatVal)
 		}
 	case 114:
 		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
-//line parser.y:643
+//line parser.y:640
 		{
 			mtailVAL.floats = mtailDollar[1].floats
 			mtailVAL.floats = append(mtailVAL.floats, float64(mtailDollar[3].intVal))
 		}
 	case 115:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:651
+//line parser.y:648
 		{
 			mtailVAL.n = &ast.DecoDecl{P: markedpos(mtaillex), Name: mtailDollar[3].text, Block: mtailDollar[4].n}
 		}
 	case 116:
 		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
-//line parser.y:659
+//line parser.y:656
 		{
 			mtailVAL.n = &ast.DecoStmt{markedpos(mtaillex), mtailDollar[2].text, mtailDollar[3].n, nil, nil}
 		}
 	case 117:
-		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:667
+		mtailDollar = mtailS[mtailpt-5 : mtailpt+1]
+//line parser.y:664
 		{
-			mtailVAL.n = &ast.DelStmt{P: tokenpos(mtaillex), N: mtailDollar[2].n, Expiry: mtailDollar[4].duration}
+			mtailVAL.n = &ast.DelStmt{P: positionFromMark(mtaillex), N: mtailDollar[3].n, Expiry: mtailDollar[5].duration}
 		}
 	case 118:
-		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:671
+		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
+//line parser.y:668
 		{
-			mtailVAL.n = &ast.DelStmt{P: tokenpos(mtaillex), N: mtailDollar[2].n}
+			mtailVAL.n = &ast.DelStmt{P: positionFromMark(mtaillex), N: mtailDollar[3].n}
 		}
 	case 119:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:678
+//line parser.y:675
 		{
 			mtailVAL.text = mtailDollar[1].text
 		}
 	case 120:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:682
+//line parser.y:679
 		{
 			mtailVAL.text = mtailDollar[1].text
 		}
 	case 121:
 		mtailDollar = mtailS[mtailpt-0 : mtailpt+1]
-//line parser.y:692
+//line parser.y:689
 		{
 			glog.V(2).Infof("position marked at %v", tokenpos(mtaillex))
 			mtaillex.(*parser).pos = tokenpos(mtaillex)
 		}
 	case 122:
 		mtailDollar = mtailS[mtailpt-0 : mtailpt+1]
-//line parser.y:702
+//line parser.y:699
 		{
 			mtaillex.(*parser).inRegex()
 		}

--- a/internal/runtime/compiler/parser/parser.y
+++ b/internal/runtime/compiler/parser/parser.y
@@ -154,10 +154,10 @@ conditional_stmt
       $$ = $2
     }
   }
-  | OTHERWISE compound_stmt
+  | mark_pos OTHERWISE compound_stmt
   {
-    o := &ast.OtherwiseStmt{tokenpos(mtaillex)}
-    $$ = &ast.CondStmt{o, $2, nil, nil}
+    o := &ast.OtherwiseStmt{positionFromMark(mtaillex)}
+    $$ = &ast.CondStmt{o, $3, nil, nil}
   }
   ;
 
@@ -462,13 +462,13 @@ id_expr
 
 /* Builtin expression describes the builtin function calls. */
 builtin_expr
-  : BUILTIN LPAREN RPAREN
+  : mark_pos BUILTIN LPAREN RPAREN
   {
-    $$ = &ast.BuiltinExpr{P: tokenpos(mtaillex), Name: $1, Args: nil}
+    $$ = &ast.BuiltinExpr{P: positionFromMark(mtaillex), Name: $2, Args: nil}
   }
-  | BUILTIN LPAREN arg_expr_list RPAREN
+  | mark_pos BUILTIN LPAREN arg_expr_list RPAREN
   {
-    $$ = &ast.BuiltinExpr{P: tokenpos(mtaillex), Name: $1, Args: $3}
+    $$ = &ast.BuiltinExpr{P: positionFromMark(mtaillex), Name: $2, Args: $4}
   }
   ;
 
@@ -498,10 +498,7 @@ arg_expr
 regex_pattern
   : mark_pos DIV in_regex REGEX DIV
   {
-    mp := markedpos(mtaillex)
-    tp := tokenpos(mtaillex)
-    pos := position.Merge(&mp, &tp)
-    $$ = &ast.PatternLit{P: *pos, Pattern: $4}
+    $$ = &ast.PatternLit{P: positionFromMark(mtaillex), Pattern: $4}
   }
   ;
 
@@ -663,13 +660,13 @@ decoration_stmt
 
 /* Delete statement parses a delete command. */
 delete_stmt
-  : DEL postfix_expr AFTER DURATIONLITERAL
+  : mark_pos DEL postfix_expr AFTER DURATIONLITERAL
   {
-    $$ = &ast.DelStmt{P: tokenpos(mtaillex), N: $2, Expiry: $4}
+    $$ = &ast.DelStmt{P: positionFromMark(mtaillex), N: $3, Expiry: $5}
   }
-  | DEL postfix_expr
+  | mark_pos DEL postfix_expr
   {
-    $$ = &ast.DelStmt{P: tokenpos(mtaillex), N: $2}
+    $$ = &ast.DelStmt{P: positionFromMark(mtaillex), N: $3}
   }
 
 /* Identifier or String parses where an ID or a string can be expected. */
@@ -724,4 +721,11 @@ func tokenpos(mtaillex mtailLexer) position.Position {
 // production.
 func markedpos(mtaillex mtailLexer) position.Position {
     return mtaillex.(*parser).pos
+}
+
+// positionFromMark returns a position spanning from the last mark to the current position.
+func positionFromMark(mtaillex mtailLexer) position.Position {
+    tp := tokenpos(mtaillex)
+    mp := markedpos(mtaillex)
+    return *position.Merge(&mp, &tp)
 }

--- a/internal/runtime/compiler/parser/y.output
+++ b/internal/runtime/compiler/parser/y.output
@@ -18,60 +18,59 @@ state 1
 state 2
 	start:  stmt_list.    (1)
 	stmt_list:  stmt_list.stmt 
-	metric_hide_spec: .    (93)
 	mark_pos: .    (121)
+	metric_hide_spec: .    (93)
 
 	$end  reduce 1 (src line 89)
 	INVALID  shift 13
+	COUNTER  reduce 93 (src line 517)
+	GAUGE  reduce 93 (src line 517)
+	TIMER  reduce 93 (src line 517)
+	TEXT  reduce 93 (src line 517)
+	HISTOGRAM  reduce 93 (src line 517)
 	CONST  shift 11
-	HIDDEN  shift 25
-	DEF  reduce 121 (src line 690)
-	DEL  shift 20
+	HIDDEN  shift 23
 	NEXT  shift 10
-	OTHERWISE  shift 15
 	STOP  shift 12
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	DECO  reduce 121 (src line 690)
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	DIV  reduce 121 (src line 690)
-	NOT  shift 33
-	LPAREN  shift 39
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	NOT  shift 31
+	LPAREN  shift 37
 	NL  shift 16
-	.  reduce 93 (src line 520)
+	.  reduce 121 (src line 687)
 
 	stmt  goto 3
 	conditional_stmt  goto 4
 	conditional_expr  goto 14
 	expr_stmt  goto 5
 	expr  goto 17
-	primary_expr  goto 30
-	multiplicative_expr  goto 47
-	additive_expr  goto 45
-	postfix_expr  goto 24
-	unary_expr  goto 29
-	assign_expr  goto 23
-	rel_expr  goto 32
-	shift_expr  goto 42
-	bitwise_expr  goto 27
-	logical_expr  goto 22
-	indexed_expr  goto 34
-	id_expr  goto 43
-	concat_expr  goto 26
-	pattern_expr  goto 21
+	primary_expr  goto 28
+	multiplicative_expr  goto 44
+	additive_expr  goto 42
+	postfix_expr  goto 22
+	unary_expr  goto 27
+	assign_expr  goto 21
+	rel_expr  goto 30
+	shift_expr  goto 40
+	bitwise_expr  goto 25
+	logical_expr  goto 20
+	indexed_expr  goto 32
+	id_expr  goto 41
+	concat_expr  goto 24
+	pattern_expr  goto 19
 	metric_declaration  goto 6
 	decorator_declaration  goto 7
 	decoration_stmt  goto 8
-	regex_pattern  goto 31
-	match_expr  goto 28
+	regex_pattern  goto 29
+	match_expr  goto 26
 	delete_stmt  goto 9
-	builtin_expr  goto 35
+	builtin_expr  goto 33
 	metric_hide_spec  goto 18
-	mark_pos  goto 19
+	mark_pos  goto 15
 
 state 3
 	stmt_list:  stmt_list stmt.    (3)
@@ -124,10 +123,10 @@ state 10
 state 11
 	stmt:  CONST.id_expr concat_expr 
 
-	ID  shift 46
+	ID  shift 43
 	.  error
 
-	id_expr  goto 48
+	id_expr  goto 45
 
 state 12
 	stmt:  STOP.    (12)
@@ -145,18 +144,29 @@ state 14
 	conditional_stmt:  conditional_expr.compound_stmt ELSE compound_stmt 
 	conditional_stmt:  conditional_expr.compound_stmt 
 
-	LCURLY  shift 50
+	LCURLY  shift 47
 	.  error
 
-	compound_stmt  goto 49
+	compound_stmt  goto 46
 
 state 15
-	conditional_stmt:  OTHERWISE.compound_stmt 
+	conditional_stmt:  mark_pos.OTHERWISE compound_stmt 
+	builtin_expr:  mark_pos.BUILTIN LPAREN RPAREN 
+	builtin_expr:  mark_pos.BUILTIN LPAREN arg_expr_list RPAREN 
+	regex_pattern:  mark_pos.DIV in_regex REGEX DIV 
+	decorator_declaration:  mark_pos.DEF ID compound_stmt 
+	decoration_stmt:  mark_pos.DECO compound_stmt 
+	delete_stmt:  mark_pos.DEL postfix_expr AFTER DURATIONLITERAL 
+	delete_stmt:  mark_pos.DEL postfix_expr 
 
-	LCURLY  shift 50
+	DEF  shift 51
+	DEL  shift 53
+	OTHERWISE  shift 48
+	BUILTIN  shift 49
+	DECO  shift 52
+	DIV  shift 50
 	.  error
 
-	compound_stmt  goto 51
 
 state 16
 	expr_stmt:  NL.    (20)
@@ -167,1133 +177,1136 @@ state 16
 state 17
 	expr_stmt:  expr.NL 
 
-	NL  shift 52
+	NL  shift 54
 	.  error
 
 
 state 18
 	metric_declaration:  metric_hide_spec.metric_type_spec metric_decl_attr_spec 
 
-	COUNTER  shift 54
-	GAUGE  shift 55
-	TIMER  shift 56
-	TEXT  shift 57
-	HISTOGRAM  shift 58
+	COUNTER  shift 56
+	GAUGE  shift 57
+	TIMER  shift 58
+	TEXT  shift 59
+	HISTOGRAM  shift 60
 	.  error
 
-	metric_type_spec  goto 53
+	metric_type_spec  goto 55
 
 state 19
-	regex_pattern:  mark_pos.DIV in_regex REGEX DIV 
-	decorator_declaration:  mark_pos.DEF ID compound_stmt 
-	decoration_stmt:  mark_pos.DECO compound_stmt 
-
-	DEF  shift 60
-	DECO  shift 61
-	DIV  shift 59
-	.  error
-
-
-state 20
-	delete_stmt:  DEL.postfix_expr AFTER DURATIONLITERAL 
-	delete_stmt:  DEL.postfix_expr 
-
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	LPAREN  shift 39
-	.  error
-
-	primary_expr  goto 63
-	postfix_expr  goto 62
-	indexed_expr  goto 34
-	id_expr  goto 43
-	builtin_expr  goto 35
-
-state 21
 	conditional_expr:  pattern_expr.    (17)
 	conditional_expr:  pattern_expr.logical_op opt_nl logical_expr 
 
-	AND  shift 65
-	OR  shift 66
+	AND  shift 62
+	OR  shift 63
 	.  reduce 17 (src line 164)
 
-	logical_op  goto 64
+	logical_op  goto 61
 
-state 22
+state 20
 	conditional_expr:  logical_expr.    (19)
 	logical_expr:  logical_expr.logical_op opt_nl bitwise_expr 
 	logical_expr:  logical_expr.logical_op opt_nl match_expr 
 
-	AND  shift 65
-	OR  shift 66
+	AND  shift 62
+	OR  shift 63
 	.  reduce 19 (src line 177)
 
-	logical_op  goto 67
+	logical_op  goto 64
 
-state 23
+state 21
 	expr:  assign_expr.    (23)
 
 	.  reduce 23 (src line 198)
 
 
-state 24
+state 22
 	expr:  postfix_expr.    (24)
 	unary_expr:  postfix_expr.    (68)
 	postfix_expr:  postfix_expr.postfix_op 
 
-	INC  shift 69
-	DEC  shift 70
+	INC  shift 66
+	DEC  shift 67
 	NL  reduce 24 (src line 201)
 	.  reduce 68 (src line 382)
 
-	postfix_op  goto 68
+	postfix_op  goto 65
 
-state 25
+state 23
 	metric_hide_spec:  HIDDEN.    (94)
 
-	.  reduce 94 (src line 525)
+	.  reduce 94 (src line 522)
 
 
-state 26
+state 24
 	pattern_expr:  concat_expr.    (58)
 	concat_expr:  concat_expr.PLUS opt_nl regex_pattern 
 	concat_expr:  concat_expr.PLUS opt_nl id_expr 
 
-	PLUS  shift 71
+	PLUS  shift 68
 	.  reduce 58 (src line 339)
 
 
-state 27
+state 25
 	logical_expr:  bitwise_expr.    (27)
 	bitwise_expr:  bitwise_expr.bitwise_op opt_nl rel_expr 
 
-	BITAND  shift 73
-	XOR  shift 75
-	BITOR  shift 74
+	BITAND  shift 70
+	XOR  shift 72
+	BITOR  shift 71
 	.  reduce 27 (src line 218)
 
-	bitwise_op  goto 72
+	bitwise_op  goto 69
 
-state 28
+state 26
 	logical_expr:  match_expr.    (28)
 
 	.  reduce 28 (src line 221)
 
 
-state 29
+state 27
 	assign_expr:  unary_expr.ASSIGN opt_nl logical_expr 
 	assign_expr:  unary_expr.ADD_ASSIGN opt_nl logical_expr 
 	multiplicative_expr:  unary_expr.    (62)
 
-	ADD_ASSIGN  shift 77
-	ASSIGN  shift 76
+	ADD_ASSIGN  shift 74
+	ASSIGN  shift 73
 	.  reduce 62 (src line 361)
 
 
-state 30
+state 28
 	match_expr:  primary_expr.match_op opt_nl pattern_expr 
 	match_expr:  primary_expr.match_op opt_nl primary_expr 
 	postfix_expr:  primary_expr.    (70)
 
-	MATCH  shift 79
-	NOT_MATCH  shift 80
+	MATCH  shift 76
+	NOT_MATCH  shift 77
 	.  reduce 70 (src line 392)
 
-	match_op  goto 78
+	match_op  goto 75
 
-state 31
+state 29
 	concat_expr:  regex_pattern.    (59)
 
 	.  reduce 59 (src line 347)
 
 
-state 32
+state 30
 	bitwise_expr:  rel_expr.    (33)
 	rel_expr:  rel_expr.rel_op opt_nl shift_expr 
 
-	LT  shift 82
-	GT  shift 83
-	LE  shift 84
-	GE  shift 85
-	EQ  shift 86
-	NE  shift 87
+	LT  shift 79
+	GT  shift 80
+	LE  shift 81
+	GE  shift 82
+	EQ  shift 83
+	NE  shift 84
 	.  reduce 33 (src line 241)
 
-	rel_op  goto 81
+	rel_op  goto 78
 
-state 33
+state 31
 	unary_expr:  NOT.unary_expr 
+	mark_pos: .    (121)
 
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	NOT  shift 33
-	LPAREN  shift 39
-	.  error
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	NOT  shift 31
+	LPAREN  shift 37
+	.  reduce 121 (src line 687)
 
-	primary_expr  goto 63
-	postfix_expr  goto 89
-	unary_expr  goto 88
-	indexed_expr  goto 34
-	id_expr  goto 43
-	builtin_expr  goto 35
+	primary_expr  goto 87
+	postfix_expr  goto 86
+	unary_expr  goto 85
+	indexed_expr  goto 32
+	id_expr  goto 41
+	builtin_expr  goto 33
+	mark_pos  goto 88
 
-state 34
+state 32
 	primary_expr:  indexed_expr.    (74)
 	indexed_expr:  indexed_expr.LSQUARE arg_expr_list RSQUARE 
 
-	LSQUARE  shift 90
+	LSQUARE  shift 89
 	.  reduce 74 (src line 409)
 
 
-state 35
+state 33
 	primary_expr:  builtin_expr.    (75)
 
 	.  reduce 75 (src line 412)
 
 
-state 36
+state 34
 	primary_expr:  CAPREF.    (76)
 
 	.  reduce 76 (src line 414)
 
 
-state 37
+state 35
 	primary_expr:  CAPREF_NAMED.    (77)
 
 	.  reduce 77 (src line 418)
 
 
-state 38
+state 36
 	primary_expr:  STRING.    (78)
 
 	.  reduce 78 (src line 422)
 
 
-state 39
+state 37
 	primary_expr:  LPAREN.logical_expr RPAREN 
+	mark_pos: .    (121)
 
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	NOT  shift 33
-	LPAREN  shift 39
-	.  error
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	NOT  shift 31
+	LPAREN  shift 37
+	.  reduce 121 (src line 687)
 
-	primary_expr  goto 30
-	multiplicative_expr  goto 47
-	additive_expr  goto 45
-	postfix_expr  goto 89
-	unary_expr  goto 92
-	rel_expr  goto 32
-	shift_expr  goto 42
-	bitwise_expr  goto 27
-	logical_expr  goto 91
-	indexed_expr  goto 34
-	id_expr  goto 43
-	match_expr  goto 28
-	builtin_expr  goto 35
+	primary_expr  goto 28
+	multiplicative_expr  goto 44
+	additive_expr  goto 42
+	postfix_expr  goto 86
+	unary_expr  goto 91
+	rel_expr  goto 30
+	shift_expr  goto 40
+	bitwise_expr  goto 25
+	logical_expr  goto 90
+	indexed_expr  goto 32
+	id_expr  goto 41
+	match_expr  goto 26
+	builtin_expr  goto 33
+	mark_pos  goto 88
 
-state 40
+state 38
 	primary_expr:  INTLITERAL.    (80)
 
 	.  reduce 80 (src line 430)
 
 
-state 41
+state 39
 	primary_expr:  FLOATLITERAL.    (81)
 
 	.  reduce 81 (src line 434)
 
 
-state 42
+state 40
 	rel_expr:  shift_expr.    (38)
 	shift_expr:  shift_expr.shift_op opt_nl additive_expr 
 
-	SHL  shift 94
-	SHR  shift 95
+	SHL  shift 93
+	SHR  shift 94
 	.  reduce 38 (src line 260)
 
-	shift_op  goto 93
+	shift_op  goto 92
 
-state 43
+state 41
 	indexed_expr:  id_expr.    (82)
 
 	.  reduce 82 (src line 441)
 
 
-state 44
-	builtin_expr:  BUILTIN.LPAREN RPAREN 
-	builtin_expr:  BUILTIN.LPAREN arg_expr_list RPAREN 
-
-	LPAREN  shift 96
-	.  error
-
-
-state 45
+state 42
 	shift_expr:  additive_expr.    (46)
 	additive_expr:  additive_expr.add_op opt_nl multiplicative_expr 
 
-	MINUS  shift 99
-	PLUS  shift 98
+	MINUS  shift 97
+	PLUS  shift 96
 	.  reduce 46 (src line 285)
 
-	add_op  goto 97
+	add_op  goto 95
 
-state 46
+state 43
 	id_expr:  ID.    (84)
 
 	.  reduce 84 (src line 456)
 
 
-state 47
+state 44
 	additive_expr:  multiplicative_expr.    (50)
 	multiplicative_expr:  multiplicative_expr.mul_op opt_nl unary_expr 
 
-	DIV  shift 102
-	MOD  shift 103
-	MUL  shift 101
-	POW  shift 104
+	DIV  shift 100
+	MOD  shift 101
+	MUL  shift 99
+	POW  shift 102
 	.  reduce 50 (src line 302)
 
-	mul_op  goto 100
+	mul_op  goto 98
 
-state 48
+state 45
 	stmt:  CONST id_expr.concat_expr 
 	mark_pos: .    (121)
 
-	.  reduce 121 (src line 690)
+	.  reduce 121 (src line 687)
 
-	concat_expr  goto 105
-	regex_pattern  goto 31
-	mark_pos  goto 106
+	concat_expr  goto 103
+	regex_pattern  goto 29
+	mark_pos  goto 104
 
-state 49
+state 46
 	conditional_stmt:  conditional_expr compound_stmt.ELSE compound_stmt 
 	conditional_stmt:  conditional_expr compound_stmt.    (15)
 
-	ELSE  shift 107
+	ELSE  shift 105
 	.  reduce 15 (src line 149)
 
 
-state 50
+state 47
 	compound_stmt:  LCURLY.stmt_list RCURLY 
 	stmt_list: .    (2)
 
 	.  reduce 2 (src line 97)
 
-	stmt_list  goto 108
+	stmt_list  goto 106
+
+state 48
+	conditional_stmt:  mark_pos OTHERWISE.compound_stmt 
+
+	LCURLY  shift 47
+	.  error
+
+	compound_stmt  goto 107
+
+state 49
+	builtin_expr:  mark_pos BUILTIN.LPAREN RPAREN 
+	builtin_expr:  mark_pos BUILTIN.LPAREN arg_expr_list RPAREN 
+
+	LPAREN  shift 108
+	.  error
+
+
+state 50
+	regex_pattern:  mark_pos DIV.in_regex REGEX DIV 
+	in_regex: .    (122)
+
+	.  reduce 122 (src line 697)
+
+	in_regex  goto 109
 
 state 51
-	conditional_stmt:  OTHERWISE compound_stmt.    (16)
+	decorator_declaration:  mark_pos DEF.ID compound_stmt 
 
-	.  reduce 16 (src line 157)
+	ID  shift 110
+	.  error
 
 
 state 52
+	decoration_stmt:  mark_pos DECO.compound_stmt 
+
+	LCURLY  shift 47
+	.  error
+
+	compound_stmt  goto 111
+
+state 53
+	delete_stmt:  mark_pos DEL.postfix_expr AFTER DURATIONLITERAL 
+	delete_stmt:  mark_pos DEL.postfix_expr 
+	mark_pos: .    (121)
+
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	LPAREN  shift 37
+	.  reduce 121 (src line 687)
+
+	primary_expr  goto 87
+	postfix_expr  goto 112
+	indexed_expr  goto 32
+	id_expr  goto 41
+	builtin_expr  goto 33
+	mark_pos  goto 88
+
+state 54
 	expr_stmt:  expr NL.    (21)
 
 	.  reduce 21 (src line 185)
 
 
-state 53
+state 55
 	metric_declaration:  metric_hide_spec metric_type_spec.metric_decl_attr_spec 
 
-	STRING  shift 112
-	ID  shift 111
+	STRING  shift 116
+	ID  shift 115
 	.  error
 
-	metric_decl_attr_spec  goto 109
-	metric_name_spec  goto 110
-
-state 54
-	metric_type_spec:  COUNTER.    (101)
-
-	.  reduce 101 (src line 567)
-
-
-state 55
-	metric_type_spec:  GAUGE.    (102)
-
-	.  reduce 102 (src line 572)
-
+	metric_decl_attr_spec  goto 113
+	metric_name_spec  goto 114
 
 state 56
-	metric_type_spec:  TIMER.    (103)
+	metric_type_spec:  COUNTER.    (101)
 
-	.  reduce 103 (src line 576)
+	.  reduce 101 (src line 564)
 
 
 state 57
-	metric_type_spec:  TEXT.    (104)
+	metric_type_spec:  GAUGE.    (102)
 
-	.  reduce 104 (src line 580)
+	.  reduce 102 (src line 569)
 
 
 state 58
-	metric_type_spec:  HISTOGRAM.    (105)
+	metric_type_spec:  TIMER.    (103)
 
-	.  reduce 105 (src line 584)
+	.  reduce 103 (src line 573)
 
 
 state 59
-	regex_pattern:  mark_pos DIV.in_regex REGEX DIV 
-	in_regex: .    (122)
+	metric_type_spec:  TEXT.    (104)
 
-	.  reduce 122 (src line 700)
+	.  reduce 104 (src line 577)
 
-	in_regex  goto 113
 
 state 60
-	decorator_declaration:  mark_pos DEF.ID compound_stmt 
+	metric_type_spec:  HISTOGRAM.    (105)
 
-	ID  shift 114
-	.  error
+	.  reduce 105 (src line 581)
 
 
 state 61
-	decoration_stmt:  mark_pos DECO.compound_stmt 
-
-	LCURLY  shift 50
-	.  error
-
-	compound_stmt  goto 115
-
-state 62
-	postfix_expr:  postfix_expr.postfix_op 
-	delete_stmt:  DEL postfix_expr.AFTER DURATIONLITERAL 
-	delete_stmt:  DEL postfix_expr.    (118)
-
-	AFTER  shift 116
-	INC  shift 69
-	DEC  shift 70
-	.  reduce 118 (src line 670)
-
-	postfix_op  goto 68
-
-state 63
-	postfix_expr:  primary_expr.    (70)
-
-	.  reduce 70 (src line 392)
-
-
-state 64
 	conditional_expr:  pattern_expr logical_op.opt_nl logical_expr 
 	opt_nl: .    (123)
 
 	NL  shift 118
-	.  reduce 123 (src line 710)
+	.  reduce 123 (src line 707)
 
 	opt_nl  goto 117
 
-state 65
+state 62
 	logical_op:  AND.    (31)
 
 	.  reduce 31 (src line 233)
 
 
-state 66
+state 63
 	logical_op:  OR.    (32)
 
 	.  reduce 32 (src line 236)
 
 
-state 67
+state 64
 	logical_expr:  logical_expr logical_op.opt_nl bitwise_expr 
 	logical_expr:  logical_expr logical_op.opt_nl match_expr 
 	opt_nl: .    (123)
 
 	NL  shift 118
-	.  reduce 123 (src line 710)
+	.  reduce 123 (src line 707)
 
 	opt_nl  goto 119
 
-state 68
+state 65
 	postfix_expr:  postfix_expr postfix_op.    (71)
 
 	.  reduce 71 (src line 395)
 
 
-state 69
+state 66
 	postfix_op:  INC.    (72)
 
 	.  reduce 72 (src line 401)
 
 
-state 70
+state 67
 	postfix_op:  DEC.    (73)
 
 	.  reduce 73 (src line 404)
 
 
-state 71
+state 68
 	concat_expr:  concat_expr PLUS.opt_nl regex_pattern 
 	concat_expr:  concat_expr PLUS.opt_nl id_expr 
 	opt_nl: .    (123)
 
 	NL  shift 118
-	.  reduce 123 (src line 710)
+	.  reduce 123 (src line 707)
 
 	opt_nl  goto 120
 
-state 72
+state 69
 	bitwise_expr:  bitwise_expr bitwise_op.opt_nl rel_expr 
 	opt_nl: .    (123)
 
 	NL  shift 118
-	.  reduce 123 (src line 710)
+	.  reduce 123 (src line 707)
 
 	opt_nl  goto 121
 
-state 73
+state 70
 	bitwise_op:  BITAND.    (35)
 
 	.  reduce 35 (src line 250)
 
 
-state 74
+state 71
 	bitwise_op:  BITOR.    (36)
 
 	.  reduce 36 (src line 253)
 
 
-state 75
+state 72
 	bitwise_op:  XOR.    (37)
 
 	.  reduce 37 (src line 255)
 
 
-state 76
+state 73
 	assign_expr:  unary_expr ASSIGN.opt_nl logical_expr 
 	opt_nl: .    (123)
 
 	NL  shift 118
-	.  reduce 123 (src line 710)
+	.  reduce 123 (src line 707)
 
 	opt_nl  goto 122
 
-state 77
+state 74
 	assign_expr:  unary_expr ADD_ASSIGN.opt_nl logical_expr 
 	opt_nl: .    (123)
 
 	NL  shift 118
-	.  reduce 123 (src line 710)
+	.  reduce 123 (src line 707)
 
 	opt_nl  goto 123
 
-state 78
+state 75
 	match_expr:  primary_expr match_op.opt_nl pattern_expr 
 	match_expr:  primary_expr match_op.opt_nl primary_expr 
 	opt_nl: .    (123)
 
 	NL  shift 118
-	.  reduce 123 (src line 710)
+	.  reduce 123 (src line 707)
 
 	opt_nl  goto 124
 
-state 79
+state 76
 	match_op:  MATCH.    (56)
 
 	.  reduce 56 (src line 330)
 
 
-state 80
+state 77
 	match_op:  NOT_MATCH.    (57)
 
 	.  reduce 57 (src line 333)
 
 
-state 81
+state 78
 	rel_expr:  rel_expr rel_op.opt_nl shift_expr 
 	opt_nl: .    (123)
 
 	NL  shift 118
-	.  reduce 123 (src line 710)
+	.  reduce 123 (src line 707)
 
 	opt_nl  goto 125
 
-state 82
+state 79
 	rel_op:  LT.    (40)
 
 	.  reduce 40 (src line 269)
 
 
-state 83
+state 80
 	rel_op:  GT.    (41)
 
 	.  reduce 41 (src line 272)
 
 
-state 84
+state 81
 	rel_op:  LE.    (42)
 
 	.  reduce 42 (src line 274)
 
 
-state 85
+state 82
 	rel_op:  GE.    (43)
 
 	.  reduce 43 (src line 276)
 
 
-state 86
+state 83
 	rel_op:  EQ.    (44)
 
 	.  reduce 44 (src line 278)
 
 
-state 87
+state 84
 	rel_op:  NE.    (45)
 
 	.  reduce 45 (src line 280)
 
 
-state 88
+state 85
 	unary_expr:  NOT unary_expr.    (69)
 
 	.  reduce 69 (src line 385)
 
 
-state 89
+state 86
 	unary_expr:  postfix_expr.    (68)
 	postfix_expr:  postfix_expr.postfix_op 
 
-	INC  shift 69
-	DEC  shift 70
+	INC  shift 66
+	DEC  shift 67
 	.  reduce 68 (src line 382)
 
-	postfix_op  goto 68
+	postfix_op  goto 65
 
-state 90
+state 87
+	postfix_expr:  primary_expr.    (70)
+
+	.  reduce 70 (src line 392)
+
+
+state 88
+	builtin_expr:  mark_pos.BUILTIN LPAREN RPAREN 
+	builtin_expr:  mark_pos.BUILTIN LPAREN arg_expr_list RPAREN 
+
+	BUILTIN  shift 49
+	.  error
+
+
+state 89
 	indexed_expr:  indexed_expr LSQUARE.arg_expr_list RSQUARE 
 	mark_pos: .    (121)
 
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	NOT  shift 33
-	LPAREN  shift 39
-	.  reduce 121 (src line 690)
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	NOT  shift 31
+	LPAREN  shift 37
+	.  reduce 121 (src line 687)
 
 	arg_expr_list  goto 126
-	primary_expr  goto 30
-	multiplicative_expr  goto 47
-	additive_expr  goto 45
-	postfix_expr  goto 89
-	unary_expr  goto 92
-	rel_expr  goto 32
-	shift_expr  goto 42
-	bitwise_expr  goto 27
+	primary_expr  goto 28
+	multiplicative_expr  goto 44
+	additive_expr  goto 42
+	postfix_expr  goto 86
+	unary_expr  goto 91
+	rel_expr  goto 30
+	shift_expr  goto 40
+	bitwise_expr  goto 25
 	logical_expr  goto 128
-	indexed_expr  goto 34
-	id_expr  goto 43
-	concat_expr  goto 26
+	indexed_expr  goto 32
+	id_expr  goto 41
+	concat_expr  goto 24
 	pattern_expr  goto 129
-	regex_pattern  goto 31
-	match_expr  goto 28
-	builtin_expr  goto 35
+	regex_pattern  goto 29
+	match_expr  goto 26
+	builtin_expr  goto 33
 	arg_expr  goto 127
-	mark_pos  goto 106
+	mark_pos  goto 130
 
-state 91
+state 90
 	logical_expr:  logical_expr.logical_op opt_nl bitwise_expr 
 	logical_expr:  logical_expr.logical_op opt_nl match_expr 
 	primary_expr:  LPAREN logical_expr.RPAREN 
 
-	AND  shift 65
-	OR  shift 66
-	RPAREN  shift 130
+	AND  shift 62
+	OR  shift 63
+	RPAREN  shift 131
 	.  error
 
-	logical_op  goto 67
+	logical_op  goto 64
 
-state 92
+state 91
 	multiplicative_expr:  unary_expr.    (62)
 
 	.  reduce 62 (src line 361)
 
 
-state 93
+state 92
 	shift_expr:  shift_expr shift_op.opt_nl additive_expr 
 	opt_nl: .    (123)
 
 	NL  shift 118
-	.  reduce 123 (src line 710)
+	.  reduce 123 (src line 707)
 
-	opt_nl  goto 131
+	opt_nl  goto 132
 
-state 94
+state 93
 	shift_op:  SHL.    (48)
 
 	.  reduce 48 (src line 294)
 
 
-state 95
+state 94
 	shift_op:  SHR.    (49)
 
 	.  reduce 49 (src line 297)
 
 
-state 96
-	builtin_expr:  BUILTIN LPAREN.RPAREN 
-	builtin_expr:  BUILTIN LPAREN.arg_expr_list RPAREN 
-	mark_pos: .    (121)
-
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	NOT  shift 33
-	LPAREN  shift 39
-	RPAREN  shift 132
-	.  reduce 121 (src line 690)
-
-	arg_expr_list  goto 133
-	primary_expr  goto 30
-	multiplicative_expr  goto 47
-	additive_expr  goto 45
-	postfix_expr  goto 89
-	unary_expr  goto 92
-	rel_expr  goto 32
-	shift_expr  goto 42
-	bitwise_expr  goto 27
-	logical_expr  goto 128
-	indexed_expr  goto 34
-	id_expr  goto 43
-	concat_expr  goto 26
-	pattern_expr  goto 129
-	regex_pattern  goto 31
-	match_expr  goto 28
-	builtin_expr  goto 35
-	arg_expr  goto 127
-	mark_pos  goto 106
-
-state 97
+state 95
 	additive_expr:  additive_expr add_op.opt_nl multiplicative_expr 
 	opt_nl: .    (123)
 
 	NL  shift 118
-	.  reduce 123 (src line 710)
+	.  reduce 123 (src line 707)
 
-	opt_nl  goto 134
+	opt_nl  goto 133
 
-state 98
+state 96
 	add_op:  PLUS.    (52)
 
 	.  reduce 52 (src line 311)
 
 
-state 99
+state 97
 	add_op:  MINUS.    (53)
 
 	.  reduce 53 (src line 314)
 
 
-state 100
+state 98
 	multiplicative_expr:  multiplicative_expr mul_op.opt_nl unary_expr 
 	opt_nl: .    (123)
 
 	NL  shift 118
-	.  reduce 123 (src line 710)
+	.  reduce 123 (src line 707)
 
-	opt_nl  goto 135
+	opt_nl  goto 134
 
-state 101
+state 99
 	mul_op:  MUL.    (64)
 
 	.  reduce 64 (src line 370)
 
 
-state 102
+state 100
 	mul_op:  DIV.    (65)
 
 	.  reduce 65 (src line 373)
 
 
-state 103
+state 101
 	mul_op:  MOD.    (66)
 
 	.  reduce 66 (src line 375)
 
 
-state 104
+state 102
 	mul_op:  POW.    (67)
 
 	.  reduce 67 (src line 377)
 
 
-state 105
+state 103
 	stmt:  CONST id_expr concat_expr.    (11)
 	concat_expr:  concat_expr.PLUS opt_nl regex_pattern 
 	concat_expr:  concat_expr.PLUS opt_nl id_expr 
 
-	PLUS  shift 71
+	PLUS  shift 68
 	.  reduce 11 (src line 129)
 
 
-state 106
+state 104
 	regex_pattern:  mark_pos.DIV in_regex REGEX DIV 
 
-	DIV  shift 59
+	DIV  shift 50
 	.  error
 
 
-state 107
+state 105
 	conditional_stmt:  conditional_expr compound_stmt ELSE.compound_stmt 
 
-	LCURLY  shift 50
+	LCURLY  shift 47
 	.  error
 
-	compound_stmt  goto 136
+	compound_stmt  goto 135
 
-state 108
+state 106
 	stmt_list:  stmt_list.stmt 
 	compound_stmt:  LCURLY stmt_list.RCURLY 
-	metric_hide_spec: .    (93)
 	mark_pos: .    (121)
+	metric_hide_spec: .    (93)
 
 	INVALID  shift 13
+	COUNTER  reduce 93 (src line 517)
+	GAUGE  reduce 93 (src line 517)
+	TIMER  reduce 93 (src line 517)
+	TEXT  reduce 93 (src line 517)
+	HISTOGRAM  reduce 93 (src line 517)
 	CONST  shift 11
-	HIDDEN  shift 25
-	DEF  reduce 121 (src line 690)
-	DEL  shift 20
+	HIDDEN  shift 23
 	NEXT  shift 10
-	OTHERWISE  shift 15
 	STOP  shift 12
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	DECO  reduce 121 (src line 690)
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	DIV  reduce 121 (src line 690)
-	NOT  shift 33
-	RCURLY  shift 137
-	LPAREN  shift 39
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	NOT  shift 31
+	RCURLY  shift 136
+	LPAREN  shift 37
 	NL  shift 16
-	.  reduce 93 (src line 520)
+	.  reduce 121 (src line 687)
 
 	stmt  goto 3
 	conditional_stmt  goto 4
 	conditional_expr  goto 14
 	expr_stmt  goto 5
 	expr  goto 17
-	primary_expr  goto 30
-	multiplicative_expr  goto 47
-	additive_expr  goto 45
-	postfix_expr  goto 24
-	unary_expr  goto 29
-	assign_expr  goto 23
-	rel_expr  goto 32
-	shift_expr  goto 42
-	bitwise_expr  goto 27
-	logical_expr  goto 22
-	indexed_expr  goto 34
-	id_expr  goto 43
-	concat_expr  goto 26
-	pattern_expr  goto 21
+	primary_expr  goto 28
+	multiplicative_expr  goto 44
+	additive_expr  goto 42
+	postfix_expr  goto 22
+	unary_expr  goto 27
+	assign_expr  goto 21
+	rel_expr  goto 30
+	shift_expr  goto 40
+	bitwise_expr  goto 25
+	logical_expr  goto 20
+	indexed_expr  goto 32
+	id_expr  goto 41
+	concat_expr  goto 24
+	pattern_expr  goto 19
 	metric_declaration  goto 6
 	decorator_declaration  goto 7
 	decoration_stmt  goto 8
-	regex_pattern  goto 31
-	match_expr  goto 28
+	regex_pattern  goto 29
+	match_expr  goto 26
 	delete_stmt  goto 9
-	builtin_expr  goto 35
+	builtin_expr  goto 33
 	metric_hide_spec  goto 18
-	mark_pos  goto 19
+	mark_pos  goto 15
+
+state 107
+	conditional_stmt:  mark_pos OTHERWISE compound_stmt.    (16)
+
+	.  reduce 16 (src line 157)
+
+
+state 108
+	builtin_expr:  mark_pos BUILTIN LPAREN.RPAREN 
+	builtin_expr:  mark_pos BUILTIN LPAREN.arg_expr_list RPAREN 
+	mark_pos: .    (121)
+
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	NOT  shift 31
+	LPAREN  shift 37
+	RPAREN  shift 137
+	.  reduce 121 (src line 687)
+
+	arg_expr_list  goto 138
+	primary_expr  goto 28
+	multiplicative_expr  goto 44
+	additive_expr  goto 42
+	postfix_expr  goto 86
+	unary_expr  goto 91
+	rel_expr  goto 30
+	shift_expr  goto 40
+	bitwise_expr  goto 25
+	logical_expr  goto 128
+	indexed_expr  goto 32
+	id_expr  goto 41
+	concat_expr  goto 24
+	pattern_expr  goto 129
+	regex_pattern  goto 29
+	match_expr  goto 26
+	builtin_expr  goto 33
+	arg_expr  goto 127
+	mark_pos  goto 130
 
 state 109
+	regex_pattern:  mark_pos DIV in_regex.REGEX DIV 
+
+	REGEX  shift 139
+	.  error
+
+
+state 110
+	decorator_declaration:  mark_pos DEF ID.compound_stmt 
+
+	LCURLY  shift 47
+	.  error
+
+	compound_stmt  goto 140
+
+state 111
+	decoration_stmt:  mark_pos DECO compound_stmt.    (116)
+
+	.  reduce 116 (src line 654)
+
+
+state 112
+	postfix_expr:  postfix_expr.postfix_op 
+	delete_stmt:  mark_pos DEL postfix_expr.AFTER DURATIONLITERAL 
+	delete_stmt:  mark_pos DEL postfix_expr.    (118)
+
+	AFTER  shift 141
+	INC  shift 66
+	DEC  shift 67
+	.  reduce 118 (src line 667)
+
+	postfix_op  goto 65
+
+state 113
 	metric_declaration:  metric_hide_spec metric_type_spec metric_decl_attr_spec.    (92)
 	metric_decl_attr_spec:  metric_decl_attr_spec.metric_by_spec 
 	metric_decl_attr_spec:  metric_decl_attr_spec.metric_as_spec 
 	metric_decl_attr_spec:  metric_decl_attr_spec.metric_buckets_spec 
 
-	AS  shift 142
-	BY  shift 141
-	BUCKETS  shift 143
-	.  reduce 92 (src line 509)
+	AS  shift 146
+	BY  shift 145
+	BUCKETS  shift 147
+	.  reduce 92 (src line 506)
 
-	metric_as_spec  goto 139
-	metric_by_spec  goto 138
-	metric_buckets_spec  goto 140
-
-state 110
-	metric_decl_attr_spec:  metric_name_spec.    (98)
-
-	.  reduce 98 (src line 548)
-
-
-state 111
-	metric_name_spec:  ID.    (99)
-
-	.  reduce 99 (src line 555)
-
-
-state 112
-	metric_name_spec:  STRING.    (100)
-
-	.  reduce 100 (src line 560)
-
-
-state 113
-	regex_pattern:  mark_pos DIV in_regex.REGEX DIV 
-
-	REGEX  shift 144
-	.  error
-
+	metric_as_spec  goto 143
+	metric_by_spec  goto 142
+	metric_buckets_spec  goto 144
 
 state 114
-	decorator_declaration:  mark_pos DEF ID.compound_stmt 
+	metric_decl_attr_spec:  metric_name_spec.    (98)
 
-	LCURLY  shift 50
-	.  error
+	.  reduce 98 (src line 545)
 
-	compound_stmt  goto 145
 
 state 115
-	decoration_stmt:  mark_pos DECO compound_stmt.    (116)
+	metric_name_spec:  ID.    (99)
 
-	.  reduce 116 (src line 657)
+	.  reduce 99 (src line 552)
 
 
 state 116
-	delete_stmt:  DEL postfix_expr AFTER.DURATIONLITERAL 
+	metric_name_spec:  STRING.    (100)
 
-	DURATIONLITERAL  shift 146
-	.  error
+	.  reduce 100 (src line 557)
 
 
 state 117
 	conditional_expr:  pattern_expr logical_op opt_nl.logical_expr 
+	mark_pos: .    (121)
 
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	NOT  shift 33
-	LPAREN  shift 39
-	.  error
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	NOT  shift 31
+	LPAREN  shift 37
+	.  reduce 121 (src line 687)
 
-	primary_expr  goto 30
-	multiplicative_expr  goto 47
-	additive_expr  goto 45
-	postfix_expr  goto 89
-	unary_expr  goto 92
-	rel_expr  goto 32
-	shift_expr  goto 42
-	bitwise_expr  goto 27
-	logical_expr  goto 147
-	indexed_expr  goto 34
-	id_expr  goto 43
-	match_expr  goto 28
-	builtin_expr  goto 35
+	primary_expr  goto 28
+	multiplicative_expr  goto 44
+	additive_expr  goto 42
+	postfix_expr  goto 86
+	unary_expr  goto 91
+	rel_expr  goto 30
+	shift_expr  goto 40
+	bitwise_expr  goto 25
+	logical_expr  goto 148
+	indexed_expr  goto 32
+	id_expr  goto 41
+	match_expr  goto 26
+	builtin_expr  goto 33
+	mark_pos  goto 88
 
 state 118
 	opt_nl:  NL.    (124)
 
-	.  reduce 124 (src line 712)
+	.  reduce 124 (src line 709)
 
 
 state 119
 	logical_expr:  logical_expr logical_op opt_nl.bitwise_expr 
 	logical_expr:  logical_expr logical_op opt_nl.match_expr 
+	mark_pos: .    (121)
 
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	NOT  shift 33
-	LPAREN  shift 39
-	.  error
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	NOT  shift 31
+	LPAREN  shift 37
+	.  reduce 121 (src line 687)
 
-	primary_expr  goto 30
-	multiplicative_expr  goto 47
-	additive_expr  goto 45
-	postfix_expr  goto 89
-	unary_expr  goto 92
-	rel_expr  goto 32
-	shift_expr  goto 42
-	bitwise_expr  goto 148
-	indexed_expr  goto 34
-	id_expr  goto 43
-	match_expr  goto 149
-	builtin_expr  goto 35
+	primary_expr  goto 28
+	multiplicative_expr  goto 44
+	additive_expr  goto 42
+	postfix_expr  goto 86
+	unary_expr  goto 91
+	rel_expr  goto 30
+	shift_expr  goto 40
+	bitwise_expr  goto 149
+	indexed_expr  goto 32
+	id_expr  goto 41
+	match_expr  goto 150
+	builtin_expr  goto 33
+	mark_pos  goto 88
 
 state 120
 	concat_expr:  concat_expr PLUS opt_nl.regex_pattern 
 	concat_expr:  concat_expr PLUS opt_nl.id_expr 
 	mark_pos: .    (121)
 
-	ID  shift 46
-	.  reduce 121 (src line 690)
+	ID  shift 43
+	.  reduce 121 (src line 687)
 
-	id_expr  goto 151
-	regex_pattern  goto 150
-	mark_pos  goto 106
+	id_expr  goto 152
+	regex_pattern  goto 151
+	mark_pos  goto 104
 
 state 121
 	bitwise_expr:  bitwise_expr bitwise_op opt_nl.rel_expr 
+	mark_pos: .    (121)
 
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	NOT  shift 33
-	LPAREN  shift 39
-	.  error
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	NOT  shift 31
+	LPAREN  shift 37
+	.  reduce 121 (src line 687)
 
-	primary_expr  goto 63
-	multiplicative_expr  goto 47
-	additive_expr  goto 45
-	postfix_expr  goto 89
-	unary_expr  goto 92
-	rel_expr  goto 152
-	shift_expr  goto 42
-	indexed_expr  goto 34
-	id_expr  goto 43
-	builtin_expr  goto 35
+	primary_expr  goto 87
+	multiplicative_expr  goto 44
+	additive_expr  goto 42
+	postfix_expr  goto 86
+	unary_expr  goto 91
+	rel_expr  goto 153
+	shift_expr  goto 40
+	indexed_expr  goto 32
+	id_expr  goto 41
+	builtin_expr  goto 33
+	mark_pos  goto 88
 
 state 122
 	assign_expr:  unary_expr ASSIGN opt_nl.logical_expr 
+	mark_pos: .    (121)
 
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	NOT  shift 33
-	LPAREN  shift 39
-	.  error
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	NOT  shift 31
+	LPAREN  shift 37
+	.  reduce 121 (src line 687)
 
-	primary_expr  goto 30
-	multiplicative_expr  goto 47
-	additive_expr  goto 45
-	postfix_expr  goto 89
-	unary_expr  goto 92
-	rel_expr  goto 32
-	shift_expr  goto 42
-	bitwise_expr  goto 27
-	logical_expr  goto 153
-	indexed_expr  goto 34
-	id_expr  goto 43
-	match_expr  goto 28
-	builtin_expr  goto 35
+	primary_expr  goto 28
+	multiplicative_expr  goto 44
+	additive_expr  goto 42
+	postfix_expr  goto 86
+	unary_expr  goto 91
+	rel_expr  goto 30
+	shift_expr  goto 40
+	bitwise_expr  goto 25
+	logical_expr  goto 154
+	indexed_expr  goto 32
+	id_expr  goto 41
+	match_expr  goto 26
+	builtin_expr  goto 33
+	mark_pos  goto 88
 
 state 123
 	assign_expr:  unary_expr ADD_ASSIGN opt_nl.logical_expr 
+	mark_pos: .    (121)
 
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	NOT  shift 33
-	LPAREN  shift 39
-	.  error
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	NOT  shift 31
+	LPAREN  shift 37
+	.  reduce 121 (src line 687)
 
-	primary_expr  goto 30
-	multiplicative_expr  goto 47
-	additive_expr  goto 45
-	postfix_expr  goto 89
-	unary_expr  goto 92
-	rel_expr  goto 32
-	shift_expr  goto 42
-	bitwise_expr  goto 27
-	logical_expr  goto 154
-	indexed_expr  goto 34
-	id_expr  goto 43
-	match_expr  goto 28
-	builtin_expr  goto 35
+	primary_expr  goto 28
+	multiplicative_expr  goto 44
+	additive_expr  goto 42
+	postfix_expr  goto 86
+	unary_expr  goto 91
+	rel_expr  goto 30
+	shift_expr  goto 40
+	bitwise_expr  goto 25
+	logical_expr  goto 155
+	indexed_expr  goto 32
+	id_expr  goto 41
+	match_expr  goto 26
+	builtin_expr  goto 33
+	mark_pos  goto 88
 
 state 124
 	match_expr:  primary_expr match_op opt_nl.pattern_expr 
 	match_expr:  primary_expr match_op opt_nl.primary_expr 
 	mark_pos: .    (121)
 
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	LPAREN  shift 39
-	.  reduce 121 (src line 690)
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	LPAREN  shift 37
+	.  reduce 121 (src line 687)
 
-	primary_expr  goto 156
-	indexed_expr  goto 34
-	id_expr  goto 43
-	concat_expr  goto 26
-	pattern_expr  goto 155
-	regex_pattern  goto 31
-	builtin_expr  goto 35
-	mark_pos  goto 106
+	primary_expr  goto 157
+	indexed_expr  goto 32
+	id_expr  goto 41
+	concat_expr  goto 24
+	pattern_expr  goto 156
+	regex_pattern  goto 29
+	builtin_expr  goto 33
+	mark_pos  goto 130
 
 state 125
 	rel_expr:  rel_expr rel_op opt_nl.shift_expr 
+	mark_pos: .    (121)
 
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	NOT  shift 33
-	LPAREN  shift 39
-	.  error
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	NOT  shift 31
+	LPAREN  shift 37
+	.  reduce 121 (src line 687)
 
-	primary_expr  goto 63
-	multiplicative_expr  goto 47
-	additive_expr  goto 45
-	postfix_expr  goto 89
-	unary_expr  goto 92
-	shift_expr  goto 157
-	indexed_expr  goto 34
-	id_expr  goto 43
-	builtin_expr  goto 35
+	primary_expr  goto 87
+	multiplicative_expr  goto 44
+	additive_expr  goto 42
+	postfix_expr  goto 86
+	unary_expr  goto 91
+	shift_expr  goto 158
+	indexed_expr  goto 32
+	id_expr  goto 41
+	builtin_expr  goto 33
+	mark_pos  goto 88
 
 state 126
 	indexed_expr:  indexed_expr LSQUARE arg_expr_list.RSQUARE 
 	arg_expr_list:  arg_expr_list.COMMA arg_expr 
 
-	RSQUARE  shift 158
-	COMMA  shift 159
+	RSQUARE  shift 159
+	COMMA  shift 160
 	.  error
 
 
@@ -1308,11 +1321,11 @@ state 128
 	logical_expr:  logical_expr.logical_op opt_nl match_expr 
 	arg_expr:  logical_expr.    (89)
 
-	AND  shift 65
-	OR  shift 66
+	AND  shift 62
+	OR  shift 63
 	.  reduce 89 (src line 490)
 
-	logical_op  goto 67
+	logical_op  goto 64
 
 state 129
 	arg_expr:  pattern_expr.    (90)
@@ -1321,332 +1334,339 @@ state 129
 
 
 state 130
+	builtin_expr:  mark_pos.BUILTIN LPAREN RPAREN 
+	builtin_expr:  mark_pos.BUILTIN LPAREN arg_expr_list RPAREN 
+	regex_pattern:  mark_pos.DIV in_regex REGEX DIV 
+
+	BUILTIN  shift 49
+	DIV  shift 50
+	.  error
+
+
+state 131
 	primary_expr:  LPAREN logical_expr RPAREN.    (79)
 
 	.  reduce 79 (src line 426)
 
 
-state 131
-	shift_expr:  shift_expr shift_op opt_nl.additive_expr 
-
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	NOT  shift 33
-	LPAREN  shift 39
-	.  error
-
-	primary_expr  goto 63
-	multiplicative_expr  goto 47
-	additive_expr  goto 160
-	postfix_expr  goto 89
-	unary_expr  goto 92
-	indexed_expr  goto 34
-	id_expr  goto 43
-	builtin_expr  goto 35
-
 state 132
-	builtin_expr:  BUILTIN LPAREN RPAREN.    (85)
+	shift_expr:  shift_expr shift_op opt_nl.additive_expr 
+	mark_pos: .    (121)
 
-	.  reduce 85 (src line 464)
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	NOT  shift 31
+	LPAREN  shift 37
+	.  reduce 121 (src line 687)
 
+	primary_expr  goto 87
+	multiplicative_expr  goto 44
+	additive_expr  goto 161
+	postfix_expr  goto 86
+	unary_expr  goto 91
+	indexed_expr  goto 32
+	id_expr  goto 41
+	builtin_expr  goto 33
+	mark_pos  goto 88
 
 state 133
-	builtin_expr:  BUILTIN LPAREN arg_expr_list.RPAREN 
-	arg_expr_list:  arg_expr_list.COMMA arg_expr 
+	additive_expr:  additive_expr add_op opt_nl.multiplicative_expr 
+	mark_pos: .    (121)
 
-	RPAREN  shift 161
-	COMMA  shift 159
-	.  error
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	NOT  shift 31
+	LPAREN  shift 37
+	.  reduce 121 (src line 687)
 
+	primary_expr  goto 87
+	multiplicative_expr  goto 162
+	postfix_expr  goto 86
+	unary_expr  goto 91
+	indexed_expr  goto 32
+	id_expr  goto 41
+	builtin_expr  goto 33
+	mark_pos  goto 88
 
 state 134
-	additive_expr:  additive_expr add_op opt_nl.multiplicative_expr 
+	multiplicative_expr:  multiplicative_expr mul_op opt_nl.unary_expr 
+	mark_pos: .    (121)
 
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	NOT  shift 33
-	LPAREN  shift 39
-	.  error
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	NOT  shift 31
+	LPAREN  shift 37
+	.  reduce 121 (src line 687)
 
-	primary_expr  goto 63
-	multiplicative_expr  goto 162
-	postfix_expr  goto 89
-	unary_expr  goto 92
-	indexed_expr  goto 34
-	id_expr  goto 43
-	builtin_expr  goto 35
+	primary_expr  goto 87
+	postfix_expr  goto 86
+	unary_expr  goto 163
+	indexed_expr  goto 32
+	id_expr  goto 41
+	builtin_expr  goto 33
+	mark_pos  goto 88
 
 state 135
-	multiplicative_expr:  multiplicative_expr mul_op opt_nl.unary_expr 
-
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	NOT  shift 33
-	LPAREN  shift 39
-	.  error
-
-	primary_expr  goto 63
-	postfix_expr  goto 89
-	unary_expr  goto 163
-	indexed_expr  goto 34
-	id_expr  goto 43
-	builtin_expr  goto 35
-
-state 136
 	conditional_stmt:  conditional_expr compound_stmt ELSE compound_stmt.    (14)
 
 	.  reduce 14 (src line 144)
 
 
-state 137
+state 136
 	compound_stmt:  LCURLY stmt_list RCURLY.    (22)
 
 	.  reduce 22 (src line 190)
 
 
-state 138
-	metric_decl_attr_spec:  metric_decl_attr_spec metric_by_spec.    (95)
+state 137
+	builtin_expr:  mark_pos BUILTIN LPAREN RPAREN.    (85)
 
-	.  reduce 95 (src line 532)
+	.  reduce 85 (src line 464)
+
+
+state 138
+	builtin_expr:  mark_pos BUILTIN LPAREN arg_expr_list.RPAREN 
+	arg_expr_list:  arg_expr_list.COMMA arg_expr 
+
+	RPAREN  shift 164
+	COMMA  shift 160
+	.  error
 
 
 state 139
-	metric_decl_attr_spec:  metric_decl_attr_spec metric_as_spec.    (96)
+	regex_pattern:  mark_pos DIV in_regex REGEX.DIV 
 
-	.  reduce 96 (src line 538)
+	DIV  shift 165
+	.  error
 
 
 state 140
-	metric_decl_attr_spec:  metric_decl_attr_spec metric_buckets_spec.    (97)
+	decorator_declaration:  mark_pos DEF ID compound_stmt.    (115)
 
-	.  reduce 97 (src line 543)
+	.  reduce 115 (src line 646)
 
 
 state 141
-	metric_by_spec:  BY.metric_by_expr_list 
+	delete_stmt:  mark_pos DEL postfix_expr AFTER.DURATIONLITERAL 
 
-	STRING  shift 167
-	ID  shift 166
+	DURATIONLITERAL  shift 166
 	.  error
 
-	id_or_string  goto 165
-	metric_by_expr_list  goto 164
 
 state 142
-	metric_as_spec:  AS.STRING 
+	metric_decl_attr_spec:  metric_decl_attr_spec metric_by_spec.    (95)
 
-	STRING  shift 168
-	.  error
+	.  reduce 95 (src line 529)
 
 
 state 143
-	metric_buckets_spec:  BUCKETS.metric_buckets_list 
+	metric_decl_attr_spec:  metric_decl_attr_spec metric_as_spec.    (96)
 
-	INTLITERAL  shift 171
-	FLOATLITERAL  shift 170
-	.  error
+	.  reduce 96 (src line 535)
 
-	metric_buckets_list  goto 169
 
 state 144
-	regex_pattern:  mark_pos DIV in_regex REGEX.DIV 
+	metric_decl_attr_spec:  metric_decl_attr_spec metric_buckets_spec.    (97)
 
-	DIV  shift 172
-	.  error
+	.  reduce 97 (src line 540)
 
 
 state 145
-	decorator_declaration:  mark_pos DEF ID compound_stmt.    (115)
+	metric_by_spec:  BY.metric_by_expr_list 
 
-	.  reduce 115 (src line 649)
+	STRING  shift 170
+	ID  shift 169
+	.  error
 
+	id_or_string  goto 168
+	metric_by_expr_list  goto 167
 
 state 146
-	delete_stmt:  DEL postfix_expr AFTER DURATIONLITERAL.    (117)
+	metric_as_spec:  AS.STRING 
 
-	.  reduce 117 (src line 665)
+	STRING  shift 171
+	.  error
 
 
 state 147
+	metric_buckets_spec:  BUCKETS.metric_buckets_list 
+
+	INTLITERAL  shift 174
+	FLOATLITERAL  shift 173
+	.  error
+
+	metric_buckets_list  goto 172
+
+state 148
 	conditional_expr:  pattern_expr logical_op opt_nl logical_expr.    (18)
 	logical_expr:  logical_expr.logical_op opt_nl bitwise_expr 
 	logical_expr:  logical_expr.logical_op opt_nl match_expr 
 
-	AND  shift 65
-	OR  shift 66
+	AND  shift 62
+	OR  shift 63
 	.  reduce 18 (src line 169)
 
-	logical_op  goto 67
+	logical_op  goto 64
 
-state 148
+state 149
 	logical_expr:  logical_expr logical_op opt_nl bitwise_expr.    (29)
 	bitwise_expr:  bitwise_expr.bitwise_op opt_nl rel_expr 
 
-	BITAND  shift 73
-	XOR  shift 75
-	BITOR  shift 74
+	BITAND  shift 70
+	XOR  shift 72
+	BITOR  shift 71
 	.  reduce 29 (src line 223)
 
-	bitwise_op  goto 72
+	bitwise_op  goto 69
 
-state 149
+state 150
 	logical_expr:  logical_expr logical_op opt_nl match_expr.    (30)
 
 	.  reduce 30 (src line 227)
 
 
-state 150
+state 151
 	concat_expr:  concat_expr PLUS opt_nl regex_pattern.    (60)
 
 	.  reduce 60 (src line 350)
 
 
-state 151
+state 152
 	concat_expr:  concat_expr PLUS opt_nl id_expr.    (61)
 
 	.  reduce 61 (src line 354)
 
 
-state 152
+state 153
 	bitwise_expr:  bitwise_expr bitwise_op opt_nl rel_expr.    (34)
 	rel_expr:  rel_expr.rel_op opt_nl shift_expr 
 
-	LT  shift 82
-	GT  shift 83
-	LE  shift 84
-	GE  shift 85
-	EQ  shift 86
-	NE  shift 87
+	LT  shift 79
+	GT  shift 80
+	LE  shift 81
+	GE  shift 82
+	EQ  shift 83
+	NE  shift 84
 	.  reduce 34 (src line 244)
 
-	rel_op  goto 81
+	rel_op  goto 78
 
-state 153
+state 154
 	assign_expr:  unary_expr ASSIGN opt_nl logical_expr.    (25)
 	logical_expr:  logical_expr.logical_op opt_nl bitwise_expr 
 	logical_expr:  logical_expr.logical_op opt_nl match_expr 
 
-	AND  shift 65
-	OR  shift 66
+	AND  shift 62
+	OR  shift 63
 	.  reduce 25 (src line 206)
 
-	logical_op  goto 67
+	logical_op  goto 64
 
-state 154
+state 155
 	assign_expr:  unary_expr ADD_ASSIGN opt_nl logical_expr.    (26)
 	logical_expr:  logical_expr.logical_op opt_nl bitwise_expr 
 	logical_expr:  logical_expr.logical_op opt_nl match_expr 
 
-	AND  shift 65
-	OR  shift 66
+	AND  shift 62
+	OR  shift 63
 	.  reduce 26 (src line 211)
 
-	logical_op  goto 67
+	logical_op  goto 64
 
-state 155
+state 156
 	match_expr:  primary_expr match_op opt_nl pattern_expr.    (54)
 
 	.  reduce 54 (src line 319)
 
 
-state 156
+state 157
 	match_expr:  primary_expr match_op opt_nl primary_expr.    (55)
 
 	.  reduce 55 (src line 324)
 
 
-state 157
+state 158
 	rel_expr:  rel_expr rel_op opt_nl shift_expr.    (39)
 	shift_expr:  shift_expr.shift_op opt_nl additive_expr 
 
-	SHL  shift 94
-	SHR  shift 95
+	SHL  shift 93
+	SHR  shift 94
 	.  reduce 39 (src line 263)
 
-	shift_op  goto 93
+	shift_op  goto 92
 
-state 158
+state 159
 	indexed_expr:  indexed_expr LSQUARE arg_expr_list RSQUARE.    (83)
 
 	.  reduce 83 (src line 446)
 
 
-state 159
+state 160
 	arg_expr_list:  arg_expr_list COMMA.arg_expr 
 	mark_pos: .    (121)
 
-	BUILTIN  shift 44
-	STRING  shift 38
-	CAPREF  shift 36
-	CAPREF_NAMED  shift 37
-	ID  shift 46
-	INTLITERAL  shift 40
-	FLOATLITERAL  shift 41
-	NOT  shift 33
-	LPAREN  shift 39
-	.  reduce 121 (src line 690)
+	STRING  shift 36
+	CAPREF  shift 34
+	CAPREF_NAMED  shift 35
+	ID  shift 43
+	INTLITERAL  shift 38
+	FLOATLITERAL  shift 39
+	NOT  shift 31
+	LPAREN  shift 37
+	.  reduce 121 (src line 687)
 
-	primary_expr  goto 30
-	multiplicative_expr  goto 47
-	additive_expr  goto 45
-	postfix_expr  goto 89
-	unary_expr  goto 92
-	rel_expr  goto 32
-	shift_expr  goto 42
-	bitwise_expr  goto 27
+	primary_expr  goto 28
+	multiplicative_expr  goto 44
+	additive_expr  goto 42
+	postfix_expr  goto 86
+	unary_expr  goto 91
+	rel_expr  goto 30
+	shift_expr  goto 40
+	bitwise_expr  goto 25
 	logical_expr  goto 128
-	indexed_expr  goto 34
-	id_expr  goto 43
-	concat_expr  goto 26
+	indexed_expr  goto 32
+	id_expr  goto 41
+	concat_expr  goto 24
 	pattern_expr  goto 129
-	regex_pattern  goto 31
-	match_expr  goto 28
-	builtin_expr  goto 35
-	arg_expr  goto 173
-	mark_pos  goto 106
+	regex_pattern  goto 29
+	match_expr  goto 26
+	builtin_expr  goto 33
+	arg_expr  goto 175
+	mark_pos  goto 130
 
-state 160
+state 161
 	shift_expr:  shift_expr shift_op opt_nl additive_expr.    (47)
 	additive_expr:  additive_expr.add_op opt_nl multiplicative_expr 
 
-	MINUS  shift 99
-	PLUS  shift 98
+	MINUS  shift 97
+	PLUS  shift 96
 	.  reduce 47 (src line 288)
 
-	add_op  goto 97
-
-state 161
-	builtin_expr:  BUILTIN LPAREN arg_expr_list RPAREN.    (86)
-
-	.  reduce 86 (src line 469)
-
+	add_op  goto 95
 
 state 162
 	additive_expr:  additive_expr add_op opt_nl multiplicative_expr.    (51)
 	multiplicative_expr:  multiplicative_expr.mul_op opt_nl unary_expr 
 
-	DIV  shift 102
-	MOD  shift 103
-	MUL  shift 101
-	POW  shift 104
+	DIV  shift 100
+	MOD  shift 101
+	MUL  shift 99
+	POW  shift 102
 	.  reduce 51 (src line 305)
 
-	mul_op  goto 100
+	mul_op  goto 98
 
 state 163
 	multiplicative_expr:  multiplicative_expr mul_op opt_nl unary_expr.    (63)
@@ -1655,115 +1675,127 @@ state 163
 
 
 state 164
-	metric_by_spec:  BY metric_by_expr_list.    (106)
-	metric_by_expr_list:  metric_by_expr_list.COMMA id_or_string 
+	builtin_expr:  mark_pos BUILTIN LPAREN arg_expr_list RPAREN.    (86)
 
-	COMMA  shift 174
-	.  reduce 106 (src line 591)
+	.  reduce 86 (src line 469)
 
 
 state 165
-	metric_by_expr_list:  id_or_string.    (107)
-
-	.  reduce 107 (src line 598)
-
-
-state 166
-	id_or_string:  ID.    (119)
-
-	.  reduce 119 (src line 676)
-
-
-state 167
-	id_or_string:  STRING.    (120)
-
-	.  reduce 120 (src line 681)
-
-
-state 168
-	metric_as_spec:  AS STRING.    (109)
-
-	.  reduce 109 (src line 612)
-
-
-state 169
-	metric_buckets_spec:  BUCKETS metric_buckets_list.    (110)
-	metric_buckets_list:  metric_buckets_list.COMMA FLOATLITERAL 
-	metric_buckets_list:  metric_buckets_list.COMMA INTLITERAL 
-
-	COMMA  shift 175
-	.  reduce 110 (src line 620)
-
-
-state 170
-	metric_buckets_list:  FLOATLITERAL.    (111)
-
-	.  reduce 111 (src line 626)
-
-
-state 171
-	metric_buckets_list:  INTLITERAL.    (112)
-
-	.  reduce 112 (src line 632)
-
-
-state 172
 	regex_pattern:  mark_pos DIV in_regex REGEX DIV.    (91)
 
 	.  reduce 91 (src line 498)
 
 
+state 166
+	delete_stmt:  mark_pos DEL postfix_expr AFTER DURATIONLITERAL.    (117)
+
+	.  reduce 117 (src line 662)
+
+
+state 167
+	metric_by_spec:  BY metric_by_expr_list.    (106)
+	metric_by_expr_list:  metric_by_expr_list.COMMA id_or_string 
+
+	COMMA  shift 176
+	.  reduce 106 (src line 588)
+
+
+state 168
+	metric_by_expr_list:  id_or_string.    (107)
+
+	.  reduce 107 (src line 595)
+
+
+state 169
+	id_or_string:  ID.    (119)
+
+	.  reduce 119 (src line 673)
+
+
+state 170
+	id_or_string:  STRING.    (120)
+
+	.  reduce 120 (src line 678)
+
+
+state 171
+	metric_as_spec:  AS STRING.    (109)
+
+	.  reduce 109 (src line 609)
+
+
+state 172
+	metric_buckets_spec:  BUCKETS metric_buckets_list.    (110)
+	metric_buckets_list:  metric_buckets_list.COMMA FLOATLITERAL 
+	metric_buckets_list:  metric_buckets_list.COMMA INTLITERAL 
+
+	COMMA  shift 177
+	.  reduce 110 (src line 617)
+
+
 state 173
+	metric_buckets_list:  FLOATLITERAL.    (111)
+
+	.  reduce 111 (src line 623)
+
+
+state 174
+	metric_buckets_list:  INTLITERAL.    (112)
+
+	.  reduce 112 (src line 629)
+
+
+state 175
 	arg_expr_list:  arg_expr_list COMMA arg_expr.    (88)
 
 	.  reduce 88 (src line 483)
 
 
-state 174
+state 176
 	metric_by_expr_list:  metric_by_expr_list COMMA.id_or_string 
 
-	STRING  shift 167
-	ID  shift 166
+	STRING  shift 170
+	ID  shift 169
 	.  error
 
-	id_or_string  goto 176
+	id_or_string  goto 178
 
-state 175
+state 177
 	metric_buckets_list:  metric_buckets_list COMMA.FLOATLITERAL 
 	metric_buckets_list:  metric_buckets_list COMMA.INTLITERAL 
 
-	INTLITERAL  shift 178
-	FLOATLITERAL  shift 177
+	INTLITERAL  shift 180
+	FLOATLITERAL  shift 179
 	.  error
 
 
-state 176
+state 178
 	metric_by_expr_list:  metric_by_expr_list COMMA id_or_string.    (108)
 
-	.  reduce 108 (src line 604)
+	.  reduce 108 (src line 601)
 
 
-state 177
+state 179
 	metric_buckets_list:  metric_buckets_list COMMA FLOATLITERAL.    (113)
 
-	.  reduce 113 (src line 637)
+	.  reduce 113 (src line 634)
 
 
-state 178
+state 180
 	metric_buckets_list:  metric_buckets_list COMMA INTLITERAL.    (114)
 
-	.  reduce 114 (src line 642)
+	.  reduce 114 (src line 639)
 
 
 65 terminals, 53 nonterminals
-125 grammar rules, 179/16000 states
+125 grammar rules, 181/16000 states
 0 shift/reduce, 0 reduce/reduce conflicts reported
 102 working sets used
-memory: parser 344/240000
-142 extra closures
-295 shift entries, 9 exceptions
-107 goto entries
-186 entries saved by goto default
-Optimizer space used: output 239/240000
-239 table entries, 0 zero
-maximum spread: 65, maximum offset: 174
+memory: parser 388/240000
+165 extra closures
+279 shift entries, 13 exceptions
+113 goto entries
+192 entries saved by goto default
+Optimizer space used: output 242/240000
+242 table entries, 0 zero
+maximum spread: 65, maximum offset: 176


### PR DESCRIPTION
The parser was incorrectly setting a position based on the token position at
the end of a production.  We must select the entire production so we must
mark_pos first and then merge the mark and current pos when setting positions.