### PR TITLE
Skip over \r when decoding a line of text from a log.

### DIFF
--- a/internal/tailer/logstream/decode.go
+++ b/internal/tailer/logstream/decode.go
@@ -16,7 +16,7 @@ import (
 // logLines counts the number of lines read per log file
 var logLines = expvar.NewMap("log_lines_total")
 
-// decodeAndSend transforms the byte addary `b` into unicode in `partial`, sending to the llp as each newline is decoded.
+// decodeAndSend transforms the byte array `b` into unicode in `partial`, sending to the llp as each newline is decoded.
 func decodeAndSend(ctx context.Context, lines chan<- *logline.LogLine, pathname string, n int, b []byte, partial *bytes.Buffer) {
 	var (
 		rune  rune
@@ -24,11 +24,20 @@ func decodeAndSend(ctx context.Context, lines chan<- *logline.LogLine, pathname 
 	)
 	for i := 0; i < len(b) && i < n; i += width {
 		rune, width = utf8.DecodeRune(b[i:])
+		// Most file-based log sources will end with \n on Unixlike systems.
+		// On Windows they appear to be both \r\n.  syslog disallows \r (and \t
+		// and others) and writes them escaped, per syslog(7).  [RFC
+		// 3164](https://www.ietf.org/rfc/rfc3164.txt) disallows newlines in
+		// the message: "The MSG part of the syslog packet MUST contain visible
+		// (printing) characters."  So for now let's assume that a \r only
+		// occurs at the end of a line anyway, and we can just eat it.
 		switch {
-		case rune != '\n':
-			partial.WriteRune(rune)
-		default:
+		case rune == '\r':
+			// nom
+		case rune == '\n':
 			sendLine(ctx, pathname, partial, lines)
+		default:
+			partial.WriteRune(rune)
 		}
 	}
 }


### PR DESCRIPTION
Fixe: #518, #324