### PR TITLE
Support IP stream and datagram sockets.

### DIFF
--- a/internal/tailer/tail.go
+++ b/internal/tailer/tail.go
@@ -206,7 +206,7 @@ func (t *Tailer) AddPattern(pattern string) error {
 	switch u.Scheme {
 	default:
 		return fmt.Errorf("unsupported URL scheme %q in path pattern %q", u.Scheme, pattern)
-	case "unix", "unixgram":
+	case "unix", "unixgram", "tcp", "udp":
 		// Keep the scheme.
 		t.socketPaths = append(t.socketPaths, pattern)
 		return nil

--- a/internal/testutil/port.go
+++ b/internal/testutil/port.go
@@ -1,0 +1,22 @@
+// Copyright 2021 Google Inc. All Rights Reserved.
+// This file is available under the Apache license.
+package testutil
+
+import (
+	"net"
+	"testing"
+)
+
+func FreePort(tb testing.TB) int {
+	tb.Helper()
+	addr, err := net.ResolveTCPAddr("tcp", "[::]:0")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}


### PR DESCRIPTION
Now we can listen on a host/port and receive TCP or UDP logs, though I don't like it because it opens mtail up for more feature requests around security, but the new Interoperability document does suggest alternatives.