### PR TITLE
Add gosec scans to mtail CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,15 @@ jobs:
           fetch-depth: 0 # so that we get tags
       - run: make --debug container
 
+  gosec:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v2
+      - run: make gosec
+
   fuzz:
     runs-on: ubuntu-latest
     container:

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ gosec: gosec
 	docker run --rm -t \
 		-w /mtail \
 		-v $(CURDIR):/mtail \
-		securego/gosec /mtail/...
+		securego/gosec --exclude=G104 /mtail/...
 
 
 ###

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,15 @@ container: Dockerfile
 	    --build-arg build_date=$(shell date -Iseconds --utc) \
 	    .
 
+## Run gosec
+.PHONY: gosec
+gosec: gosec
+	docker run --rm -t \
+		-w /mtail \
+		-v $(CURDIR):/mtail \
+		securego/gosec /mtail/...
+
+
 ###
 ## Fuzz testing
 #

--- a/TODO
+++ b/TODO
@@ -81,9 +81,6 @@ ci: rerun failed tests to see if they're flaky
 Find out if OpenTelemetry is better than OpenCensus when creating no-op trace spans.
 
 
-run with gosec, and possibly annotate safe sections in code
-
-
 Test that when path/* is the logpathpattern that we handle log rotation, e.g. log -> log.1
  = how can this work, we can't tell the difference between log.1 being a rotation or a new log.  This could work if we can have a tailer-level registry of filenames currently with a goroutine.  But we don't know the name of the new file when filestream creates a new goroutine for the replacement; fd.Stat() doesn't return the new name of the file.
  - Workaround: warn when '*' is the last of a glob pattern.

--- a/cmd/mdot/main.go
+++ b/cmd/mdot/main.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/golang/glog"
@@ -131,7 +132,7 @@ func (d *dotter) VisitAfter(node ast.Node) ast.Node {
 }
 
 func makeDot(name string, w io.Writer) error {
-	f, err := os.Open(name)
+	f, err := os.Open(filepath.Clean(name))
 	if err != nil {
 		return err
 	}

--- a/cmd/mgen/main.go
+++ b/cmd/mgen/main.go
@@ -95,6 +95,7 @@ func rand(n int) (r int) {
 		a, _ := crand.Int(crand.Reader, big.NewInt(int64(n)))
 		r = int(a.Int64())
 	} else {
+		/* #nosec G404 */
 		r = mrand.Intn(n)
 	}
 	return

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -114,7 +114,7 @@ func (r *Runtime) LoadProgram(programPath string) error {
 		glog.V(2).Infof("Skipping %s due to file extension.", programPath)
 		return nil
 	}
-	f, err := os.OpenFile(programPath, os.O_RDONLY, 0600)
+	f, err := os.OpenFile(filepath.Clean(programPath), os.O_RDONLY, 0600)
 	if err != nil {
 		ProgLoadErrors.Add(name, 1)
 		return errors.Wrapf(err, "Failed to read program %q", programPath)

--- a/internal/testutil/fs.go
+++ b/internal/testutil/fs.go
@@ -6,6 +6,7 @@ package testutil
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -27,7 +28,7 @@ func TestTempDir(tb testing.TB) string {
 // TestOpenFile creates a new file called name and returns the opened file.
 func TestOpenFile(tb testing.TB, name string) *os.File {
 	tb.Helper()
-	f, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	f, err := os.OpenFile(filepath.Clean(name), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -37,7 +38,7 @@ func TestOpenFile(tb testing.TB, name string) *os.File {
 // OpenLogFile creates a new file that emulates being a log.
 func OpenLogFile(tb testing.TB, name string) *os.File {
 	tb.Helper()
-	f, err := os.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_WRONLY|os.O_APPEND, 0600)
+	f, err := os.OpenFile(filepath.Clean(name), os.O_CREATE|os.O_TRUNC|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		tb.Fatal(err)
 	}


### PR DESCRIPTION
Hi maintainers! 
I work at [Bison Trails](https://bisontrails.co/). We're doing an internal hackathon this week.

Our team loves `mtail`, but it got flagged during a recent security review. Our team voted to use our hackathon time to patch vulnerabilities in our favorite OSS tools and specifically to try to get `mtail` approved for usage within our organization. 

## What's here:
- adds `gosec` security scans to github actions
- addresses the HIGH + MEDIUM severity issues from `gosec` scan

## Impact: 
These changes should improve `mtail`'s security posture. We identified these vulnerabilities using [Salus](https://github.com/coinbase/salus) and the [OSSF scorecard](https://github.com/ossf/scorecard). The specific issues I am hoping to address here are:
```
[/mtail/cmd/mgen/main.go:98] - G404 (CWE-338): Use of weak random number generator (math/rand instead of crypto/rand) (Confidence: MEDIUM, Severity: HIGH)
    97: 	} else {
  > 98: 		r = mrand.Intn(n)
    99: 	}



[/mtail/internal/testutil/fs.go:40] - G304 (CWE-22): Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
    39: 	tb.Helper()
  > 40: 	f, err := os.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_WRONLY|os.O_APPEND, 0600)
    41: 	if err != nil {



[/mtail/internal/testutil/fs.go:30] - G304 (CWE-22): Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
    29: 	tb.Helper()
  > 30: 	f, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
    31: 	if err != nil {



[/mtail/internal/runtime/runtime.go:117] - G304 (CWE-22): Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
    116: 	}
  > 117: 	f, err := os.OpenFile(programPath, os.O_RDONLY, 0600)
    118: 	if err != nil {



[/mtail/cmd/mdot/main.go:134] - G304 (CWE-22): Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
    133: func makeDot(name string, w io.Writer) error {
  > 134: 	f, err := os.Open(name)
    135: 	if err != nil {

```

## What's next:
- figure out what to do with the LOW severity issues


Thank you so much for your work building and maintaining `mtail`, and thank you for taking the time to look at these proposed changes!


