### PR TITLE
examples/apache_metrics.mtail: fix http_request_duration_seconds division

### DIFF
--- a/examples/apache_metrics.mtail
+++ b/examples/apache_metrics.mtail
@@ -26,7 +26,7 @@ histogram http_request_duration_seconds by server_port, handler, method, code, p
   ###
   # HTTP Requests with histogram buckets.
   #
-  http_request_duration_seconds[$server_port][$handler][$method][$code][$protocol] = $time_us / 1000000
+  http_request_duration_seconds[$server_port][$handler][$method][$code][$protocol] = $time_us / 1000000.0
 
   ###
   # Sent/Received bytes.


### PR DESCRIPTION
We need to use floating point division, instead of integer division,
otherwise the values end up as wrong and unexpected numbers in the
histogram's buckets.