### PR TITLE
Add -one_shot_format to support Prometheus one shot output

### DIFF
--- a/cmd/mtail/main.go
+++ b/cmd/mtail/main.go
@@ -48,7 +48,7 @@ var (
 
 	// Compiler behaviour flags.
 	oneShot       = flag.Bool("one_shot", false, "Compile the programs, then read the contents of the provided logs from start until EOF, print the values of the metrics store in the given format and exit. This is a debugging flag only, not for production use.")
-	oneShotFormat = flag.String("format", "json", "Format to use with -one_shot. This is a debugging flag only, not for production use. Supported formats: json, prometheus.")
+	oneShotFormat = flag.String("one_shot_format", "json", "Format to use with -one_shot. This is a debugging flag only, not for production use. Supported formats: json, prometheus.")
 	compileOnly   = flag.Bool("compile_only", false, "Compile programs only, do not load the virtual machine.")
 	dumpAst       = flag.Bool("dump_ast", false, "Dump AST of programs after parse (to INFO log).")
 	dumpAstTypes  = flag.Bool("dump_ast_types", false, "Dump AST of programs with type annotation after typecheck (to INFO log).")


### PR DESCRIPTION
This provides an easier to develop mtail programs because the Prometheus
exposition format is more concise.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>