### PR TITLE
Unify returns Type

### DIFF
--- a/internal/runtime/compiler/checker/checker.go
+++ b/internal/runtime/compiler/checker/checker.go
@@ -333,13 +333,13 @@ func (c *checker) VisitAfter(node ast.Node) ast.Node {
 	case *ast.BinaryExpr:
 		var rType types.Type
 		lT := n.LHS.Type()
-		if types.IsErrorType(lT) {
-			n.SetType(types.Error)
+		if types.IsTypeError(lT) {
+			n.SetType(lT)
 			return n
 		}
 		rT := n.RHS.Type()
-		if types.IsErrorType(rT) {
-			n.SetType(types.Error)
+		if types.IsTypeError(rT) {
+			n.SetType(rT)
 			return n
 		}
 		switch n.Op {
@@ -349,7 +349,7 @@ func (c *checker) VisitAfter(node ast.Node) ast.Node {
 			// Tl <= Tr , Tr <= Tl
 			// ⇒ O ⊢ e : lub(Tl, Tr)
 			rType = types.LeastUpperBound(lT, rT)
-			if types.IsErrorType(rType) {
+			if types.IsTypeError(rType) {
 				c.errors.Add(n.Pos(), fmt.Sprintf("type mismatch: %q and %q have no common type", lT, rT))
 				n.SetType(rType)
 				return n
@@ -412,7 +412,7 @@ func (c *checker) VisitAfter(node ast.Node) ast.Node {
 			rType = types.Bool
 			gotType := types.Function(lT, rT, rType)
 			t := types.LeastUpperBound(lT, rT)
-			if types.IsErrorType(t) {
+			if types.IsTypeError(t) {
 				c.errors.Add(n.Pos(), fmt.Sprintf("Can't compare LHS of type %s with RHS of type %s.", lT, rT))
 				n.SetType(t)
 				return n
@@ -489,8 +489,8 @@ func (c *checker) VisitAfter(node ast.Node) ast.Node {
 		return n
 
 	case *ast.UnaryExpr:
-		if types.IsErrorType(n.Expr.Type()) {
-			n.SetType(types.Error)
+		if types.IsTypeError(n.Expr.Type()) {
+			n.SetType(n.Expr.Type())
 			return n
 		}
 		switch n.Op {
@@ -560,8 +560,8 @@ func (c *checker) VisitAfter(node ast.Node) ast.Node {
 	case *ast.ExprList:
 		argTypes := []types.Type{}
 		for _, arg := range n.Children {
-			if types.IsErrorType(arg.Type()) {
-				n.SetType(types.Error)
+			if types.IsTypeError(arg.Type()) {
+				n.SetType(arg.Type())
 				return n
 			}
 			argTypes = append(argTypes, arg.Type())
@@ -579,8 +579,8 @@ func (c *checker) VisitAfter(node ast.Node) ast.Node {
 
 		argTypes := []types.Type{}
 		for _, arg := range exprList.Children {
-			if types.IsErrorType(arg.Type()) {
-				n.SetType(types.Error)
+			if types.IsTypeError(arg.Type()) {
+				n.SetType(arg.Type())
 				return n
 			}
 			argTypes = append(argTypes, arg.Type())

--- a/internal/runtime/compiler/checker/checker.go
+++ b/internal/runtime/compiler/checker/checker.go
@@ -561,9 +561,9 @@ func (c *checker) VisitAfter(node ast.Node) ast.Node {
 				return n
 			}
 
-			rType := types.Int
-			wantType := types.Function(rType, rType)
-			gotType := types.Function(n.Expr.Type(), types.NewVariable())
+			rType := types.NewVariable()
+			wantType := types.Function(types.Int, types.Int)
+			gotType := types.Function(n.Expr.Type(), rType)
 			uType := types.Unify(wantType, gotType)
 			var err *types.TypeError
 			if types.AsTypeError(uType, &err) {

--- a/internal/runtime/compiler/checker/checker_test.go
+++ b/internal/runtime/compiler/checker/checker_test.go
@@ -287,7 +287,7 @@ m`,
 		`text l
 l++
 `,
-		[]string{"len invalid args:2:1: Expecting an Int for INC, not String."},
+		[]string{"len invalid args:2:1: type mismatch: expecting an Int for INC, not String."},
 	},
 
 	{
@@ -302,7 +302,7 @@ l++
 		`gauge l
 l++=l
 `,
-		[]string{"assign to rvalue:2:1-3: Can't assign to this expression on the left."},
+		[]string{"assign to rvalue:2:1-3: Can't assign to expression on left; expecting a variable here."},
 	},
 
 	{
@@ -316,7 +316,7 @@ l++=l
 		"dec non var",
 		`strptime("", "")--
 `,
-		[]string{"dec non var:1:1-16: Expecting a variable here."},
+		[]string{"dec non var:1:1-16: Can't assign to expression; expecting a variable here."},
 	},
 
 	// TODO(jaq): This is an instance of bug #190, the capref is ambiguous.
@@ -328,7 +328,7 @@ l++=l
 		"cmp to None",
 		`strptime("","")<5{}
 `,
-		[]string{"cmp to None:1:1-17: Can't compare LHS of type None with RHS of type Int."},
+		[]string{"cmp to None:1:1-17: type mismatch: can't apply LT to LHS of type \"None\" with RHS of type \"Int\"."},
 	},
 
 	{

--- a/internal/runtime/compiler/types/types.go
+++ b/internal/runtime/compiler/types/types.go
@@ -334,7 +334,7 @@ func Unify(a, b Type) error {
 			}
 		case *Operator:
 			if occursInType(a2, b2) {
-				return fmt.Errorf("%w on %v and %v", ErrRecursiveUnification, a2, b2)
+				return &TypeError{ErrRecursiveUnification, a2, b2}
 			}
 			glog.V(2).Infof("Making %q type %q", a2, b1)
 			a2.SetInstance(b1)

--- a/internal/runtime/compiler/types/types.go
+++ b/internal/runtime/compiler/types/types.go
@@ -33,7 +33,7 @@ type TypeError struct {
 var (
 	ErrRecursiveUnification = errors.New("recursive unification error")
 	ErrTypeMismatch         = errors.New("type mismatch")
-	ErrInternalUnification  = errors.New("internal unification error")
+	ErrInternal             = errors.New("internal error")
 )
 
 func (e *TypeError) Root() Type {
@@ -61,6 +61,10 @@ func (e *TypeError) String() string {
 
 func (e TypeError) Error() string {
 	return e.String()
+}
+
+func (e *TypeError) Unwrap() error {
+	return e.error
 }
 
 // AsTypeError behaves like `errors.As`, attempting to cast the type `t` into a
@@ -205,14 +209,15 @@ func IsComplete(t Type) bool {
 
 // Builtin type constants.
 var (
-	Error   = &TypeError{}
-	Undef   = &Operator{"Undef", []Type{}}
-	None    = &Operator{"None", []Type{}}
-	Bool    = &Operator{"Bool", []Type{}}
-	Int     = &Operator{"Int", []Type{}}
-	Float   = &Operator{"Float", []Type{}}
-	String  = &Operator{"String", []Type{}}
-	Pattern = &Operator{"Pattern", []Type{}}
+	Error         = &TypeError{}
+	InternalError = &TypeError{error: ErrInternal}
+	Undef         = &Operator{"Undef", []Type{}}
+	None          = &Operator{"None", []Type{}}
+	Bool          = &Operator{"Bool", []Type{}}
+	Int           = &Operator{"Int", []Type{}}
+	Float         = &Operator{"Float", []Type{}}
+	String        = &Operator{"String", []Type{}}
+	Pattern       = &Operator{"Pattern", []Type{}}
 	// TODO(jaq): use composite type so we can typecheck the bucket directly, e.g. hist[j] = i.
 	Buckets = &Operator{"Buckets", []Type{}}
 )
@@ -368,7 +373,7 @@ func Unify(a, b Type) Type {
 				}
 				var ok bool
 				if rType, ok = t.(*Operator); !ok {
-					return &TypeError{ErrInternalUnification, a2, b2}
+					return &TypeError{ErrInternal, a2, b2}
 				}
 			} else {
 				rType = &Operator{a2.Name, []Type{}}
@@ -385,7 +390,7 @@ func Unify(a, b Type) Type {
 			return rType
 		}
 	}
-	return &TypeError{ErrInternalUnification, a, b}
+	return &TypeError{ErrInternal, a, b}
 }
 
 // LeastUpperBound returns the smallest type that may contain both parameter types.

--- a/internal/runtime/compiler/types/types.go
+++ b/internal/runtime/compiler/types/types.go
@@ -138,7 +138,7 @@ type Operator struct {
 	// Args is the sequence of types that are parameters to this type.  They
 	// may be fully bound type operators, or partially defined (i.e. contain
 	// TypeVariables) in which case they represent polymorphism in the operator
-	// they are argyments to.
+	// they are arguments to.
 	Args []Type
 }
 
@@ -178,7 +178,8 @@ func IsFunction(t Type) bool {
 }
 
 // Dimension is a convenience method which instantiates a new Dimension type
-// scheme, with the given args as the dimensions of the type.
+// scheme, with the given args as the dimensions of the type.  (This type looks
+// a lot like a Product type.)
 func Dimension(args ...Type) *Operator {
 	return &Operator{"⨯", args}
 }

--- a/internal/runtime/compiler/types/types_test.go
+++ b/internal/runtime/compiler/types/types_test.go
@@ -128,7 +128,7 @@ var typeUnificationTests = []struct {
 		Pattern, Int,
 		Bool,
 	},
-	// Undef secedes to oether
+	// Undef secedes to other
 	{
 		Undef, Int,
 		Int,
@@ -140,6 +140,15 @@ var typeUnificationTests = []struct {
 	{
 		Undef, Undef,
 		Undef,
+	},
+	// TypeError supercedes to other.
+	{
+		Pattern, &TypeError{},
+		&TypeError{},
+	},
+	{
+		&TypeError{}, Float,
+		&TypeError{},
 	},
 }
 
@@ -328,5 +337,10 @@ func TestTypeEquals(t *testing.T) {
 	testutil.FatalIfErr(t, err)
 	if !Equals(t3, Int) {
 		t.Error("unified variable and const not same")
+	}
+
+	typeErr := &TypeError{}
+	if Equals(typeErr, typeErr) {
+		t.Error("error type equals itself")
 	}
 }

--- a/internal/runtime/compiler/types/types_test.go
+++ b/internal/runtime/compiler/types/types_test.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -342,5 +343,21 @@ func TestTypeEquals(t *testing.T) {
 	typeErr := &TypeError{}
 	if Equals(typeErr, typeErr) {
 		t.Error("error type equals itself")
+	}
+}
+
+func TestAsTypeError(t *testing.T) {
+	e := &TypeError{ErrTypeMismatch, Int, Bool}
+
+	var e1 *TypeError
+	if !AsTypeError(e, &e1) {
+		t.Errorf("want type error, got: %#v", e1)
+	}
+	if !errors.Is(e1.error, ErrTypeMismatch) {
+		t.Errorf("want ErrTypeMismatch, got: %#v", e1.error)
+	}
+	if e.expected != e1.expected || e.received != e1.received {
+		t.Errorf("want %#v, got: %#v", e.expected, e1.expected)
+		t.Errorf("want %#v, got: %#v", e.received, e1.received)
 	}
 }

--- a/internal/testutil/diff.go
+++ b/internal/testutil/diff.go
@@ -39,8 +39,8 @@ func ExpectNoDiff(tb testing.TB, a, b interface{}, opts ...cmp.Option) bool {
 	tb.Helper()
 	if diff := Diff(a, b, opts...); diff != "" {
 		tb.Errorf("Unexpected diff, -want +got:\n%s", diff)
-		tb.Logf("expected:\n%#V", a)
-		tb.Logf("received:\n%#V", b)
+		tb.Logf("expected:\n%#v", a)
+		tb.Logf("received:\n%#v", b)
 		return false
 	}
 	return true


### PR DESCRIPTION
Refactor type checking so that we can assign a type based on the returned value of `types.Unify()`.