### PR TITLE
Type reporting cleanup

### DIFF
--- a/internal/runtime/compiler/checker/checker.go
+++ b/internal/runtime/compiler/checker/checker.go
@@ -357,7 +357,7 @@ func (c *checker) VisitAfter(node ast.Node) ast.Node {
 			if types.AsTypeError(rType, &err) {
 				// Change the type mismatch error to make more sense in this context.
 				if goerrors.Is(err, types.ErrTypeMismatch) {
-					c.errors.Add(n.Pos(), fmt.Sprintf("type mismatch: can't apply %s to LHS of type %q with RHS of type %q.", parser.Kind(n.Op), lT, rT))
+					c.errors.Add(n.Pos(), fmt.Sprintf("type mismatch; can't apply %s to LHS of type %q with RHS of type %q.", parser.Kind(n.Op), lT, rT))
 				} else {
 					c.errors.Add(n.Pos(), err.Error())
 				}
@@ -501,7 +501,11 @@ func (c *checker) VisitAfter(node ast.Node) ast.Node {
 			uType := types.Unify(wantType, gotType)
 			var err *types.TypeError
 			if types.AsTypeError(uType, &err) {
-				c.errors.Add(n.Pos(), err.Error())
+				if goerrors.Is(err, types.ErrTypeMismatch) {
+					c.errors.Add(n.Pos(), fmt.Sprintf("%s for %s operator.", err, parser.Kind(n.Op)))
+				} else {
+					c.errors.Add(n.Pos(), err.Error())
+				}
 				n.SetType(err)
 				return n
 			}
@@ -597,7 +601,11 @@ func (c *checker) VisitAfter(node ast.Node) ast.Node {
 			uType := types.Unify(wantType, gotType)
 			var err *types.TypeError
 			if types.AsTypeError(uType, &err) {
-				c.errors.Add(n.Pos(), err.Error())
+				if goerrors.Is(err, types.ErrTypeMismatch) {
+					c.errors.Add(n.Pos(), fmt.Sprintf("type mismatch: MATCH expects Pattern, received %s", n.Expr.Type()))
+				} else {
+					c.errors.Add(n.Pos(), err.Error())
+				}
 				n.SetType(err)
 				return n
 			}

--- a/internal/runtime/compiler/checker/checker.go
+++ b/internal/runtime/compiler/checker/checker.go
@@ -238,9 +238,9 @@ func (c *checker) VisitBefore(node ast.Node) (ast.Visitor, ast.Node) {
 	return c, node
 }
 
-// checkSymbolUsage emits errors if any eligible symbols in the current scope
-// are not marked as used.
-func (c *checker) checkSymbolUsage() {
+// checkSymbolTable emits errors if any eligible symbols in the current scope
+// are not marked as used or have an invalid type.
+func (c *checker) checkSymbolTable() {
 	for _, sym := range c.scope.Symbols {
 		if !sym.Used {
 			// Users don't have control over the patterns given from decorators
@@ -276,7 +276,7 @@ func (c *checker) VisitAfter(node ast.Node) ast.Node {
 
 	switch n := node.(type) {
 	case *ast.StmtList:
-		c.checkSymbolUsage()
+		c.checkSymbolTable()
 		// Pop the scope
 		c.scope = n.Scope.Parent
 		return n
@@ -291,7 +291,7 @@ func (c *checker) VisitAfter(node ast.Node) ast.Node {
 		default:
 			c.errors.Add(n.Cond.Pos(), fmt.Sprintf("Can't interpret %s as a boolean expression here.\n\tTry using comparison operators to make the condition explicit.", n.Cond.Type()))
 		}
-		c.checkSymbolUsage()
+		c.checkSymbolTable()
 		// Pop the scope.
 		c.scope = n.Scope.Parent
 		return n

--- a/internal/runtime/compiler/checker/checker.go
+++ b/internal/runtime/compiler/checker/checker.go
@@ -579,7 +579,7 @@ func (c *checker) VisitAfter(node ast.Node) ast.Node {
 				return n
 			}
 			// After unification, the expr still has to be of Int type.
-			if !types.Equals(types.Int, uTypeOperator.Args[0]) {
+			if !types.OccursIn(types.Int, []types.Type{uTypeOperator.Args[0]}) {
 				c.errors.Add(n.Expr.Pos(), fmt.Sprintf("type mismatch: expecting an Int for %s, not %v.", parser.Kind(n.Op), n.Expr.Type()))
 				n.SetType(types.Error)
 				return n

--- a/internal/runtime/compiler/checker/checker_test.go
+++ b/internal/runtime/compiler/checker/checker_test.go
@@ -283,11 +283,11 @@ m`,
 	},
 
 	{
-		"len invalid args",
+		"inc invalid args",
 		`text l
 l++
 `,
-		[]string{"len invalid args:2:1: type mismatch: expecting an Int for INC, not String."},
+		[]string{"inc invalid args:2:1: type mismatch: expecting an Int for INC, not String."},
 	},
 
 	{

--- a/internal/runtime/compiler/types/types.go
+++ b/internal/runtime/compiler/types/types.go
@@ -394,6 +394,18 @@ func Unify(a, b Type) Type {
 	return &TypeError{ErrInternal, a, b}
 }
 
+var typeCoercions = []struct {
+	sub, sup Type
+}{
+	{Bool, Int},
+	{Bool, Float}, // contentious
+	{Int, Float},  // contentious
+	{Bool, String},
+	{Int, String},
+	{Float, String},
+	{String, Pattern},
+}
+
 // LeastUpperBound returns the smallest type that may contain both parameter types.
 func LeastUpperBound(a, b Type) Type {
 	a1, b1 := a.Root(), b.Root()
@@ -416,29 +428,19 @@ func LeastUpperBound(a, b Type) Type {
 	if Equals(b1, Undef) {
 		return a1
 	}
+
 	// Easy substitutions
-	if (Equals(a1, Float) && Equals(b1, Int)) ||
-		(Equals(b1, Float) && Equals(a1, Int)) {
-		return Float
+	for _, pair := range typeCoercions {
+		if (Equals(a1, pair.sub) && Equals(b1, pair.sup)) ||
+			(Equals(b1, pair.sub) && Equals(a1, pair.sup)) {
+			return pair.sup
+		}
 	}
-	if (Equals(a1, String) && Equals(b1, Int)) ||
-		(Equals(b1, String) && Equals(a1, Int)) ||
-		(Equals(a1, String) && Equals(b1, Float)) ||
-		(Equals(b1, String) && Equals(a1, Float)) {
-		return String
-	}
+	// TODO bogus?
+	// Patterns imply match status, which is boolean.
 	if (Equals(a1, Pattern) && Equals(b1, Bool)) ||
 		(Equals(a1, Bool) && Equals(b1, Pattern)) {
 		return Bool
-	}
-	if (Equals(a1, Bool) && Equals(b1, Int)) ||
-		(Equals(a1, Int) && Equals(b1, Bool)) {
-		return Int
-	}
-	// A string can be a pattern, but not vice versa.
-	if (Equals(a1, String) && Equals(b1, Pattern)) ||
-		(Equals(a1, Pattern) && Equals(b1, String)) {
-		return Pattern
 	}
 	// A pattern and an Int are Bool
 	if (Equals(a1, Pattern) && Equals(b1, Int)) ||

--- a/internal/runtime/compiler/types/types.go
+++ b/internal/runtime/compiler/types/types.go
@@ -270,7 +270,7 @@ func FreshType(t Type) Type {
 }
 
 // occursIn returns true if `v` is in any of `types`.
-func occursIn(v Type, types []Type) bool {
+func OccursIn(v Type, types []Type) bool {
 	for _, t2 := range types {
 		if occursInType(v, t2) {
 			return true
@@ -286,7 +286,7 @@ func occursInType(v Type, t2 Type) bool {
 		return true
 	}
 	if to, ok := root.(*Operator); ok {
-		return occursIn(v, to.Args)
+		return OccursIn(v, to.Args)
 	}
 	return false
 }

--- a/internal/runtime/compiler/types/types.go
+++ b/internal/runtime/compiler/types/types.go
@@ -353,6 +353,7 @@ func Unify(a, b Type) Type {
 	case *Operator:
 		switch b2 := b1.(type) {
 		case *Variable:
+			// reverse args to call above
 			t := Unify(b, a)
 			var e *TypeError
 			if AsTypeError(t, &e) {

--- a/internal/runtime/compiler/types/types.go
+++ b/internal/runtime/compiler/types/types.go
@@ -394,9 +394,12 @@ func Unify(a, b Type) Type {
 	return &TypeError{ErrInternal, a, b}
 }
 
-var typeCoercions = []struct {
+type TypeCoercion struct {
 	sub, sup Type
-}{
+}
+
+// type coercions for builtin types
+var typeCoercions = []TypeCoercion{
 	{Bool, Int},
 	{Bool, Float}, // contentious
 	{Int, Float},  // contentious

--- a/internal/runtime/compiler/types/types_test.go
+++ b/internal/runtime/compiler/types/types_test.go
@@ -163,7 +163,7 @@ func TestTypeUnification(t *testing.T) {
 				return
 			}
 			if !Equals(tc.expected, tU) {
-				t.Errorf("want %#v, got %#v", tc.expected, tU)
+				t.Errorf("want %q, got %q", tc.expected, tU)
 			}
 		})
 	}

--- a/internal/runtime/runtime_integration_test.go
+++ b/internal/runtime/runtime_integration_test.go
@@ -1052,6 +1052,7 @@ a
 }
 
 func TestRuntimeEndToEnd(t *testing.T) {
+	testutil.SkipIfShort(t)
 	if testing.Verbose() {
 		testutil.SetFlag(t, "vmodule", "vm=2,loader=2,checker=2")
 	}


### PR DESCRIPTION
Clean up the error messages used in type mismatch reporting.

Standardise the form used when constructing types for unification.