### PR TITLE
Fix permissions and triggers for the dependabot auto merge.

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -5,24 +5,25 @@ name: automerge
 on:
   pull_request_target:
     types:
+      # Dependabot will label the PR
       - labeled
+      # Dependabot has rebased the PR
+      - synchronize
 jobs:
   approve-and-merge-dependabot:
     if: github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies')
     runs-on: ubuntu-latest
-    # TODO(jaq): The enable automerge permission is incorrect, pending solution
-    # in https://github.community/t/what-permission-does-a-github-action-need-to-call-graphql-enablepullrequestautomerge/197708
-    # permissions:
-    #   # wait-on-check requires check read
-    #   checks: read
-    #   # enable-automerge is a graphql query, not REST, so isn't documented,
-    #   # except in a mention in
-    #   # https://github.blog/changelog/2021-02-04-pull-request-auto-merge-is-now-generally-available/
-    #   # which says "can only be enabled by users with permissino to merge"; the
-    #   # REST documentation says you need contents: write to perform a merge.
-    #   contents: write
-    #   # auto-approve-action requires write on actions
-    #   actions: write
+    permissions:
+      # wait-on-check requires check read
+      checks: read
+      # enable-automerge is a graphql query, not REST, so isn't documented,
+      # except in a mention in
+      # https://github.blog/changelog/2021-02-04-pull-request-auto-merge-is-now-generally-available/
+      # which says "can only be enabled by users with permissino to merge"; the
+      # REST documentation says you need contents: write to perform a merge.
+      contents: write
+      # auto-approve-action requires write on pull-requests
+      pull-requests: write
     steps:
 
     # Enable auto-merge *before* issuing an approval.


### PR DESCRIPTION
We now have the correct permissions to reduce the surface of the token.