### PR TITLE
Split pollInterval option to reduce filepath.Glob overhead

### DIFF
--- a/cmd/mtail/main.go
+++ b/cmd/mtail/main.go
@@ -62,8 +62,8 @@ var (
 	logRuntimeErrors     = flag.Bool("vm_logs_runtime_errors", true, "Enables logging of runtime errors to the standard log.  Set to false to only have the errors printed to the HTTP console.")
 
 	// Ops flags.
-	pollInterval                = flag.Duration("poll_interval", 250*time.Millisecond, "Set the interval to poll all log files for list; must be positive, or zero to disable polling.  With polling mode, only the files found at mtail startup will be polled.")
-	pollLogInterval             = flag.Duration("poll_log_interval", 250*time.Millisecond, "Set the interval to poll all log files for data; must be positive, or zero to disable polling.  With polling mode, only the files found at mtail startup will be polled.")
+	pollInterval                = flag.Duration("poll_interval", 250*time.Millisecond, "Set the interval to poll each log file for data; must be positive, or zero to disable polling.  With polling mode, only the files found at mtail startup will be polled.")
+	pollLogInterval             = flag.Duration("poll_log_interval", 250*time.Millisecond, "Set the interval to find all matched log files for polling; must be positive, or zero to disable polling.  With polling mode, only the files found at mtail startup will be polled.")
 	expiredMetricGcTickInterval = flag.Duration("expired_metrics_gc_interval", time.Hour, "interval between expired metric garbage collection runs")
 	staleLogGcTickInterval      = flag.Duration("stale_log_gc_interval", time.Hour, "interval between stale log garbage collection runs")
 	metricPushInterval          = flag.Duration("metric_push_interval", time.Minute, "interval between metric pushes to passive collectors")
@@ -145,12 +145,12 @@ func main() {
 		trace.ApplyConfig(trace.Config{DefaultSampler: trace.ProbabilitySampler(1 / float64(*traceSamplePeriod))})
 	}
 	if *pollInterval == 0 {
-		glog.Infof("no poll interval specified; defaulting to 250ms poll")
+		glog.Infof("no poll log data interval specified; defaulting to 250ms poll")
 		*pollInterval = time.Millisecond * 250
 	}
 	if *pollLogInterval == 0 {
-		glog.Infof("no poll interval specified; defaulting to pollInterval")
-		*pollLogInterval = *pollInterval
+		glog.Infof("no poll log pattern interval specified; defaulting to 250ms poll")
+		*pollLogInterval = time.Millisecond * 250
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -183,8 +183,8 @@ func main() {
 		opts = append(opts, mtail.StaleLogGcWaker(staleLogGcWaker))
 	}
 	if *pollInterval > 0 {
-		logPatternPollWaker := waker.NewTimed(ctx, *pollInterval)
-		logStreamPollWaker := waker.NewTimed(ctx, *pollLogInterval)
+		logStreamPollWaker := waker.NewTimed(ctx, *pollInterval)
+		logPatternPollWaker := waker.NewTimed(ctx, *pollLogInterval)
 		opts = append(opts, mtail.LogPatternPollWaker(logPatternPollWaker), mtail.LogstreamPollWaker(logStreamPollWaker))
 	}
 	if *unixSocket == "" {

--- a/docs/Deploying.md
+++ b/docs/Deploying.md
@@ -39,13 +39,13 @@ want to tail.  This includes named pipes.
 
 ### Polling the file system
 
-`mtail` polls every `--poll_interval`, or 250ms by default, the supplied `--logs` patterns for newly created or deleted log pathnames.
+`mtail` polls matched log files every `--poll_log_interval`, or 250ms by default, the supplied `--logs` patterns for newly created or deleted log pathnames.
 
-Known and active logs are read until EOF every 250ms by default.
+Known and active logs are read until EOF every `--poll_interval`, or 250ms by default.
 
 Example:
 ```
-mtail --progs /etc/mtail --logs /var/log/syslog --poll_interval 250ms
+mtail --progs /etc/mtail --logs /var/log/syslog --poll_interval 250ms --poll_log_interval 250ms
 ```
 
 

--- a/internal/mtail/testing.go
+++ b/internal/mtail/testing.go
@@ -97,7 +97,10 @@ func (ts *TestServer) Start() func() {
 func (ts *TestServer) PollWatched(n int) {
 	glog.Info("Testserver starting poll")
 	glog.Infof("TestServer polling filesystem patterns")
-	if err := ts.t.Poll(); err != nil {
+	if err := ts.t.PollLogPatterns(); err != nil {
+		glog.Info(err)
+	}
+	if err := ts.t.PollLogStreams(); err != nil {
 		glog.Info(err)
 	}
 	glog.Infof("TestServer reloading programs")

--- a/internal/tailer/tail_test.go
+++ b/internal/tailer/tail_test.go
@@ -154,21 +154,25 @@ func TestTailerOpenRetries(t *testing.T) {
 	if err := ta.TailPath(logfile); err == nil || !os.IsPermission(err) {
 		t.Fatalf("Expected a permission denied error here: %s", err)
 	}
-	testutil.FatalIfErr(t, ta.Poll())
+	testutil.FatalIfErr(t, ta.PollLogPatterns())
+	testutil.FatalIfErr(t, ta.PollLogStreams())
 	glog.Info("remove")
 	if err := os.Remove(logfile); err != nil {
 		t.Fatal(err)
 	}
-	testutil.FatalIfErr(t, ta.Poll())
+	testutil.FatalIfErr(t, ta.PollLogPatterns())
+	testutil.FatalIfErr(t, ta.PollLogStreams())
 	glog.Info("openfile")
 	f, err := os.OpenFile(logfile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0)
 	testutil.FatalIfErr(t, err)
-	testutil.FatalIfErr(t, ta.Poll())
+	testutil.FatalIfErr(t, ta.PollLogPatterns())
+	testutil.FatalIfErr(t, ta.PollLogStreams())
 	glog.Info("chmod")
 	if err := os.Chmod(logfile, 0666); err != nil {
 		t.Fatal(err)
 	}
-	testutil.FatalIfErr(t, ta.Poll())
+	testutil.FatalIfErr(t, ta.PollLogPatterns())
+	testutil.FatalIfErr(t, ta.PollLogStreams())
 	awaken(1) // force sync to EOF
 	glog.Info("write string")
 	testutil.WriteString(t, f, "\n")


### PR DESCRIPTION

Hi,  i'm using mtail to monitor the docker logs of the machine, and every machine has 500+ matched log files .  Below is the configuration:

```
mtail --progs /etc/mtail --logs "/home/docker/logs/*/*/*/*/*/platform-*.log" --expired_metrics_gc_interval 10m
```

I notice that mtail always keeps more than 60% cpu usage, **even no logs produced**.   After profiling the process, i found that the primary reason is **tailer#PollLogPatterns**  calls frequently (run per 250ms by default).  We can't separately control the interval of poll-log-pattern or poll-log-stream.  I tried to split the option and deployed the fixed mtail on production for a few weeks, and it works well.  Could you help me to review the feature? 

