### PR TITLE
If WriteString writes to an actual file, then Sync to disk.

### DIFF
--- a/internal/tailer/tail_test.go
+++ b/internal/tailer/tail_test.go
@@ -85,7 +85,6 @@ func TestHandleLogTruncate(t *testing.T) {
 
 	testutil.WriteString(t, f, "a\nb\nc\n")
 	awaken(1)
-	awaken(1) // double sync to ensure that a whole pass through the filestream has occurred
 
 	if err := f.Truncate(0); err != nil {
 		t.Fatal(err)

--- a/internal/testutil/file.go
+++ b/internal/testutil/file.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"io"
+	"os"
 	"testing"
 
 	"github.com/golang/glog"
@@ -12,5 +13,15 @@ func WriteString(tb testing.TB, f io.StringWriter, str string) int {
 	n, err := f.WriteString(str)
 	FatalIfErr(tb, err)
 	glog.Infof("Wrote %d bytes", n)
+	// If this is a regular file (not a pipe or other StringWriter) then ensure
+	// it's flushed to disk, to guarantee the write happens-before this
+	// returns.
+	if v, ok := f.(*os.File); ok {
+		fi, err := v.Stat()
+		FatalIfErr(tb, err)
+		if fi.Mode().IsRegular() {
+			FatalIfErr(tb, v.Sync())
+		}
+	}
 	return n
 }


### PR DESCRIPTION
This avoids dual awaken races because we're making sure the data is where we
thought it was.

Thanks to @Loyilee for discovering this issue.

Issue: #603