### PR TITLE
Don't run a second goroutine on the logstreamWaker.

### DIFF
--- a/internal/mtail/testing.go
+++ b/internal/mtail/testing.go
@@ -97,10 +97,7 @@ func (ts *TestServer) Start() func() {
 func (ts *TestServer) PollWatched(n int) {
 	glog.Info("Testserver starting poll")
 	glog.Infof("TestServer polling filesystem patterns")
-	if err := ts.t.PollLogPatterns(); err != nil {
-		glog.Info(err)
-	}
-	if err := ts.t.PollLogStreams(); err != nil {
+	if err := ts.t.Poll(); err != nil {
 		glog.Info(err)
 	}
 	glog.Infof("TestServer reloading programs")
@@ -108,7 +105,7 @@ func (ts *TestServer) PollWatched(n int) {
 		glog.Info(err)
 	}
 	glog.Infof("TestServer tailer gcing")
-	if err := ts.t.Gc(); err != nil {
+	if err := ts.t.ExpireStaleLogstreams(); err != nil {
 		glog.Info(err)
 	}
 	glog.Info("TestServer waking idle routines")

--- a/internal/tailer/tail.go
+++ b/internal/tailer/tail.go
@@ -95,7 +95,7 @@ type staleLogGcWaker struct {
 }
 
 func (opt staleLogGcWaker) apply(t *Tailer) error {
-	t.StartGcLoop(opt.Waker)
+	t.StartStaleLogstreamExpirationLoop(opt.Waker)
 	return nil
 }
 
@@ -123,7 +123,7 @@ type logstreamPollWaker struct {
 }
 
 func (opt logstreamPollWaker) apply(t *Tailer) error {
-	t.StartLogStreamPollLoop(opt.Waker)
+	t.logstreamPollWaker = opt.Waker
 	return nil
 }
 
@@ -284,8 +284,8 @@ func (t *Tailer) TailPath(pathname string) error {
 	return nil
 }
 
-// Gc removes logstreams that have had no reads for 1h or more.
-func (t *Tailer) Gc() error {
+// ExpireStaleLogstreams removes logstreams that have had no reads for 1h or more.
+func (t *Tailer) ExpireStaleLogstreams() error {
 	t.logstreamsMu.Lock()
 	defer t.logstreamsMu.Unlock()
 	for _, v := range t.logstreams {
@@ -296,8 +296,8 @@ func (t *Tailer) Gc() error {
 	return nil
 }
 
-// StartGcLoop runs a permanent goroutine to expire metrics every duration.
-func (t *Tailer) StartGcLoop(waker waker.Waker) {
+// StartStaleLogstreamExpirationLoop runs a permanent goroutine to expire stale logstreams.
+func (t *Tailer) StartStaleLogstreamExpirationLoop(waker waker.Waker) {
 	if waker == nil {
 		glog.Info("Log handle expiration disabled")
 		return
@@ -316,7 +316,7 @@ func (t *Tailer) StartGcLoop(waker waker.Waker) {
 			case <-t.ctx.Done():
 				return
 			case <-waker.Wake():
-				if err := t.Gc(); err != nil {
+				if err := t.ExpireStaleLogstreams(); err != nil {
 					glog.Info(err)
 				}
 			}
@@ -344,7 +344,7 @@ func (t *Tailer) StartLogPatternPollLoop(waker waker.Waker) {
 			case <-t.ctx.Done():
 				return
 			case <-waker.Wake():
-				if err := t.PollLogPatterns(); err != nil {
+				if err := t.Poll(); err != nil {
 					glog.Info(err)
 				}
 			}
@@ -382,38 +382,9 @@ func (t *Tailer) PollLogPatterns() error {
 	return nil
 }
 
-// StartLogStreamPollLoop runs a permanent goroutine to poll for new log files.
-func (t *Tailer) StartLogStreamPollLoop(waker waker.Waker) {
-	if waker == nil {
-		glog.Info("Log stream polling disabled")
-		return
-	}
-	t.logstreamPollWaker = waker
-	t.wg.Add(1)
-	go func() {
-		defer t.wg.Done()
-		<-t.initDone
-		if t.oneShot {
-			glog.Info("No polling loop in oneshot mode.")
-			return
-		}
-		// glog.Infof("Starting log stream poll loop every %s", duration.String())
-		for {
-			select {
-			case <-t.ctx.Done():
-				return
-			case <-waker.Wake():
-				if err := t.PollLogStreams(); err != nil {
-					glog.Info(err)
-				}
-			}
-		}
-	}()
-}
-
-// PollLogStreams looks at the existing paths and checks if they're already
+// PollLogStreamsForCompletion looks at the existing paths and checks if they're already
 // complete, removing it from the map if so.
-func (t *Tailer) PollLogStreams() error {
+func (t *Tailer) PollLogStreamsForCompletion() error {
 	t.logstreamsMu.Lock()
 	defer t.logstreamsMu.Unlock()
 	for name, l := range t.logstreams {
@@ -422,6 +393,17 @@ func (t *Tailer) PollLogStreams() error {
 			delete(t.logstreams, name)
 			logCount.Add(-1)
 			continue
+		}
+	}
+	return nil
+}
+
+func (t *Tailer) Poll() error {
+	t.pollMu.Lock()
+	defer t.pollMu.Unlock()
+	for _, f := range []func() error{t.PollLogPatterns, t.PollLogStreamsForCompletion} {
+		if err := f(); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/testutil/file.go
+++ b/internal/testutil/file.go
@@ -20,6 +20,7 @@ func WriteString(tb testing.TB, f io.StringWriter, str string) int {
 		fi, err := v.Stat()
 		FatalIfErr(tb, err)
 		if fi.Mode().IsRegular() {
+			glog.Infof("This is a regular file, doing a sync.")
 			FatalIfErr(tb, v.Sync())
 		}
 	}

--- a/internal/waker/testwaker.go
+++ b/internal/waker/testwaker.go
@@ -73,7 +73,7 @@ func (t *testWaker) Wake() (w <-chan struct{}) {
 	t.mu.Lock()
 	w = t.wake
 	t.mu.Unlock()
-	glog.Infof("waiting for wake on chan %p", w)
+	glog.InfoDepth(1, "waiting for wakeup on chan ", w)
 	// Background this so we can return the wake channel.
 	// The wakeFunc won't close the channel until this completes.
 	go func() {


### PR DESCRIPTION
Test synchronisation relies on the logstreams being the only wakee waiting on
the testwaker.  If we use it in a second stream, we either have to bump the
awaken counter or remove it.

The PollLogstream method was incorrectly named; renaming for more clarity means
we see that we don't need to call it on the same waker but instead clean up
streams when we poll for new patterns, less frequently but frequent enough.

This undoes some of the changes from #603 as mentioned in that comment thread.