### PR TITLE
Fix tests hanging

### DIFF
--- a/internal/mtail/log_deletion_integration_test.go
+++ b/internal/mtail/log_deletion_integration_test.go
@@ -28,6 +28,7 @@ func TestLogDeletion(t *testing.T) {
 	logCloseCheck := m.ExpectMapExpvarDeltaWithDeadline("log_closes_total", logFilepath, 1)
 	logCountCheck := m.ExpectExpvarDeltaWithDeadline("log_count", -1)
 
+	m.PollWatched(1) // Force sync to EOF
 	glog.Info("remove")
 	testutil.FatalIfErr(t, os.Remove(logFilepath))
 


### PR DESCRIPTION
* 8ae3a26  - Avoid test hang when net.Conn.Write times out
  As described in #614, some times writing a zero-length message fails with a 
  time out error, causing the goroutine to fail without marking the stream as 
  finished, and so the test server never finishes.

  This commit adds a work-around by retrying the `Write` call until it succeeds
  or returns a non-timeout error. It also adds a `Sleep` call between tries as 
  otherwise this becomes a spin loop, filling the log with timeout errors.

* c4be4d97 - Fix race in TestLogDeletion
  As described in #614, I discovered a race condition in this test which
  results in the test blocking forever. This commit fixes the issue by calling
  `PollWatched` before deleting the log file.

Closes: #614
