### PR TITLE
Add metric size limits to the language and metric store.

### DIFF
--- a/docs/Language.md
+++ b/docs/Language.md
@@ -340,7 +340,8 @@ For example, parsing syslog timestamps is something you may only wish to do
 once, as it's expensive to match (and difficult to read!)
 
 ```
-counter foo counter bar
+counter foo
+counter bar
 
 /^(?P<date>\w+\s+\d+\s+\d+:\d+:\d+)/ {
   strptime($date, "Jan 02 15:04:05")
@@ -539,6 +540,8 @@ that log line.
 
 #### Variable Storage Management
 
+##### `del`
+
 `mtail` performs no implicit garbage collection in the metric storage. The
 program can hint to the virtual machine that a specific datum in a dimensioned
 metric is no longer going to be used with the `del` keyword.
@@ -574,6 +577,21 @@ The del-after form takes any time period supported by the go
 [`time.ParseDuration`](https://golang.org/pkg/time/#ParseDuration) function.
 
 Expiry is only processed once ever hour, so durations shorter than 1h won't take effect until the next hour has passed.
+
+This command only makes sense for dimensioned metrics.
+
+##### `limit`
+
+A size limit can be specified on a metric with the modifier `limit`.
+
+```
+counter bytes_total by operation limit 500
+```
+
+When the garbage collection run encounters a variable with size limit that is over its size limit, it will remove the oldest values until the whole metric is below its limit again.  Oldest values are chosen by the timestamp of the datum.
+
+This modifier only makes sense for dimensioned metrics.
+
 
 ### Stopping the program
 

--- a/internal/metrics/metric.go
+++ b/internal/metrics/metric.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/google/mtail/internal/metrics/datum"
 	"github.com/pkg/errors"
 )
@@ -92,7 +93,7 @@ type Metric struct {
 	labelValuesMap map[string]*LabelValue
 	Source         string        `json:",omitempty"`
 	Buckets        []datum.Range `json:",omitempty"`
-	Limit          int64         `json:",omitempty"`
+	Limit          int           `json:",omitempty"`
 }
 
 // NewMetric returns a new empty metric of dimension len(keys).
@@ -177,6 +178,20 @@ func (m *Metric) GetDatum(labelvalues ...string) (d datum.Datum, err error) {
 		}
 	}
 	return d, nil
+}
+
+// RemoveOldestDatum scans the Metric's LabelValues for the Datum with the oldest timestamp, and removes it.
+func (m *Metric) RemoveOldestDatum() {
+	var oldestLV *LabelValue
+	for _, lv := range m.LabelValues {
+		if oldestLV == nil || lv.Value.TimeUTC().Before(oldestLV.Value.TimeUTC()) {
+			oldestLV = lv
+		}
+	}
+	if oldestLV != nil {
+		glog.V(1).Infof("removeOldest: removing oldest LV: %v", oldestLV)
+		m.RemoveDatum(oldestLV.Labels...)
+	}
 }
 
 // RemoveDatum removes the Datum described by labelvalues from the Metric m.

--- a/internal/metrics/metric.go
+++ b/internal/metrics/metric.go
@@ -92,6 +92,7 @@ type Metric struct {
 	labelValuesMap map[string]*LabelValue
 	Source         string        `json:",omitempty"`
 	Buckets        []datum.Range `json:",omitempty"`
+	Limit          int64         `json:",omitempty"`
 }
 
 // NewMetric returns a new empty metric of dimension len(keys).

--- a/internal/metrics/metric.go
+++ b/internal/metrics/metric.go
@@ -155,6 +155,7 @@ func (m *Metric) GetDatum(labelvalues ...string) (d datum.Datum, err error) {
 	if lv := m.FindLabelValueOrNil(labelvalues); lv != nil {
 		d = lv.Value
 	} else {
+		// TODO Check m.Limit and expire old data
 		switch m.Type {
 		case Int:
 			d = datum.NewInt()

--- a/internal/metrics/metric_test.go
+++ b/internal/metrics/metric_test.go
@@ -252,3 +252,23 @@ func TestRemoveMetricLabelValue(t *testing.T) {
 		t.Errorf("label value still exists")
 	}
 }
+
+func TestMetricLabelValueRemovePastLimit(t *testing.T) {
+	m := NewMetric("test", "prog", Counter, Int, "foo")
+	m.Limit = 1
+	_, err := m.GetDatum("a")
+	testutil.FatalIfErr(t, err)
+	m.RemoveOldestDatum()
+	_, err = m.GetDatum("b")
+	testutil.FatalIfErr(t, err)
+	m.RemoveOldestDatum()
+	_, err = m.GetDatum("c")
+	testutil.FatalIfErr(t, err)
+	m.RemoveOldestDatum()
+	if len(m.LabelValues) > 2 {
+		t.Errorf("Expected 2 labelvalues got %#v", m.LabelValues)
+	}
+	if x := m.FindLabelValueOrNil([]string{"a"}); x != nil {
+		t.Errorf("found label a which is unexpected: %#v", x)
+	}
+}

--- a/internal/runtime/compiler/ast/ast.go
+++ b/internal/runtime/compiler/ast/ast.go
@@ -208,6 +208,7 @@ type VarDecl struct {
 	Name         string
 	Hidden       bool
 	Keys         []string
+	Limit        int64
 	Buckets      []float64
 	Kind         metrics.Kind
 	ExportedName string

--- a/internal/runtime/compiler/codegen/codegen.go
+++ b/internal/runtime/compiler/codegen/codegen.go
@@ -161,6 +161,8 @@ func (c *codegen) VisitBefore(node ast.Node) (ast.Visitor, ast.Node) {
 		}
 
 		m.Hidden = n.Hidden
+		m.Limit = n.Limit
+
 		n.Symbol.Binding = m
 		n.Symbol.Addr = len(c.obj.Metrics)
 		c.obj.Metrics = append(c.obj.Metrics, m)

--- a/internal/runtime/compiler/codegen/codegen.go
+++ b/internal/runtime/compiler/codegen/codegen.go
@@ -161,7 +161,14 @@ func (c *codegen) VisitBefore(node ast.Node) (ast.Visitor, ast.Node) {
 		}
 
 		m.Hidden = n.Hidden
-		m.Limit = n.Limit
+		// int is int64 only on 64bit platforms.  To be fair MaxInt is a
+		// ridiculously excessive size for this anyway, you're going to use 2GiB
+		// x sizeof(datum) in a single metric.
+		if n.Limit > math.MaxInt {
+			c.errorf(n.Pos(), "limit %d too large; max %d", n.Limit, math.MaxInt)
+			return nil, n
+		}
+		m.Limit = int(n.Limit)
 
 		n.Symbol.Binding = m
 		n.Symbol.Addr = len(c.obj.Metrics)

--- a/internal/runtime/compiler/parser/lexer.go
+++ b/internal/runtime/compiler/parser/lexer.go
@@ -30,6 +30,7 @@ var keywords = map[string]Kind{
 	"gauge":     GAUGE,
 	"hidden":    HIDDEN,
 	"histogram": HISTOGRAM,
+	"limit":     LIMIT,
 	"next":      NEXT,
 	"otherwise": OTHERWISE,
 	"stop":      STOP,

--- a/internal/runtime/compiler/parser/parser.go
+++ b/internal/runtime/compiler/parser/parser.go
@@ -50,50 +50,51 @@ const OTHERWISE = 57360
 const ELSE = 57361
 const STOP = 57362
 const BUCKETS = 57363
-const BUILTIN = 57364
-const REGEX = 57365
-const STRING = 57366
-const CAPREF = 57367
-const CAPREF_NAMED = 57368
-const ID = 57369
-const DECO = 57370
-const INTLITERAL = 57371
-const FLOATLITERAL = 57372
-const DURATIONLITERAL = 57373
-const INC = 57374
-const DEC = 57375
-const DIV = 57376
-const MOD = 57377
-const MUL = 57378
-const MINUS = 57379
-const PLUS = 57380
-const POW = 57381
-const SHL = 57382
-const SHR = 57383
-const LT = 57384
-const GT = 57385
-const LE = 57386
-const GE = 57387
-const EQ = 57388
-const NE = 57389
-const BITAND = 57390
-const XOR = 57391
-const BITOR = 57392
-const NOT = 57393
-const AND = 57394
-const OR = 57395
-const ADD_ASSIGN = 57396
-const ASSIGN = 57397
-const MATCH = 57398
-const NOT_MATCH = 57399
-const LCURLY = 57400
-const RCURLY = 57401
-const LPAREN = 57402
-const RPAREN = 57403
-const LSQUARE = 57404
-const RSQUARE = 57405
-const COMMA = 57406
-const NL = 57407
+const LIMIT = 57364
+const BUILTIN = 57365
+const REGEX = 57366
+const STRING = 57367
+const CAPREF = 57368
+const CAPREF_NAMED = 57369
+const ID = 57370
+const DECO = 57371
+const INTLITERAL = 57372
+const FLOATLITERAL = 57373
+const DURATIONLITERAL = 57374
+const INC = 57375
+const DEC = 57376
+const DIV = 57377
+const MOD = 57378
+const MUL = 57379
+const MINUS = 57380
+const PLUS = 57381
+const POW = 57382
+const SHL = 57383
+const SHR = 57384
+const LT = 57385
+const GT = 57386
+const LE = 57387
+const GE = 57388
+const EQ = 57389
+const NE = 57390
+const BITAND = 57391
+const XOR = 57392
+const BITOR = 57393
+const NOT = 57394
+const AND = 57395
+const OR = 57396
+const ADD_ASSIGN = 57397
+const ASSIGN = 57398
+const MATCH = 57399
+const NOT_MATCH = 57400
+const LCURLY = 57401
+const RCURLY = 57402
+const LPAREN = 57403
+const RPAREN = 57404
+const LSQUARE = 57405
+const RSQUARE = 57406
+const COMMA = 57407
+const NL = 57408
 
 var mtailToknames = [...]string{
 	"$end",
@@ -117,6 +118,7 @@ var mtailToknames = [...]string{
 	"ELSE",
 	"STOP",
 	"BUCKETS",
+	"LIMIT",
 	"BUILTIN",
 	"REGEX",
 	"STRING",
@@ -169,7 +171,7 @@ const mtailEofCode = 1
 const mtailErrCode = 2
 const mtailInitialStackSize = 16
 
-//line parser.y:715
+//line parser.y:733
 
 //  tokenpos returns the position of the current token.
 func tokenpos(mtaillex mtailLexer) position.Position {
@@ -201,9 +203,9 @@ var mtailExca = [...]int{
 	7, 93,
 	8, 93,
 	9, 93,
-	-2, 121,
+	-2, 124,
 	-1, 22,
-	65, 24,
+	66, 24,
 	-2, 68,
 	-1, 106,
 	5, 93,
@@ -211,86 +213,86 @@ var mtailExca = [...]int{
 	7, 93,
 	8, 93,
 	9, 93,
-	-2, 121,
+	-2, 124,
 }
 
 const mtailPrivate = 57344
 
-const mtailLast = 243
+const mtailLast = 249
 
 var mtailAct = [...]int{
-	169, 88, 126, 28, 15, 91, 42, 44, 27, 30,
-	103, 127, 41, 24, 20, 86, 40, 165, 22, 128,
-	161, 178, 19, 26, 45, 29, 104, 25, 36, 34,
-	35, 43, 54, 38, 39, 87, 177, 85, 89, 125,
+	171, 88, 126, 28, 15, 91, 42, 44, 27, 30,
+	103, 127, 41, 24, 20, 86, 40, 167, 22, 128,
+	163, 182, 19, 26, 45, 29, 104, 25, 36, 34,
+	35, 43, 54, 38, 39, 87, 181, 85, 89, 125,
 	108, 46, 36, 34, 35, 43, 47, 38, 39, 90,
-	160, 161, 62, 63, 2, 31, 49, 87, 76, 77,
+	162, 163, 62, 63, 2, 31, 49, 87, 76, 77,
 	68, 130, 74, 73, 37, 138, 62, 63, 50, 112,
-	93, 94, 117, 97, 96, 118, 166, 50, 37, 119,
+	93, 94, 117, 97, 96, 118, 168, 50, 37, 119,
 	120, 70, 72, 71, 121, 122, 123, 66, 67, 124,
-	107, 129, 181, 180, 111, 79, 80, 81, 82, 83,
-	84, 167, 106, 131, 43, 135, 132, 172, 15, 133,
-	129, 110, 27, 140, 100, 101, 99, 134, 20, 102,
-	171, 135, 22, 170, 87, 129, 19, 158, 87, 149,
-	154, 142, 153, 155, 156, 87, 87, 87, 162, 164,
-	163, 159, 151, 157, 49, 152, 150, 136, 139, 13,
-	105, 109, 141, 66, 67, 175, 174, 116, 11, 23,
-	115, 1, 10, 129, 176, 12, 64, 13, 173, 36,
-	34, 35, 43, 145, 38, 39, 11, 23, 179, 65,
-	10, 147, 146, 12, 75, 98, 61, 36, 34, 35,
-	43, 148, 38, 39, 95, 69, 31, 36, 34, 35,
-	43, 92, 38, 39, 137, 37, 51, 53, 78, 48,
-	16, 18, 168, 49, 31, 143, 144, 55, 33, 52,
-	114, 9, 8, 37, 31, 50, 7, 113, 16, 6,
-	32, 21, 17, 37, 56, 57, 58, 59, 60, 5,
-	14, 4, 3,
+	107, 129, 185, 184, 111, 79, 80, 81, 82, 83,
+	84, 169, 106, 131, 179, 135, 132, 175, 15, 133,
+	129, 43, 27, 110, 100, 101, 99, 134, 20, 102,
+	174, 135, 22, 173, 87, 129, 19, 160, 87, 151,
+	156, 142, 155, 157, 158, 87, 87, 87, 164, 166,
+	165, 161, 153, 159, 140, 154, 152, 136, 139, 178,
+	177, 13, 141, 116, 66, 67, 115, 49, 105, 109,
+	11, 23, 1, 176, 10, 129, 180, 12, 64, 145,
+	13, 65, 36, 34, 35, 43, 75, 38, 39, 11,
+	23, 98, 183, 10, 95, 69, 12, 92, 61, 78,
+	18, 36, 34, 35, 43, 170, 38, 39, 143, 31,
+	56, 57, 58, 59, 60, 172, 144, 137, 37, 36,
+	34, 35, 43, 16, 38, 39, 146, 55, 31, 33,
+	51, 53, 114, 48, 9, 8, 7, 37, 49, 113,
+	6, 32, 16, 21, 52, 17, 31, 148, 147, 5,
+	50, 14, 4, 3, 0, 37, 0, 149, 150,
 }
 
 var mtailPact = [...]int{
-	-1000, -1000, 163, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	-1000, 77, -1000, -1000, -12, 191, -1000, -33, 229, 14,
-	14, -1000, 55, -1000, 22, 33, -1000, 8, 2, -1000,
-	53, 173, -24, -1000, -1000, -1000, -1000, 173, -1000, -1000,
-	30, -1000, 36, -1000, 80, -39, 131, -1000, -12, -20,
-	-1000, 84, -12, 18, -1000, 133, -1000, -1000, -1000, -1000,
-	-1000, -39, -1000, -1000, -39, -1000, -1000, -1000, -39, -39,
-	-1000, -1000, -1000, -39, -39, -39, -1000, -1000, -39, -1000,
-	-1000, -1000, -1000, -1000, -1000, -1000, 55, -1000, 122, 173,
-	0, -1000, -39, -1000, -1000, -39, -1000, -1000, -39, -1000,
-	-1000, -1000, -1000, -1000, -1000, -12, 145, -1000, 4, 90,
-	-12, -1000, 121, 170, -1000, -1000, -1000, 173, 173, 77,
-	173, 173, 173, 18, 173, -13, -1000, 14, -1000, 34,
-	-1000, 173, 173, 173, 22, 43, -1000, -1000, -1000, -44,
-	42, -1000, 70, -1000, -1000, -1000, 96, 83, 126, 14,
-	33, -1000, -1000, -1000, 53, 14, 14, -1000, -1000, 30,
-	-1000, 173, 36, 80, -1000, -1000, -1000, -1000, -28, -1000,
-	-1000, -1000, -1000, -43, -1000, -1000, -1000, 96, 63, -1000,
-	-1000, -1000,
+	-1000, -1000, 166, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
+	-1000, 83, -1000, -1000, -13, 205, -1000, -34, 195, 13,
+	13, -1000, 54, -1000, 21, 32, -1000, 7, 1, -1000,
+	52, 184, -25, -1000, -1000, -1000, -1000, 184, -1000, -1000,
+	29, -1000, 35, -1000, 79, -40, 139, -1000, -13, -21,
+	-1000, 85, -13, 17, -1000, 128, -1000, -1000, -1000, -1000,
+	-1000, -40, -1000, -1000, -40, -1000, -1000, -1000, -40, -40,
+	-1000, -1000, -1000, -40, -40, -40, -1000, -1000, -40, -1000,
+	-1000, -1000, -1000, -1000, -1000, -1000, 54, -1000, 134, 184,
+	-1, -1000, -40, -1000, -1000, -40, -1000, -1000, -40, -1000,
+	-1000, -1000, -1000, -1000, -1000, -13, 147, -1000, 3, 120,
+	-13, -1000, 121, 226, -1000, -1000, -1000, 184, 184, 83,
+	184, 184, 184, 17, 184, -14, -1000, 13, -1000, 33,
+	-1000, 184, 184, 184, 21, 42, -1000, -1000, -1000, -45,
+	41, -1000, 69, -1000, -1000, -1000, -1000, 95, 82, 119,
+	74, 13, 32, -1000, -1000, -1000, 52, 13, 13, -1000,
+	-1000, 29, -1000, 184, 35, 79, -1000, -1000, -1000, -1000,
+	-29, -1000, -1000, -1000, -1000, -1000, -44, -1000, -1000, -1000,
+	-1000, 95, 62, -1000, -1000, -1000,
 }
 
 var mtailPgo = [...]int{
-	0, 54, 242, 39, 41, 241, 240, 239, 232, 3,
-	7, 6, 15, 5, 231, 9, 16, 27, 11, 230,
-	12, 13, 19, 229, 227, 226, 222, 25, 23, 221,
-	220, 218, 2, 217, 216, 0, 215, 212, 211, 208,
-	201, 195, 166, 194, 185, 184, 179, 173, 168, 161,
-	10, 1, 151,
+	0, 54, 243, 39, 41, 242, 241, 239, 235, 3,
+	7, 6, 15, 5, 233, 9, 16, 27, 11, 231,
+	12, 13, 19, 230, 229, 226, 225, 25, 23, 224,
+	222, 219, 2, 217, 216, 206, 205, 0, 198, 195,
+	190, 189, 187, 185, 168, 184, 181, 176, 171, 169,
+	163, 162, 10, 1, 159,
 }
 
 var mtailR1 = [...]int{
-	0, 49, 1, 1, 2, 2, 2, 2, 2, 2,
+	0, 51, 1, 1, 2, 2, 2, 2, 2, 2,
 	2, 2, 2, 2, 5, 5, 5, 6, 6, 6,
 	7, 7, 4, 8, 8, 14, 14, 18, 18, 18,
-	18, 42, 42, 17, 17, 41, 41, 41, 15, 15,
-	39, 39, 39, 39, 39, 39, 16, 16, 40, 40,
-	11, 11, 43, 43, 28, 28, 45, 45, 22, 21,
-	21, 21, 10, 10, 44, 44, 44, 44, 13, 13,
-	12, 12, 46, 46, 9, 9, 9, 9, 9, 9,
+	18, 44, 44, 17, 17, 43, 43, 43, 15, 15,
+	41, 41, 41, 41, 41, 41, 16, 16, 42, 42,
+	11, 11, 45, 45, 28, 28, 47, 47, 22, 21,
+	21, 21, 10, 10, 46, 46, 46, 46, 13, 13,
+	12, 12, 48, 48, 9, 9, 9, 9, 9, 9,
 	9, 9, 19, 19, 20, 31, 31, 3, 3, 32,
-	32, 27, 23, 38, 38, 24, 24, 24, 24, 30,
-	30, 33, 33, 33, 33, 33, 36, 37, 37, 34,
-	47, 48, 48, 48, 48, 25, 26, 29, 29, 35,
-	35, 51, 52, 50, 50,
+	32, 27, 23, 40, 40, 24, 24, 24, 24, 24,
+	30, 30, 33, 33, 33, 33, 33, 38, 39, 39,
+	37, 35, 34, 49, 50, 50, 50, 50, 25, 26,
+	29, 29, 36, 36, 53, 54, 52, 52,
 }
 
 var mtailR2 = [...]int{
@@ -303,54 +305,54 @@ var mtailR2 = [...]int{
 	4, 4, 1, 4, 1, 1, 1, 1, 1, 2,
 	1, 2, 1, 1, 1, 1, 1, 1, 1, 3,
 	1, 1, 1, 4, 1, 4, 5, 1, 3, 1,
-	1, 5, 3, 0, 1, 2, 2, 2, 1, 1,
-	1, 1, 1, 1, 1, 1, 2, 1, 3, 2,
-	2, 1, 1, 3, 3, 4, 3, 5, 3, 1,
-	1, 0, 0, 0, 1,
+	1, 5, 3, 0, 1, 2, 2, 2, 2, 1,
+	1, 1, 1, 1, 1, 1, 1, 2, 1, 3,
+	1, 2, 2, 2, 1, 1, 3, 3, 4, 3,
+	5, 3, 1, 1, 0, 0, 0, 1,
 }
 
 var mtailChk = [...]int{
-	-1000, -49, -1, -2, -5, -7, -23, -25, -26, -29,
-	17, 13, 20, 4, -6, -51, 65, -8, -38, -22,
+	-1000, -51, -1, -2, -5, -7, -23, -25, -26, -29,
+	17, 13, 20, 4, -6, -53, 66, -8, -40, -22,
 	-18, -14, -12, 14, -21, -17, -28, -13, -9, -27,
-	-15, 51, -19, -31, 25, 26, 24, 60, 29, 30,
-	-16, -20, -11, 27, -10, -20, -4, 58, 18, 22,
-	34, 15, 28, 16, 65, -33, 5, 6, 7, 8,
-	9, -42, 52, 53, -42, -46, 32, 33, 38, -41,
-	48, 50, 49, 55, 54, -45, 56, 57, -39, 42,
-	43, 44, 45, 46, 47, -13, -12, -9, -51, 62,
-	-18, -13, -40, 40, 41, -43, 38, 37, -44, 36,
-	34, 35, 39, -50, 65, 19, -1, -4, 60, -52,
-	27, -4, -12, -24, -30, 27, 24, -50, -50, -50,
-	-50, -50, -50, -50, -50, -3, -32, -18, -22, -51,
-	61, -50, -50, -50, -21, -51, -4, 59, 61, -3,
-	23, -4, 10, -36, -34, -47, 12, 11, 21, -18,
-	-17, -28, -27, -20, -15, -18, -18, -22, -9, -16,
-	63, 64, -11, -10, -13, 61, 34, 31, -37, -35,
-	27, 24, 24, -48, 30, 29, -32, 64, 64, -35,
-	30, 29,
+	-15, 52, -19, -31, 26, 27, 25, 61, 30, 31,
+	-16, -20, -11, 28, -10, -20, -4, 59, 18, 23,
+	35, 15, 29, 16, 66, -33, 5, 6, 7, 8,
+	9, -44, 53, 54, -44, -48, 33, 34, 39, -43,
+	49, 51, 50, 56, 55, -47, 57, 58, -41, 43,
+	44, 45, 46, 47, 48, -13, -12, -9, -53, 63,
+	-18, -13, -42, 41, 42, -45, 39, 38, -46, 37,
+	35, 36, 40, -52, 66, 19, -1, -4, 61, -54,
+	28, -4, -12, -24, -30, 28, 25, -52, -52, -52,
+	-52, -52, -52, -52, -52, -3, -32, -18, -22, -53,
+	62, -52, -52, -52, -21, -53, -4, 60, 62, -3,
+	24, -4, 10, -38, -35, -49, -34, 12, 11, 21,
+	22, -18, -17, -28, -27, -20, -15, -18, -18, -22,
+	-9, -16, 64, 65, -11, -10, -13, 62, 35, 32,
+	-39, -37, -36, 28, 25, 25, -50, 31, 30, 30,
+	-32, 65, 65, -37, 31, 30,
 }
 
 var mtailDef = [...]int{
 	2, -2, -2, 3, 4, 5, 6, 7, 8, 9,
 	10, 0, 12, 13, 0, 0, 20, 0, 0, 17,
 	19, 23, -2, 94, 58, 27, 28, 62, 70, 59,
-	33, 121, 74, 75, 76, 77, 78, 121, 80, 81,
-	38, 82, 46, 84, 50, 123, 15, 2, 0, 0,
-	122, 0, 0, 121, 21, 0, 101, 102, 103, 104,
-	105, 123, 31, 32, 123, 71, 72, 73, 123, 123,
-	35, 36, 37, 123, 123, 123, 56, 57, 123, 40,
-	41, 42, 43, 44, 45, 69, 68, 70, 0, 121,
-	0, 62, 123, 48, 49, 123, 52, 53, 123, 64,
-	65, 66, 67, 121, 124, 0, -2, 16, 121, 0,
-	0, 116, 118, 92, 98, 99, 100, 121, 121, 121,
-	121, 121, 121, 121, 121, 0, 87, 89, 90, 0,
-	79, 121, 121, 121, 11, 0, 14, 22, 85, 0,
-	0, 115, 0, 95, 96, 97, 0, 0, 0, 18,
-	29, 30, 60, 61, 34, 25, 26, 54, 55, 39,
-	83, 121, 47, 51, 63, 86, 91, 117, 106, 107,
-	119, 120, 109, 110, 111, 112, 88, 0, 0, 108,
-	113, 114,
+	33, 124, 74, 75, 76, 77, 78, 124, 80, 81,
+	38, 82, 46, 84, 50, 126, 15, 2, 0, 0,
+	125, 0, 0, 124, 21, 0, 102, 103, 104, 105,
+	106, 126, 31, 32, 126, 71, 72, 73, 126, 126,
+	35, 36, 37, 126, 126, 126, 56, 57, 126, 40,
+	41, 42, 43, 44, 45, 69, 68, 70, 0, 124,
+	0, 62, 126, 48, 49, 126, 52, 53, 126, 64,
+	65, 66, 67, 124, 127, 0, -2, 16, 124, 0,
+	0, 119, 121, 92, 99, 100, 101, 124, 124, 124,
+	124, 124, 124, 124, 124, 0, 87, 89, 90, 0,
+	79, 124, 124, 124, 11, 0, 14, 22, 85, 0,
+	0, 118, 0, 95, 96, 97, 98, 0, 0, 0,
+	0, 18, 29, 30, 60, 61, 34, 25, 26, 54,
+	55, 39, 83, 124, 47, 51, 63, 86, 91, 120,
+	107, 108, 110, 122, 123, 111, 113, 114, 115, 112,
+	88, 0, 0, 109, 116, 117,
 }
 
 var mtailTok1 = [...]int{
@@ -364,7 +366,7 @@ var mtailTok2 = [...]int{
 	32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
 	42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
 	52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
-	62, 63, 64, 65,
+	62, 63, 64, 65, 66,
 }
 
 var mtailTok3 = [...]int{
@@ -380,8 +382,8 @@ var mtailErrorMessages = [...]struct {
 	{15, 1, "unexpected end of file, expecting '}' to end block"},
 	{15, 1, "unexpected end of file, expecting '}' to end block"},
 	{15, 1, "unexpected end of file, expecting '}' to end block"},
-	{14, 62, "unexpected indexing of an expression"},
-	{14, 65, "statement with no effect, missing an assignment, `+' concatenation, or `{}' block?"},
+	{14, 63, "unexpected indexing of an expression"},
+	{14, 66, "statement with no effect, missing an assignment, `+' concatenation, or `{}' block?"},
 }
 
 //line yaccpar:1
@@ -717,19 +719,19 @@ mtaildefault:
 
 	case 1:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:92
+//line parser.y:93
 		{
 			mtaillex.(*parser).root = mtailDollar[1].n
 		}
 	case 2:
 		mtailDollar = mtailS[mtailpt-0 : mtailpt+1]
-//line parser.y:100
+//line parser.y:101
 		{
 			mtailVAL.n = &ast.StmtList{}
 		}
 	case 3:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:104
+//line parser.y:105
 		{
 			mtailVAL.n = mtailDollar[1].n
 			if mtailDollar[2].n != nil {
@@ -738,73 +740,73 @@ mtaildefault:
 		}
 	case 4:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:115
+//line parser.y:116
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 5:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:117
+//line parser.y:118
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 6:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:119
+//line parser.y:120
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 7:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:121
+//line parser.y:122
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 8:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:123
+//line parser.y:124
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 9:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:125
+//line parser.y:126
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 10:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:127
+//line parser.y:128
 		{
 			mtailVAL.n = &ast.NextStmt{tokenpos(mtaillex)}
 		}
 	case 11:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:131
+//line parser.y:132
 		{
 			mtailVAL.n = &ast.PatternFragment{ID: mtailDollar[2].n, Expr: mtailDollar[4].n}
 		}
 	case 12:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:135
+//line parser.y:136
 		{
 			mtailVAL.n = &ast.StopStmt{tokenpos(mtaillex)}
 		}
 	case 13:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:139
+//line parser.y:140
 		{
 			mtailVAL.n = &ast.Error{tokenpos(mtaillex), mtailDollar[1].text}
 		}
 	case 14:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:147
+//line parser.y:148
 		{
 			mtailVAL.n = &ast.CondStmt{mtailDollar[1].n, mtailDollar[2].n, mtailDollar[4].n, nil}
 		}
 	case 15:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:151
+//line parser.y:152
 		{
 			if mtailDollar[1].n != nil {
 				mtailVAL.n = &ast.CondStmt{mtailDollar[1].n, mtailDollar[2].n, nil, nil}
@@ -814,20 +816,20 @@ mtaildefault:
 		}
 	case 16:
 		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
-//line parser.y:159
+//line parser.y:160
 		{
 			o := &ast.OtherwiseStmt{positionFromMark(mtaillex)}
 			mtailVAL.n = &ast.CondStmt{o, mtailDollar[3].n, nil, nil}
 		}
 	case 17:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:167
+//line parser.y:168
 		{
 			mtailVAL.n = &ast.UnaryExpr{P: tokenpos(mtaillex), Expr: mtailDollar[1].n, Op: MATCH}
 		}
 	case 18:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:171
+//line parser.y:172
 		{
 			mtailVAL.n = &ast.BinaryExpr{
 				LHS: &ast.UnaryExpr{P: tokenpos(mtaillex), Expr: mtailDollar[1].n, Op: MATCH},
@@ -837,392 +839,392 @@ mtaildefault:
 		}
 	case 19:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:179
+//line parser.y:180
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 20:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:185
+//line parser.y:186
 		{
 			mtailVAL.n = nil
 		}
 	case 21:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:187
+//line parser.y:188
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 22:
 		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
-//line parser.y:193
+//line parser.y:194
 		{
 			mtailVAL.n = mtailDollar[2].n
 		}
 	case 23:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:201
+//line parser.y:202
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 24:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:203
+//line parser.y:204
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 25:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:209
+//line parser.y:210
 		{
 			mtailVAL.n = &ast.BinaryExpr{LHS: mtailDollar[1].n, RHS: mtailDollar[4].n, Op: mtailDollar[2].op}
 		}
 	case 26:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:213
+//line parser.y:214
 		{
 			mtailVAL.n = &ast.BinaryExpr{LHS: mtailDollar[1].n, RHS: mtailDollar[4].n, Op: mtailDollar[2].op}
 		}
 	case 27:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:221
+//line parser.y:222
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 28:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:223
+//line parser.y:224
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 29:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:225
+//line parser.y:226
 		{
 			mtailVAL.n = &ast.BinaryExpr{LHS: mtailDollar[1].n, RHS: mtailDollar[4].n, Op: mtailDollar[2].op}
 		}
 	case 30:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:229
+//line parser.y:230
 		{
 			mtailVAL.n = &ast.BinaryExpr{LHS: mtailDollar[1].n, RHS: mtailDollar[4].n, Op: mtailDollar[2].op}
 		}
 	case 31:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:236
+//line parser.y:237
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 32:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:238
+//line parser.y:239
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 33:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:244
+//line parser.y:245
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 34:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:246
+//line parser.y:247
 		{
 			mtailVAL.n = &ast.BinaryExpr{LHS: mtailDollar[1].n, RHS: mtailDollar[4].n, Op: mtailDollar[2].op}
 		}
 	case 35:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:253
+//line parser.y:254
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 36:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:255
+//line parser.y:256
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 37:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:257
+//line parser.y:258
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 38:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:263
+//line parser.y:264
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 39:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:265
+//line parser.y:266
 		{
 			mtailVAL.n = &ast.BinaryExpr{LHS: mtailDollar[1].n, RHS: mtailDollar[4].n, Op: mtailDollar[2].op}
 		}
 	case 40:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:272
+//line parser.y:273
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 41:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:274
+//line parser.y:275
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 42:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:276
+//line parser.y:277
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 43:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:278
+//line parser.y:279
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 44:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:280
+//line parser.y:281
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 45:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:282
+//line parser.y:283
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 46:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:288
+//line parser.y:289
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 47:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:290
+//line parser.y:291
 		{
 			mtailVAL.n = &ast.BinaryExpr{LHS: mtailDollar[1].n, RHS: mtailDollar[4].n, Op: mtailDollar[2].op}
 		}
 	case 48:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:297
+//line parser.y:298
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 49:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:299
+//line parser.y:300
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 50:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:305
+//line parser.y:306
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 51:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:307
+//line parser.y:308
 		{
 			mtailVAL.n = &ast.BinaryExpr{LHS: mtailDollar[1].n, RHS: mtailDollar[4].n, Op: mtailDollar[2].op}
 		}
 	case 52:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:314
+//line parser.y:315
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 53:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:316
+//line parser.y:317
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 54:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:322
+//line parser.y:323
 		{
 			mtailVAL.n = &ast.BinaryExpr{LHS: mtailDollar[1].n, RHS: mtailDollar[4].n, Op: mtailDollar[2].op}
 		}
 	case 55:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:326
+//line parser.y:327
 		{
 			mtailVAL.n = &ast.BinaryExpr{LHS: mtailDollar[1].n, RHS: mtailDollar[4].n, Op: mtailDollar[2].op}
 		}
 	case 56:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:333
+//line parser.y:334
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 57:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:335
+//line parser.y:336
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 58:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:342
+//line parser.y:343
 		{
 			mtailVAL.n = &ast.PatternExpr{Expr: mtailDollar[1].n}
 		}
 	case 59:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:350
+//line parser.y:351
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 60:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:352
+//line parser.y:353
 		{
 			mtailVAL.n = &ast.BinaryExpr{LHS: mtailDollar[1].n, RHS: mtailDollar[4].n, Op: PLUS}
 		}
 	case 61:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:356
+//line parser.y:357
 		{
 			mtailVAL.n = &ast.BinaryExpr{LHS: mtailDollar[1].n, RHS: mtailDollar[4].n, Op: PLUS}
 		}
 	case 62:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:364
+//line parser.y:365
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 63:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:366
+//line parser.y:367
 		{
 			mtailVAL.n = &ast.BinaryExpr{LHS: mtailDollar[1].n, RHS: mtailDollar[4].n, Op: mtailDollar[2].op}
 		}
 	case 64:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:373
+//line parser.y:374
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 65:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:375
+//line parser.y:376
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 66:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:377
+//line parser.y:378
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 67:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:379
+//line parser.y:380
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 68:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:385
+//line parser.y:386
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 69:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:387
+//line parser.y:388
 		{
 			mtailVAL.n = &ast.UnaryExpr{P: tokenpos(mtaillex), Expr: mtailDollar[2].n, Op: mtailDollar[1].op}
 		}
 	case 70:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:395
+//line parser.y:396
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 71:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:397
+//line parser.y:398
 		{
 			mtailVAL.n = &ast.UnaryExpr{P: tokenpos(mtaillex), Expr: mtailDollar[1].n, Op: mtailDollar[2].op}
 		}
 	case 72:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:404
+//line parser.y:405
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 73:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:406
+//line parser.y:407
 		{
 			mtailVAL.op = mtailDollar[1].op
 		}
 	case 74:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:412
+//line parser.y:413
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 75:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:414
+//line parser.y:415
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 76:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:416
+//line parser.y:417
 		{
 			mtailVAL.n = &ast.CaprefTerm{tokenpos(mtaillex), mtailDollar[1].text, false, nil}
 		}
 	case 77:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:420
+//line parser.y:421
 		{
 			mtailVAL.n = &ast.CaprefTerm{tokenpos(mtaillex), mtailDollar[1].text, true, nil}
 		}
 	case 78:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:424
+//line parser.y:425
 		{
 			mtailVAL.n = &ast.StringLit{tokenpos(mtaillex), mtailDollar[1].text}
 		}
 	case 79:
 		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
-//line parser.y:428
+//line parser.y:429
 		{
 			mtailVAL.n = mtailDollar[2].n
 		}
 	case 80:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:432
+//line parser.y:433
 		{
 			mtailVAL.n = &ast.IntLit{tokenpos(mtaillex), mtailDollar[1].intVal}
 		}
 	case 81:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:436
+//line parser.y:437
 		{
 			mtailVAL.n = &ast.FloatLit{tokenpos(mtaillex), mtailDollar[1].floatVal}
 		}
 	case 82:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:444
+//line parser.y:445
 		{
 			// Build an empty IndexedExpr so that the recursive rule below doesn't need to handle the alternative.
 			mtailVAL.n = &ast.IndexedExpr{LHS: mtailDollar[1].n, Index: &ast.ExprList{}}
 		}
 	case 83:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:449
+//line parser.y:450
 		{
 			mtailVAL.n = mtailDollar[1].n
 			mtailVAL.n.(*ast.IndexedExpr).Index.(*ast.ExprList).Children = append(
@@ -1231,57 +1233,57 @@ mtaildefault:
 		}
 	case 84:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:460
+//line parser.y:461
 		{
 			mtailVAL.n = &ast.IDTerm{tokenpos(mtaillex), mtailDollar[1].text, nil, false}
 		}
 	case 85:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:468
+//line parser.y:469
 		{
 			mtailVAL.n = &ast.BuiltinExpr{P: positionFromMark(mtaillex), Name: mtailDollar[2].text, Args: nil}
 		}
 	case 86:
 		mtailDollar = mtailS[mtailpt-5 : mtailpt+1]
-//line parser.y:472
+//line parser.y:473
 		{
 			mtailVAL.n = &ast.BuiltinExpr{P: positionFromMark(mtaillex), Name: mtailDollar[2].text, Args: mtailDollar[4].n}
 		}
 	case 87:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:481
+//line parser.y:482
 		{
 			mtailVAL.n = &ast.ExprList{}
 			mtailVAL.n.(*ast.ExprList).Children = append(mtailVAL.n.(*ast.ExprList).Children, mtailDollar[1].n)
 		}
 	case 88:
 		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
-//line parser.y:486
+//line parser.y:487
 		{
 			mtailVAL.n = mtailDollar[1].n
 			mtailVAL.n.(*ast.ExprList).Children = append(mtailVAL.n.(*ast.ExprList).Children, mtailDollar[3].n)
 		}
 	case 89:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:494
+//line parser.y:495
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 90:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:496
+//line parser.y:497
 		{
 			mtailVAL.n = mtailDollar[1].n
 		}
 	case 91:
 		mtailDollar = mtailS[mtailpt-5 : mtailpt+1]
-//line parser.y:502
+//line parser.y:503
 		{
 			mtailVAL.n = &ast.PatternLit{P: positionFromMark(mtaillex), Pattern: mtailDollar[4].text}
 		}
 	case 92:
 		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
-//line parser.y:510
+//line parser.y:511
 		{
 			mtailVAL.n = mtailDollar[3].n
 			d := mtailVAL.n.(*ast.VarDecl)
@@ -1290,191 +1292,210 @@ mtaildefault:
 		}
 	case 93:
 		mtailDollar = mtailS[mtailpt-0 : mtailpt+1]
-//line parser.y:521
+//line parser.y:522
 		{
 			mtailVAL.flag = false
 		}
 	case 94:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:525
+//line parser.y:526
 		{
 			mtailVAL.flag = true
 		}
 	case 95:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:533
+//line parser.y:534
 		{
 			mtailVAL.n = mtailDollar[1].n
 			mtailVAL.n.(*ast.VarDecl).Keys = mtailDollar[2].texts
 		}
 	case 96:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:538
+//line parser.y:539
 		{
 			mtailVAL.n = mtailDollar[1].n
 			mtailVAL.n.(*ast.VarDecl).ExportedName = mtailDollar[2].text
 		}
 	case 97:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:543
+//line parser.y:544
 		{
 			mtailVAL.n = mtailDollar[1].n
 			mtailVAL.n.(*ast.VarDecl).Buckets = mtailDollar[2].floats
 		}
 	case 98:
-		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:548
+		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
+//line parser.y:549
 		{
 			mtailVAL.n = mtailDollar[1].n
+			mtailVAL.n.(*ast.VarDecl).Limit = mtailDollar[2].intVal
 		}
 	case 99:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:556
+//line parser.y:554
 		{
-			mtailVAL.n = &ast.VarDecl{P: tokenpos(mtaillex), Name: mtailDollar[1].text}
+			mtailVAL.n = mtailDollar[1].n
 		}
 	case 100:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:560
+//line parser.y:562
 		{
 			mtailVAL.n = &ast.VarDecl{P: tokenpos(mtaillex), Name: mtailDollar[1].text}
 		}
 	case 101:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:568
+//line parser.y:566
 		{
-			mtailVAL.kind = metrics.Counter
+			mtailVAL.n = &ast.VarDecl{P: tokenpos(mtaillex), Name: mtailDollar[1].text}
 		}
 	case 102:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:572
+//line parser.y:574
 		{
-			mtailVAL.kind = metrics.Gauge
+			mtailVAL.kind = metrics.Counter
 		}
 	case 103:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:576
+//line parser.y:578
 		{
-			mtailVAL.kind = metrics.Timer
+			mtailVAL.kind = metrics.Gauge
 		}
 	case 104:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:580
+//line parser.y:582
 		{
-			mtailVAL.kind = metrics.Text
+			mtailVAL.kind = metrics.Timer
 		}
 	case 105:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:584
+//line parser.y:586
+		{
+			mtailVAL.kind = metrics.Text
+		}
+	case 106:
+		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
+//line parser.y:590
 		{
 			mtailVAL.kind = metrics.Histogram
 		}
-	case 106:
+	case 107:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:592
+//line parser.y:598
 		{
 			mtailVAL.texts = mtailDollar[2].texts
 		}
-	case 107:
+	case 108:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:599
+//line parser.y:605
 		{
 			mtailVAL.texts = make([]string, 0)
 			mtailVAL.texts = append(mtailVAL.texts, mtailDollar[1].text)
 		}
-	case 108:
+	case 109:
 		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
-//line parser.y:604
+//line parser.y:610
 		{
 			mtailVAL.texts = mtailDollar[1].texts
 			mtailVAL.texts = append(mtailVAL.texts, mtailDollar[3].text)
 		}
-	case 109:
+	case 110:
+		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
+//line parser.y:618
+		{
+			mtailVAL.text = mtailDollar[1].text
+		}
+	case 111:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:613
+//line parser.y:624
 		{
 			mtailVAL.text = mtailDollar[2].text
 		}
-	case 110:
+	case 112:
 		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
-//line parser.y:621
+//line parser.y:631
+		{
+			mtailVAL.intVal = mtailDollar[2].intVal
+		}
+	case 113:
+		mtailDollar = mtailS[mtailpt-2 : mtailpt+1]
+//line parser.y:639
 		{
 			mtailVAL.floats = mtailDollar[2].floats
 		}
-	case 111:
+	case 114:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:627
+//line parser.y:645
 		{
 			mtailVAL.floats = make([]float64, 0)
 			mtailVAL.floats = append(mtailVAL.floats, mtailDollar[1].floatVal)
 		}
-	case 112:
+	case 115:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:632
+//line parser.y:650
 		{
 			mtailVAL.floats = make([]float64, 0)
 			mtailVAL.floats = append(mtailVAL.floats, float64(mtailDollar[1].intVal))
 		}
-	case 113:
+	case 116:
 		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
-//line parser.y:637
+//line parser.y:655
 		{
 			mtailVAL.floats = mtailDollar[1].floats
 			mtailVAL.floats = append(mtailVAL.floats, mtailDollar[3].floatVal)
 		}
-	case 114:
+	case 117:
 		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
-//line parser.y:642
+//line parser.y:660
 		{
 			mtailVAL.floats = mtailDollar[1].floats
 			mtailVAL.floats = append(mtailVAL.floats, float64(mtailDollar[3].intVal))
 		}
-	case 115:
+	case 118:
 		mtailDollar = mtailS[mtailpt-4 : mtailpt+1]
-//line parser.y:650
+//line parser.y:668
 		{
 			mtailVAL.n = &ast.DecoDecl{P: markedpos(mtaillex), Name: mtailDollar[3].text, Block: mtailDollar[4].n}
 		}
-	case 116:
+	case 119:
 		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
-//line parser.y:658
+//line parser.y:676
 		{
 			mtailVAL.n = &ast.DecoStmt{markedpos(mtaillex), mtailDollar[2].text, mtailDollar[3].n, nil, nil}
 		}
-	case 117:
+	case 120:
 		mtailDollar = mtailS[mtailpt-5 : mtailpt+1]
-//line parser.y:666
+//line parser.y:684
 		{
 			mtailVAL.n = &ast.DelStmt{P: positionFromMark(mtaillex), N: mtailDollar[3].n, Expiry: mtailDollar[5].duration}
 		}
-	case 118:
+	case 121:
 		mtailDollar = mtailS[mtailpt-3 : mtailpt+1]
-//line parser.y:670
+//line parser.y:688
 		{
 			mtailVAL.n = &ast.DelStmt{P: positionFromMark(mtaillex), N: mtailDollar[3].n}
 		}
-	case 119:
+	case 122:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:677
+//line parser.y:695
 		{
 			mtailVAL.text = mtailDollar[1].text
 		}
-	case 120:
+	case 123:
 		mtailDollar = mtailS[mtailpt-1 : mtailpt+1]
-//line parser.y:681
+//line parser.y:699
 		{
 			mtailVAL.text = mtailDollar[1].text
 		}
-	case 121:
+	case 124:
 		mtailDollar = mtailS[mtailpt-0 : mtailpt+1]
-//line parser.y:691
+//line parser.y:709
 		{
 			glog.V(2).Infof("position marked at %v", tokenpos(mtaillex))
 			mtaillex.(*parser).pos = tokenpos(mtaillex)
 		}
-	case 122:
+	case 125:
 		mtailDollar = mtailS[mtailpt-0 : mtailpt+1]
-//line parser.y:701
+//line parser.y:719
 		{
 			mtaillex.(*parser).inRegex()
 		}

--- a/internal/runtime/compiler/parser/parser_test.go
+++ b/internal/runtime/compiler/parser/parser_test.go
@@ -45,6 +45,11 @@ var parserTests = []struct {
 	},
 
 	{
+		"declare dimensioned metric with limit",
+		"counter foo by a, b limit 100",
+	},
+
+	{
 		"declare multi-dimensioned counter",
 		"counter foo by bar, baz, quux\n",
 	},
@@ -576,6 +581,12 @@ var parserInvalidPrograms = []parserInvalidProgram{
 	/(?P<b>.)/ {}
 	`,
 		[]string{"paired pattern without block:2:11: syntax error: statement with no effect, missing an assignment, `+' concatenation, or `{}' block?"},
+	},
+
+	{
+		"dimensioned limit per dimension",
+		"counter foo by a limit 10, b",
+		[]string{"dimensioned limit per dimension:1:26: syntax error: unexpected COMMA"},
 	},
 }
 

--- a/internal/runtime/compiler/parser/unparser.go
+++ b/internal/runtime/compiler/parser/unparser.go
@@ -188,6 +188,9 @@ func (u *Unparser) VisitBefore(n ast.Node) (ast.Visitor, ast.Node) {
 		if len(v.Keys) > 0 {
 			u.emit(" by " + strings.Join(v.Keys, ", "))
 		}
+		if v.Limit > 0 {
+			u.emit(fmt.Sprintf(" limit %d", v.Limit))
+		}
 		if len(v.Buckets) > 0 {
 			buckets := strings.Builder{}
 			buckets.WriteString(" buckets ")

--- a/internal/runtime/compiler/parser/y.output
+++ b/internal/runtime/compiler/parser/y.output
@@ -3,7 +3,7 @@ state 0
 	$accept: .start $end 
 	stmt_list: .    (2)
 
-	.  reduce 2 (src line 98)
+	.  reduce 2 (src line 99)
 
 	stmt_list  goto 2
 	start  goto 1
@@ -18,16 +18,16 @@ state 1
 state 2
 	start:  stmt_list.    (1)
 	stmt_list:  stmt_list.stmt 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 	metric_hide_spec: .    (93)
 
-	$end  reduce 1 (src line 90)
+	$end  reduce 1 (src line 91)
 	INVALID  shift 13
-	COUNTER  reduce 93 (src line 519)
-	GAUGE  reduce 93 (src line 519)
-	TIMER  reduce 93 (src line 519)
-	TEXT  reduce 93 (src line 519)
-	HISTOGRAM  reduce 93 (src line 519)
+	COUNTER  reduce 93 (src line 520)
+	GAUGE  reduce 93 (src line 520)
+	TIMER  reduce 93 (src line 520)
+	TEXT  reduce 93 (src line 520)
+	HISTOGRAM  reduce 93 (src line 520)
 	CONST  shift 11
 	HIDDEN  shift 23
 	NEXT  shift 10
@@ -41,7 +41,7 @@ state 2
 	NOT  shift 31
 	LPAREN  shift 37
 	NL  shift 16
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	stmt  goto 3
 	conditional_stmt  goto 4
@@ -75,49 +75,49 @@ state 2
 state 3
 	stmt_list:  stmt_list stmt.    (3)
 
-	.  reduce 3 (src line 103)
+	.  reduce 3 (src line 104)
 
 
 state 4
 	stmt:  conditional_stmt.    (4)
 
-	.  reduce 4 (src line 113)
+	.  reduce 4 (src line 114)
 
 
 state 5
 	stmt:  expr_stmt.    (5)
 
-	.  reduce 5 (src line 116)
+	.  reduce 5 (src line 117)
 
 
 state 6
 	stmt:  metric_declaration.    (6)
 
-	.  reduce 6 (src line 118)
+	.  reduce 6 (src line 119)
 
 
 state 7
 	stmt:  decorator_declaration.    (7)
 
-	.  reduce 7 (src line 120)
+	.  reduce 7 (src line 121)
 
 
 state 8
 	stmt:  decoration_stmt.    (8)
 
-	.  reduce 8 (src line 122)
+	.  reduce 8 (src line 123)
 
 
 state 9
 	stmt:  delete_stmt.    (9)
 
-	.  reduce 9 (src line 124)
+	.  reduce 9 (src line 125)
 
 
 state 10
 	stmt:  NEXT.    (10)
 
-	.  reduce 10 (src line 126)
+	.  reduce 10 (src line 127)
 
 
 state 11
@@ -131,13 +131,13 @@ state 11
 state 12
 	stmt:  STOP.    (12)
 
-	.  reduce 12 (src line 134)
+	.  reduce 12 (src line 135)
 
 
 state 13
 	stmt:  INVALID.    (13)
 
-	.  reduce 13 (src line 138)
+	.  reduce 13 (src line 139)
 
 
 state 14
@@ -171,7 +171,7 @@ state 15
 state 16
 	expr_stmt:  NL.    (20)
 
-	.  reduce 20 (src line 183)
+	.  reduce 20 (src line 184)
 
 
 state 17
@@ -199,7 +199,7 @@ state 19
 
 	AND  shift 62
 	OR  shift 63
-	.  reduce 17 (src line 165)
+	.  reduce 17 (src line 166)
 
 	logical_op  goto 61
 
@@ -210,14 +210,14 @@ state 20
 
 	AND  shift 62
 	OR  shift 63
-	.  reduce 19 (src line 178)
+	.  reduce 19 (src line 179)
 
 	logical_op  goto 64
 
 state 21
 	expr:  assign_expr.    (23)
 
-	.  reduce 23 (src line 199)
+	.  reduce 23 (src line 200)
 
 
 state 22
@@ -227,15 +227,15 @@ state 22
 
 	INC  shift 66
 	DEC  shift 67
-	NL  reduce 24 (src line 202)
-	.  reduce 68 (src line 383)
+	NL  reduce 24 (src line 203)
+	.  reduce 68 (src line 384)
 
 	postfix_op  goto 65
 
 state 23
 	metric_hide_spec:  HIDDEN.    (94)
 
-	.  reduce 94 (src line 524)
+	.  reduce 94 (src line 525)
 
 
 state 24
@@ -244,7 +244,7 @@ state 24
 	concat_expr:  concat_expr.PLUS opt_nl id_expr 
 
 	PLUS  shift 68
-	.  reduce 58 (src line 340)
+	.  reduce 58 (src line 341)
 
 
 state 25
@@ -254,14 +254,14 @@ state 25
 	BITAND  shift 70
 	XOR  shift 72
 	BITOR  shift 71
-	.  reduce 27 (src line 219)
+	.  reduce 27 (src line 220)
 
 	bitwise_op  goto 69
 
 state 26
 	logical_expr:  match_expr.    (28)
 
-	.  reduce 28 (src line 222)
+	.  reduce 28 (src line 223)
 
 
 state 27
@@ -271,7 +271,7 @@ state 27
 
 	ADD_ASSIGN  shift 74
 	ASSIGN  shift 73
-	.  reduce 62 (src line 362)
+	.  reduce 62 (src line 363)
 
 
 state 28
@@ -281,14 +281,14 @@ state 28
 
 	MATCH  shift 76
 	NOT_MATCH  shift 77
-	.  reduce 70 (src line 393)
+	.  reduce 70 (src line 394)
 
 	match_op  goto 75
 
 state 29
 	concat_expr:  regex_pattern.    (59)
 
-	.  reduce 59 (src line 348)
+	.  reduce 59 (src line 349)
 
 
 state 30
@@ -301,13 +301,13 @@ state 30
 	GE  shift 82
 	EQ  shift 83
 	NE  shift 84
-	.  reduce 33 (src line 242)
+	.  reduce 33 (src line 243)
 
 	rel_op  goto 78
 
 state 31
 	unary_expr:  NOT.unary_expr 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	STRING  shift 36
 	CAPREF  shift 34
@@ -317,7 +317,7 @@ state 31
 	FLOATLITERAL  shift 39
 	NOT  shift 31
 	LPAREN  shift 37
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	primary_expr  goto 87
 	postfix_expr  goto 86
@@ -332,36 +332,36 @@ state 32
 	indexed_expr:  indexed_expr.LSQUARE arg_expr_list RSQUARE 
 
 	LSQUARE  shift 89
-	.  reduce 74 (src line 410)
+	.  reduce 74 (src line 411)
 
 
 state 33
 	primary_expr:  builtin_expr.    (75)
 
-	.  reduce 75 (src line 413)
+	.  reduce 75 (src line 414)
 
 
 state 34
 	primary_expr:  CAPREF.    (76)
 
-	.  reduce 76 (src line 415)
+	.  reduce 76 (src line 416)
 
 
 state 35
 	primary_expr:  CAPREF_NAMED.    (77)
 
-	.  reduce 77 (src line 419)
+	.  reduce 77 (src line 420)
 
 
 state 36
 	primary_expr:  STRING.    (78)
 
-	.  reduce 78 (src line 423)
+	.  reduce 78 (src line 424)
 
 
 state 37
 	primary_expr:  LPAREN.logical_expr RPAREN 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	STRING  shift 36
 	CAPREF  shift 34
@@ -371,7 +371,7 @@ state 37
 	FLOATLITERAL  shift 39
 	NOT  shift 31
 	LPAREN  shift 37
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	primary_expr  goto 28
 	multiplicative_expr  goto 44
@@ -391,13 +391,13 @@ state 37
 state 38
 	primary_expr:  INTLITERAL.    (80)
 
-	.  reduce 80 (src line 431)
+	.  reduce 80 (src line 432)
 
 
 state 39
 	primary_expr:  FLOATLITERAL.    (81)
 
-	.  reduce 81 (src line 435)
+	.  reduce 81 (src line 436)
 
 
 state 40
@@ -406,14 +406,14 @@ state 40
 
 	SHL  shift 93
 	SHR  shift 94
-	.  reduce 38 (src line 261)
+	.  reduce 38 (src line 262)
 
 	shift_op  goto 92
 
 state 41
 	indexed_expr:  id_expr.    (82)
 
-	.  reduce 82 (src line 442)
+	.  reduce 82 (src line 443)
 
 
 state 42
@@ -422,14 +422,14 @@ state 42
 
 	MINUS  shift 97
 	PLUS  shift 96
-	.  reduce 46 (src line 286)
+	.  reduce 46 (src line 287)
 
 	add_op  goto 95
 
 state 43
 	id_expr:  ID.    (84)
 
-	.  reduce 84 (src line 458)
+	.  reduce 84 (src line 459)
 
 
 state 44
@@ -440,16 +440,16 @@ state 44
 	MOD  shift 101
 	MUL  shift 99
 	POW  shift 102
-	.  reduce 50 (src line 303)
+	.  reduce 50 (src line 304)
 
 	mul_op  goto 98
 
 state 45
 	stmt:  CONST id_expr.opt_nl concat_expr 
-	opt_nl: .    (123)
+	opt_nl: .    (126)
 
 	NL  shift 104
-	.  reduce 123 (src line 709)
+	.  reduce 126 (src line 727)
 
 	opt_nl  goto 103
 
@@ -458,14 +458,14 @@ state 46
 	conditional_stmt:  conditional_expr compound_stmt.    (15)
 
 	ELSE  shift 105
-	.  reduce 15 (src line 150)
+	.  reduce 15 (src line 151)
 
 
 state 47
 	compound_stmt:  LCURLY.stmt_list RCURLY 
 	stmt_list: .    (2)
 
-	.  reduce 2 (src line 98)
+	.  reduce 2 (src line 99)
 
 	stmt_list  goto 106
 
@@ -487,9 +487,9 @@ state 49
 
 state 50
 	regex_pattern:  mark_pos DIV.in_regex REGEX DIV 
-	in_regex: .    (122)
+	in_regex: .    (125)
 
-	.  reduce 122 (src line 699)
+	.  reduce 125 (src line 717)
 
 	in_regex  goto 109
 
@@ -511,7 +511,7 @@ state 52
 state 53
 	delete_stmt:  mark_pos DEL.postfix_expr AFTER DURATIONLITERAL 
 	delete_stmt:  mark_pos DEL.postfix_expr 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	STRING  shift 36
 	CAPREF  shift 34
@@ -520,7 +520,7 @@ state 53
 	INTLITERAL  shift 38
 	FLOATLITERAL  shift 39
 	LPAREN  shift 37
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	primary_expr  goto 87
 	postfix_expr  goto 112
@@ -532,7 +532,7 @@ state 53
 state 54
 	expr_stmt:  expr NL.    (21)
 
-	.  reduce 21 (src line 186)
+	.  reduce 21 (src line 187)
 
 
 state 55
@@ -546,210 +546,210 @@ state 55
 	metric_name_spec  goto 114
 
 state 56
-	metric_type_spec:  COUNTER.    (101)
+	metric_type_spec:  COUNTER.    (102)
 
-	.  reduce 101 (src line 566)
+	.  reduce 102 (src line 572)
 
 
 state 57
-	metric_type_spec:  GAUGE.    (102)
+	metric_type_spec:  GAUGE.    (103)
 
-	.  reduce 102 (src line 571)
+	.  reduce 103 (src line 577)
 
 
 state 58
-	metric_type_spec:  TIMER.    (103)
+	metric_type_spec:  TIMER.    (104)
 
-	.  reduce 103 (src line 575)
+	.  reduce 104 (src line 581)
 
 
 state 59
-	metric_type_spec:  TEXT.    (104)
+	metric_type_spec:  TEXT.    (105)
 
-	.  reduce 104 (src line 579)
+	.  reduce 105 (src line 585)
 
 
 state 60
-	metric_type_spec:  HISTOGRAM.    (105)
+	metric_type_spec:  HISTOGRAM.    (106)
 
-	.  reduce 105 (src line 583)
+	.  reduce 106 (src line 589)
 
 
 state 61
 	conditional_expr:  pattern_expr logical_op.opt_nl logical_expr 
-	opt_nl: .    (123)
+	opt_nl: .    (126)
 
 	NL  shift 104
-	.  reduce 123 (src line 709)
+	.  reduce 126 (src line 727)
 
 	opt_nl  goto 117
 
 state 62
 	logical_op:  AND.    (31)
 
-	.  reduce 31 (src line 234)
+	.  reduce 31 (src line 235)
 
 
 state 63
 	logical_op:  OR.    (32)
 
-	.  reduce 32 (src line 237)
+	.  reduce 32 (src line 238)
 
 
 state 64
 	logical_expr:  logical_expr logical_op.opt_nl bitwise_expr 
 	logical_expr:  logical_expr logical_op.opt_nl match_expr 
-	opt_nl: .    (123)
+	opt_nl: .    (126)
 
 	NL  shift 104
-	.  reduce 123 (src line 709)
+	.  reduce 126 (src line 727)
 
 	opt_nl  goto 118
 
 state 65
 	postfix_expr:  postfix_expr postfix_op.    (71)
 
-	.  reduce 71 (src line 396)
+	.  reduce 71 (src line 397)
 
 
 state 66
 	postfix_op:  INC.    (72)
 
-	.  reduce 72 (src line 402)
+	.  reduce 72 (src line 403)
 
 
 state 67
 	postfix_op:  DEC.    (73)
 
-	.  reduce 73 (src line 405)
+	.  reduce 73 (src line 406)
 
 
 state 68
 	concat_expr:  concat_expr PLUS.opt_nl regex_pattern 
 	concat_expr:  concat_expr PLUS.opt_nl id_expr 
-	opt_nl: .    (123)
+	opt_nl: .    (126)
 
 	NL  shift 104
-	.  reduce 123 (src line 709)
+	.  reduce 126 (src line 727)
 
 	opt_nl  goto 119
 
 state 69
 	bitwise_expr:  bitwise_expr bitwise_op.opt_nl rel_expr 
-	opt_nl: .    (123)
+	opt_nl: .    (126)
 
 	NL  shift 104
-	.  reduce 123 (src line 709)
+	.  reduce 126 (src line 727)
 
 	opt_nl  goto 120
 
 state 70
 	bitwise_op:  BITAND.    (35)
 
-	.  reduce 35 (src line 251)
+	.  reduce 35 (src line 252)
 
 
 state 71
 	bitwise_op:  BITOR.    (36)
 
-	.  reduce 36 (src line 254)
+	.  reduce 36 (src line 255)
 
 
 state 72
 	bitwise_op:  XOR.    (37)
 
-	.  reduce 37 (src line 256)
+	.  reduce 37 (src line 257)
 
 
 state 73
 	assign_expr:  unary_expr ASSIGN.opt_nl logical_expr 
-	opt_nl: .    (123)
+	opt_nl: .    (126)
 
 	NL  shift 104
-	.  reduce 123 (src line 709)
+	.  reduce 126 (src line 727)
 
 	opt_nl  goto 121
 
 state 74
 	assign_expr:  unary_expr ADD_ASSIGN.opt_nl logical_expr 
-	opt_nl: .    (123)
+	opt_nl: .    (126)
 
 	NL  shift 104
-	.  reduce 123 (src line 709)
+	.  reduce 126 (src line 727)
 
 	opt_nl  goto 122
 
 state 75
 	match_expr:  primary_expr match_op.opt_nl pattern_expr 
 	match_expr:  primary_expr match_op.opt_nl primary_expr 
-	opt_nl: .    (123)
+	opt_nl: .    (126)
 
 	NL  shift 104
-	.  reduce 123 (src line 709)
+	.  reduce 126 (src line 727)
 
 	opt_nl  goto 123
 
 state 76
 	match_op:  MATCH.    (56)
 
-	.  reduce 56 (src line 331)
+	.  reduce 56 (src line 332)
 
 
 state 77
 	match_op:  NOT_MATCH.    (57)
 
-	.  reduce 57 (src line 334)
+	.  reduce 57 (src line 335)
 
 
 state 78
 	rel_expr:  rel_expr rel_op.opt_nl shift_expr 
-	opt_nl: .    (123)
+	opt_nl: .    (126)
 
 	NL  shift 104
-	.  reduce 123 (src line 709)
+	.  reduce 126 (src line 727)
 
 	opt_nl  goto 124
 
 state 79
 	rel_op:  LT.    (40)
 
-	.  reduce 40 (src line 270)
+	.  reduce 40 (src line 271)
 
 
 state 80
 	rel_op:  GT.    (41)
 
-	.  reduce 41 (src line 273)
+	.  reduce 41 (src line 274)
 
 
 state 81
 	rel_op:  LE.    (42)
 
-	.  reduce 42 (src line 275)
+	.  reduce 42 (src line 276)
 
 
 state 82
 	rel_op:  GE.    (43)
 
-	.  reduce 43 (src line 277)
+	.  reduce 43 (src line 278)
 
 
 state 83
 	rel_op:  EQ.    (44)
 
-	.  reduce 44 (src line 279)
+	.  reduce 44 (src line 280)
 
 
 state 84
 	rel_op:  NE.    (45)
 
-	.  reduce 45 (src line 281)
+	.  reduce 45 (src line 282)
 
 
 state 85
 	unary_expr:  NOT unary_expr.    (69)
 
-	.  reduce 69 (src line 386)
+	.  reduce 69 (src line 387)
 
 
 state 86
@@ -758,14 +758,14 @@ state 86
 
 	INC  shift 66
 	DEC  shift 67
-	.  reduce 68 (src line 383)
+	.  reduce 68 (src line 384)
 
 	postfix_op  goto 65
 
 state 87
 	postfix_expr:  primary_expr.    (70)
 
-	.  reduce 70 (src line 393)
+	.  reduce 70 (src line 394)
 
 
 state 88
@@ -778,7 +778,7 @@ state 88
 
 state 89
 	indexed_expr:  indexed_expr LSQUARE.arg_expr_list RSQUARE 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	STRING  shift 36
 	CAPREF  shift 34
@@ -788,7 +788,7 @@ state 89
 	FLOATLITERAL  shift 39
 	NOT  shift 31
 	LPAREN  shift 37
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	arg_expr_list  goto 125
 	primary_expr  goto 28
@@ -825,98 +825,98 @@ state 90
 state 91
 	multiplicative_expr:  unary_expr.    (62)
 
-	.  reduce 62 (src line 362)
+	.  reduce 62 (src line 363)
 
 
 state 92
 	shift_expr:  shift_expr shift_op.opt_nl additive_expr 
-	opt_nl: .    (123)
+	opt_nl: .    (126)
 
 	NL  shift 104
-	.  reduce 123 (src line 709)
+	.  reduce 126 (src line 727)
 
 	opt_nl  goto 131
 
 state 93
 	shift_op:  SHL.    (48)
 
-	.  reduce 48 (src line 295)
+	.  reduce 48 (src line 296)
 
 
 state 94
 	shift_op:  SHR.    (49)
 
-	.  reduce 49 (src line 298)
+	.  reduce 49 (src line 299)
 
 
 state 95
 	additive_expr:  additive_expr add_op.opt_nl multiplicative_expr 
-	opt_nl: .    (123)
+	opt_nl: .    (126)
 
 	NL  shift 104
-	.  reduce 123 (src line 709)
+	.  reduce 126 (src line 727)
 
 	opt_nl  goto 132
 
 state 96
 	add_op:  PLUS.    (52)
 
-	.  reduce 52 (src line 312)
+	.  reduce 52 (src line 313)
 
 
 state 97
 	add_op:  MINUS.    (53)
 
-	.  reduce 53 (src line 315)
+	.  reduce 53 (src line 316)
 
 
 state 98
 	multiplicative_expr:  multiplicative_expr mul_op.opt_nl unary_expr 
-	opt_nl: .    (123)
+	opt_nl: .    (126)
 
 	NL  shift 104
-	.  reduce 123 (src line 709)
+	.  reduce 126 (src line 727)
 
 	opt_nl  goto 133
 
 state 99
 	mul_op:  MUL.    (64)
 
-	.  reduce 64 (src line 371)
+	.  reduce 64 (src line 372)
 
 
 state 100
 	mul_op:  DIV.    (65)
 
-	.  reduce 65 (src line 374)
+	.  reduce 65 (src line 375)
 
 
 state 101
 	mul_op:  MOD.    (66)
 
-	.  reduce 66 (src line 376)
+	.  reduce 66 (src line 377)
 
 
 state 102
 	mul_op:  POW.    (67)
 
-	.  reduce 67 (src line 378)
+	.  reduce 67 (src line 379)
 
 
 state 103
 	stmt:  CONST id_expr opt_nl.concat_expr 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	concat_expr  goto 134
 	regex_pattern  goto 29
 	mark_pos  goto 135
 
 state 104
-	opt_nl:  NL.    (124)
+	opt_nl:  NL.    (127)
 
-	.  reduce 124 (src line 711)
+	.  reduce 127 (src line 729)
 
 
 state 105
@@ -930,15 +930,15 @@ state 105
 state 106
 	stmt_list:  stmt_list.stmt 
 	compound_stmt:  LCURLY stmt_list.RCURLY 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 	metric_hide_spec: .    (93)
 
 	INVALID  shift 13
-	COUNTER  reduce 93 (src line 519)
-	GAUGE  reduce 93 (src line 519)
-	TIMER  reduce 93 (src line 519)
-	TEXT  reduce 93 (src line 519)
-	HISTOGRAM  reduce 93 (src line 519)
+	COUNTER  reduce 93 (src line 520)
+	GAUGE  reduce 93 (src line 520)
+	TIMER  reduce 93 (src line 520)
+	TEXT  reduce 93 (src line 520)
+	HISTOGRAM  reduce 93 (src line 520)
 	CONST  shift 11
 	HIDDEN  shift 23
 	NEXT  shift 10
@@ -953,7 +953,7 @@ state 106
 	RCURLY  shift 137
 	LPAREN  shift 37
 	NL  shift 16
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	stmt  goto 3
 	conditional_stmt  goto 4
@@ -987,13 +987,13 @@ state 106
 state 107
 	conditional_stmt:  mark_pos OTHERWISE compound_stmt.    (16)
 
-	.  reduce 16 (src line 158)
+	.  reduce 16 (src line 159)
 
 
 state 108
 	builtin_expr:  mark_pos BUILTIN LPAREN.RPAREN 
 	builtin_expr:  mark_pos BUILTIN LPAREN.arg_expr_list RPAREN 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	STRING  shift 36
 	CAPREF  shift 34
@@ -1004,7 +1004,7 @@ state 108
 	NOT  shift 31
 	LPAREN  shift 37
 	RPAREN  shift 138
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	arg_expr_list  goto 139
 	primary_expr  goto 28
@@ -1042,20 +1042,20 @@ state 110
 	compound_stmt  goto 141
 
 state 111
-	decoration_stmt:  mark_pos DECO compound_stmt.    (116)
+	decoration_stmt:  mark_pos DECO compound_stmt.    (119)
 
-	.  reduce 116 (src line 656)
+	.  reduce 119 (src line 674)
 
 
 state 112
 	postfix_expr:  postfix_expr.postfix_op 
 	delete_stmt:  mark_pos DEL postfix_expr.AFTER DURATIONLITERAL 
-	delete_stmt:  mark_pos DEL postfix_expr.    (118)
+	delete_stmt:  mark_pos DEL postfix_expr.    (121)
 
 	AFTER  shift 142
 	INC  shift 66
 	DEC  shift 67
-	.  reduce 118 (src line 669)
+	.  reduce 121 (src line 687)
 
 	postfix_op  goto 65
 
@@ -1064,37 +1064,40 @@ state 113
 	metric_decl_attr_spec:  metric_decl_attr_spec.metric_by_spec 
 	metric_decl_attr_spec:  metric_decl_attr_spec.metric_as_spec 
 	metric_decl_attr_spec:  metric_decl_attr_spec.metric_buckets_spec 
+	metric_decl_attr_spec:  metric_decl_attr_spec.metric_limit_spec 
 
-	AS  shift 147
-	BY  shift 146
-	BUCKETS  shift 148
-	.  reduce 92 (src line 508)
+	AS  shift 148
+	BY  shift 147
+	BUCKETS  shift 149
+	LIMIT  shift 150
+	.  reduce 92 (src line 509)
 
+	metric_limit_spec  goto 146
 	metric_as_spec  goto 144
 	metric_by_spec  goto 143
 	metric_buckets_spec  goto 145
 
 state 114
-	metric_decl_attr_spec:  metric_name_spec.    (98)
+	metric_decl_attr_spec:  metric_name_spec.    (99)
 
-	.  reduce 98 (src line 547)
+	.  reduce 99 (src line 553)
 
 
 state 115
-	metric_name_spec:  ID.    (99)
+	metric_name_spec:  ID.    (100)
 
-	.  reduce 99 (src line 554)
+	.  reduce 100 (src line 560)
 
 
 state 116
-	metric_name_spec:  STRING.    (100)
+	metric_name_spec:  STRING.    (101)
 
-	.  reduce 100 (src line 559)
+	.  reduce 101 (src line 565)
 
 
 state 117
 	conditional_expr:  pattern_expr logical_op opt_nl.logical_expr 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	STRING  shift 36
 	CAPREF  shift 34
@@ -1104,7 +1107,7 @@ state 117
 	FLOATLITERAL  shift 39
 	NOT  shift 31
 	LPAREN  shift 37
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	primary_expr  goto 28
 	multiplicative_expr  goto 44
@@ -1114,7 +1117,7 @@ state 117
 	rel_expr  goto 30
 	shift_expr  goto 40
 	bitwise_expr  goto 25
-	logical_expr  goto 149
+	logical_expr  goto 151
 	indexed_expr  goto 32
 	id_expr  goto 41
 	match_expr  goto 26
@@ -1124,7 +1127,7 @@ state 117
 state 118
 	logical_expr:  logical_expr logical_op opt_nl.bitwise_expr 
 	logical_expr:  logical_expr logical_op opt_nl.match_expr 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	STRING  shift 36
 	CAPREF  shift 34
@@ -1134,7 +1137,7 @@ state 118
 	FLOATLITERAL  shift 39
 	NOT  shift 31
 	LPAREN  shift 37
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	primary_expr  goto 28
 	multiplicative_expr  goto 44
@@ -1143,28 +1146,28 @@ state 118
 	unary_expr  goto 91
 	rel_expr  goto 30
 	shift_expr  goto 40
-	bitwise_expr  goto 150
+	bitwise_expr  goto 152
 	indexed_expr  goto 32
 	id_expr  goto 41
-	match_expr  goto 151
+	match_expr  goto 153
 	builtin_expr  goto 33
 	mark_pos  goto 88
 
 state 119
 	concat_expr:  concat_expr PLUS opt_nl.regex_pattern 
 	concat_expr:  concat_expr PLUS opt_nl.id_expr 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	ID  shift 43
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
-	id_expr  goto 153
-	regex_pattern  goto 152
+	id_expr  goto 155
+	regex_pattern  goto 154
 	mark_pos  goto 135
 
 state 120
 	bitwise_expr:  bitwise_expr bitwise_op opt_nl.rel_expr 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	STRING  shift 36
 	CAPREF  shift 34
@@ -1174,14 +1177,14 @@ state 120
 	FLOATLITERAL  shift 39
 	NOT  shift 31
 	LPAREN  shift 37
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	primary_expr  goto 87
 	multiplicative_expr  goto 44
 	additive_expr  goto 42
 	postfix_expr  goto 86
 	unary_expr  goto 91
-	rel_expr  goto 154
+	rel_expr  goto 156
 	shift_expr  goto 40
 	indexed_expr  goto 32
 	id_expr  goto 41
@@ -1190,7 +1193,7 @@ state 120
 
 state 121
 	assign_expr:  unary_expr ASSIGN opt_nl.logical_expr 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	STRING  shift 36
 	CAPREF  shift 34
@@ -1200,7 +1203,7 @@ state 121
 	FLOATLITERAL  shift 39
 	NOT  shift 31
 	LPAREN  shift 37
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	primary_expr  goto 28
 	multiplicative_expr  goto 44
@@ -1210,7 +1213,7 @@ state 121
 	rel_expr  goto 30
 	shift_expr  goto 40
 	bitwise_expr  goto 25
-	logical_expr  goto 155
+	logical_expr  goto 157
 	indexed_expr  goto 32
 	id_expr  goto 41
 	match_expr  goto 26
@@ -1219,7 +1222,7 @@ state 121
 
 state 122
 	assign_expr:  unary_expr ADD_ASSIGN opt_nl.logical_expr 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	STRING  shift 36
 	CAPREF  shift 34
@@ -1229,7 +1232,7 @@ state 122
 	FLOATLITERAL  shift 39
 	NOT  shift 31
 	LPAREN  shift 37
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	primary_expr  goto 28
 	multiplicative_expr  goto 44
@@ -1239,7 +1242,7 @@ state 122
 	rel_expr  goto 30
 	shift_expr  goto 40
 	bitwise_expr  goto 25
-	logical_expr  goto 156
+	logical_expr  goto 158
 	indexed_expr  goto 32
 	id_expr  goto 41
 	match_expr  goto 26
@@ -1249,7 +1252,7 @@ state 122
 state 123
 	match_expr:  primary_expr match_op opt_nl.pattern_expr 
 	match_expr:  primary_expr match_op opt_nl.primary_expr 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	STRING  shift 36
 	CAPREF  shift 34
@@ -1258,20 +1261,20 @@ state 123
 	INTLITERAL  shift 38
 	FLOATLITERAL  shift 39
 	LPAREN  shift 37
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
-	primary_expr  goto 158
+	primary_expr  goto 160
 	indexed_expr  goto 32
 	id_expr  goto 41
 	concat_expr  goto 24
-	pattern_expr  goto 157
+	pattern_expr  goto 159
 	regex_pattern  goto 29
 	builtin_expr  goto 33
 	mark_pos  goto 129
 
 state 124
 	rel_expr:  rel_expr rel_op opt_nl.shift_expr 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	STRING  shift 36
 	CAPREF  shift 34
@@ -1281,14 +1284,14 @@ state 124
 	FLOATLITERAL  shift 39
 	NOT  shift 31
 	LPAREN  shift 37
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	primary_expr  goto 87
 	multiplicative_expr  goto 44
 	additive_expr  goto 42
 	postfix_expr  goto 86
 	unary_expr  goto 91
-	shift_expr  goto 159
+	shift_expr  goto 161
 	indexed_expr  goto 32
 	id_expr  goto 41
 	builtin_expr  goto 33
@@ -1298,15 +1301,15 @@ state 125
 	indexed_expr:  indexed_expr LSQUARE arg_expr_list.RSQUARE 
 	arg_expr_list:  arg_expr_list.COMMA arg_expr 
 
-	RSQUARE  shift 160
-	COMMA  shift 161
+	RSQUARE  shift 162
+	COMMA  shift 163
 	.  error
 
 
 state 126
 	arg_expr_list:  arg_expr.    (87)
 
-	.  reduce 87 (src line 479)
+	.  reduce 87 (src line 480)
 
 
 state 127
@@ -1316,14 +1319,14 @@ state 127
 
 	AND  shift 62
 	OR  shift 63
-	.  reduce 89 (src line 492)
+	.  reduce 89 (src line 493)
 
 	logical_op  goto 64
 
 state 128
 	arg_expr:  pattern_expr.    (90)
 
-	.  reduce 90 (src line 495)
+	.  reduce 90 (src line 496)
 
 
 state 129
@@ -1339,12 +1342,12 @@ state 129
 state 130
 	primary_expr:  LPAREN logical_expr RPAREN.    (79)
 
-	.  reduce 79 (src line 427)
+	.  reduce 79 (src line 428)
 
 
 state 131
 	shift_expr:  shift_expr shift_op opt_nl.additive_expr 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	STRING  shift 36
 	CAPREF  shift 34
@@ -1354,11 +1357,11 @@ state 131
 	FLOATLITERAL  shift 39
 	NOT  shift 31
 	LPAREN  shift 37
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	primary_expr  goto 87
 	multiplicative_expr  goto 44
-	additive_expr  goto 162
+	additive_expr  goto 164
 	postfix_expr  goto 86
 	unary_expr  goto 91
 	indexed_expr  goto 32
@@ -1368,7 +1371,7 @@ state 131
 
 state 132
 	additive_expr:  additive_expr add_op opt_nl.multiplicative_expr 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	STRING  shift 36
 	CAPREF  shift 34
@@ -1378,10 +1381,10 @@ state 132
 	FLOATLITERAL  shift 39
 	NOT  shift 31
 	LPAREN  shift 37
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	primary_expr  goto 87
-	multiplicative_expr  goto 163
+	multiplicative_expr  goto 165
 	postfix_expr  goto 86
 	unary_expr  goto 91
 	indexed_expr  goto 32
@@ -1391,7 +1394,7 @@ state 132
 
 state 133
 	multiplicative_expr:  multiplicative_expr mul_op opt_nl.unary_expr 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	STRING  shift 36
 	CAPREF  shift 34
@@ -1401,11 +1404,11 @@ state 133
 	FLOATLITERAL  shift 39
 	NOT  shift 31
 	LPAREN  shift 37
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	primary_expr  goto 87
 	postfix_expr  goto 86
-	unary_expr  goto 164
+	unary_expr  goto 166
 	indexed_expr  goto 32
 	id_expr  goto 41
 	builtin_expr  goto 33
@@ -1417,7 +1420,7 @@ state 134
 	concat_expr:  concat_expr.PLUS opt_nl id_expr 
 
 	PLUS  shift 68
-	.  reduce 11 (src line 130)
+	.  reduce 11 (src line 131)
 
 
 state 135
@@ -1430,135 +1433,149 @@ state 135
 state 136
 	conditional_stmt:  conditional_expr compound_stmt ELSE compound_stmt.    (14)
 
-	.  reduce 14 (src line 145)
+	.  reduce 14 (src line 146)
 
 
 state 137
 	compound_stmt:  LCURLY stmt_list RCURLY.    (22)
 
-	.  reduce 22 (src line 191)
+	.  reduce 22 (src line 192)
 
 
 state 138
 	builtin_expr:  mark_pos BUILTIN LPAREN RPAREN.    (85)
 
-	.  reduce 85 (src line 466)
+	.  reduce 85 (src line 467)
 
 
 state 139
 	builtin_expr:  mark_pos BUILTIN LPAREN arg_expr_list.RPAREN 
 	arg_expr_list:  arg_expr_list.COMMA arg_expr 
 
-	RPAREN  shift 165
-	COMMA  shift 161
+	RPAREN  shift 167
+	COMMA  shift 163
 	.  error
 
 
 state 140
 	regex_pattern:  mark_pos DIV in_regex REGEX.DIV 
 
-	DIV  shift 166
+	DIV  shift 168
 	.  error
 
 
 state 141
-	decorator_declaration:  mark_pos DEF ID compound_stmt.    (115)
+	decorator_declaration:  mark_pos DEF ID compound_stmt.    (118)
 
-	.  reduce 115 (src line 648)
+	.  reduce 118 (src line 666)
 
 
 state 142
 	delete_stmt:  mark_pos DEL postfix_expr AFTER.DURATIONLITERAL 
 
-	DURATIONLITERAL  shift 167
+	DURATIONLITERAL  shift 169
 	.  error
 
 
 state 143
 	metric_decl_attr_spec:  metric_decl_attr_spec metric_by_spec.    (95)
 
-	.  reduce 95 (src line 531)
+	.  reduce 95 (src line 532)
 
 
 state 144
 	metric_decl_attr_spec:  metric_decl_attr_spec metric_as_spec.    (96)
 
-	.  reduce 96 (src line 537)
+	.  reduce 96 (src line 538)
 
 
 state 145
 	metric_decl_attr_spec:  metric_decl_attr_spec metric_buckets_spec.    (97)
 
-	.  reduce 97 (src line 542)
+	.  reduce 97 (src line 543)
 
 
 state 146
-	metric_by_spec:  BY.metric_by_expr_list 
+	metric_decl_attr_spec:  metric_decl_attr_spec metric_limit_spec.    (98)
 
-	STRING  shift 171
-	ID  shift 170
-	.  error
+	.  reduce 98 (src line 548)
 
-	id_or_string  goto 169
-	metric_by_expr_list  goto 168
 
 state 147
-	metric_as_spec:  AS.STRING 
+	metric_by_spec:  BY.metric_by_expr_list 
 
-	STRING  shift 172
+	STRING  shift 174
+	ID  shift 173
 	.  error
 
+	id_or_string  goto 172
+	metric_by_expr  goto 171
+	metric_by_expr_list  goto 170
 
 state 148
-	metric_buckets_spec:  BUCKETS.metric_buckets_list 
+	metric_as_spec:  AS.STRING 
 
-	INTLITERAL  shift 175
-	FLOATLITERAL  shift 174
+	STRING  shift 175
 	.  error
 
-	metric_buckets_list  goto 173
 
 state 149
+	metric_buckets_spec:  BUCKETS.metric_buckets_list 
+
+	INTLITERAL  shift 178
+	FLOATLITERAL  shift 177
+	.  error
+
+	metric_buckets_list  goto 176
+
+state 150
+	metric_limit_spec:  LIMIT.INTLITERAL 
+
+	INTLITERAL  shift 179
+	.  error
+
+
+state 151
 	conditional_expr:  pattern_expr logical_op opt_nl logical_expr.    (18)
 	logical_expr:  logical_expr.logical_op opt_nl bitwise_expr 
 	logical_expr:  logical_expr.logical_op opt_nl match_expr 
 
 	AND  shift 62
 	OR  shift 63
-	.  reduce 18 (src line 170)
+	.  reduce 18 (src line 171)
 
 	logical_op  goto 64
 
-state 150
+state 152
 	logical_expr:  logical_expr logical_op opt_nl bitwise_expr.    (29)
 	bitwise_expr:  bitwise_expr.bitwise_op opt_nl rel_expr 
 
 	BITAND  shift 70
 	XOR  shift 72
 	BITOR  shift 71
-	.  reduce 29 (src line 224)
+	.  reduce 29 (src line 225)
 
 	bitwise_op  goto 69
 
-state 151
+state 153
 	logical_expr:  logical_expr logical_op opt_nl match_expr.    (30)
 
-	.  reduce 30 (src line 228)
-
-
-state 152
-	concat_expr:  concat_expr PLUS opt_nl regex_pattern.    (60)
-
-	.  reduce 60 (src line 351)
-
-
-state 153
-	concat_expr:  concat_expr PLUS opt_nl id_expr.    (61)
-
-	.  reduce 61 (src line 355)
+	.  reduce 30 (src line 229)
 
 
 state 154
+	concat_expr:  concat_expr PLUS opt_nl regex_pattern.    (60)
+
+	.  reduce 60 (src line 352)
+
+
+state 155
+	concat_expr:  concat_expr PLUS opt_nl id_expr.    (61)
+
+	.  reduce 61 (src line 356)
+
+
+state 156
 	bitwise_expr:  bitwise_expr bitwise_op opt_nl rel_expr.    (34)
 	rel_expr:  rel_expr.rel_op opt_nl shift_expr 
 
@@ -1568,63 +1585,63 @@ state 154
 	GE  shift 82
 	EQ  shift 83
 	NE  shift 84
-	.  reduce 34 (src line 245)
+	.  reduce 34 (src line 246)
 
 	rel_op  goto 78
 
-state 155
+state 157
 	assign_expr:  unary_expr ASSIGN opt_nl logical_expr.    (25)
 	logical_expr:  logical_expr.logical_op opt_nl bitwise_expr 
 	logical_expr:  logical_expr.logical_op opt_nl match_expr 
 
 	AND  shift 62
 	OR  shift 63
-	.  reduce 25 (src line 207)
+	.  reduce 25 (src line 208)
 
 	logical_op  goto 64
 
-state 156
+state 158
 	assign_expr:  unary_expr ADD_ASSIGN opt_nl logical_expr.    (26)
 	logical_expr:  logical_expr.logical_op opt_nl bitwise_expr 
 	logical_expr:  logical_expr.logical_op opt_nl match_expr 
 
 	AND  shift 62
 	OR  shift 63
-	.  reduce 26 (src line 212)
+	.  reduce 26 (src line 213)
 
 	logical_op  goto 64
 
-state 157
+state 159
 	match_expr:  primary_expr match_op opt_nl pattern_expr.    (54)
 
-	.  reduce 54 (src line 320)
+	.  reduce 54 (src line 321)
 
 
-state 158
+state 160
 	match_expr:  primary_expr match_op opt_nl primary_expr.    (55)
 
-	.  reduce 55 (src line 325)
+	.  reduce 55 (src line 326)
 
 
-state 159
+state 161
 	rel_expr:  rel_expr rel_op opt_nl shift_expr.    (39)
 	shift_expr:  shift_expr.shift_op opt_nl additive_expr 
 
 	SHL  shift 93
 	SHR  shift 94
-	.  reduce 39 (src line 264)
+	.  reduce 39 (src line 265)
 
 	shift_op  goto 92
 
-state 160
+state 162
 	indexed_expr:  indexed_expr LSQUARE arg_expr_list RSQUARE.    (83)
 
-	.  reduce 83 (src line 448)
+	.  reduce 83 (src line 449)
 
 
-state 161
+state 163
 	arg_expr_list:  arg_expr_list COMMA.arg_expr 
-	mark_pos: .    (121)
+	mark_pos: .    (124)
 
 	STRING  shift 36
 	CAPREF  shift 34
@@ -1634,7 +1651,7 @@ state 161
 	FLOATLITERAL  shift 39
 	NOT  shift 31
 	LPAREN  shift 37
-	.  reduce 121 (src line 689)
+	.  reduce 124 (src line 707)
 
 	primary_expr  goto 28
 	multiplicative_expr  goto 44
@@ -1652,20 +1669,20 @@ state 161
 	regex_pattern  goto 29
 	match_expr  goto 26
 	builtin_expr  goto 33
-	arg_expr  goto 176
+	arg_expr  goto 180
 	mark_pos  goto 129
 
-state 162
+state 164
 	shift_expr:  shift_expr shift_op opt_nl additive_expr.    (47)
 	additive_expr:  additive_expr.add_op opt_nl multiplicative_expr 
 
 	MINUS  shift 97
 	PLUS  shift 96
-	.  reduce 47 (src line 289)
+	.  reduce 47 (src line 290)
 
 	add_op  goto 95
 
-state 163
+state 165
 	additive_expr:  additive_expr add_op opt_nl multiplicative_expr.    (51)
 	multiplicative_expr:  multiplicative_expr.mul_op opt_nl unary_expr 
 
@@ -1673,138 +1690,151 @@ state 163
 	MOD  shift 101
 	MUL  shift 99
 	POW  shift 102
-	.  reduce 51 (src line 306)
+	.  reduce 51 (src line 307)
 
 	mul_op  goto 98
 
-state 164
+state 166
 	multiplicative_expr:  multiplicative_expr mul_op opt_nl unary_expr.    (63)
 
-	.  reduce 63 (src line 365)
-
-
-state 165
-	builtin_expr:  mark_pos BUILTIN LPAREN arg_expr_list RPAREN.    (86)
-
-	.  reduce 86 (src line 471)
-
-
-state 166
-	regex_pattern:  mark_pos DIV in_regex REGEX DIV.    (91)
-
-	.  reduce 91 (src line 500)
+	.  reduce 63 (src line 366)
 
 
 state 167
-	delete_stmt:  mark_pos DEL postfix_expr AFTER DURATIONLITERAL.    (117)
+	builtin_expr:  mark_pos BUILTIN LPAREN arg_expr_list RPAREN.    (86)
 
-	.  reduce 117 (src line 664)
+	.  reduce 86 (src line 472)
 
 
 state 168
-	metric_by_spec:  BY metric_by_expr_list.    (106)
-	metric_by_expr_list:  metric_by_expr_list.COMMA id_or_string 
+	regex_pattern:  mark_pos DIV in_regex REGEX DIV.    (91)
 
-	COMMA  shift 177
-	.  reduce 106 (src line 590)
+	.  reduce 91 (src line 501)
 
 
 state 169
-	metric_by_expr_list:  id_or_string.    (107)
+	delete_stmt:  mark_pos DEL postfix_expr AFTER DURATIONLITERAL.    (120)
 
-	.  reduce 107 (src line 597)
+	.  reduce 120 (src line 682)
 
 
 state 170
-	id_or_string:  ID.    (119)
+	metric_by_spec:  BY metric_by_expr_list.    (107)
+	metric_by_expr_list:  metric_by_expr_list.COMMA metric_by_expr 
 
-	.  reduce 119 (src line 675)
+	COMMA  shift 181
+	.  reduce 107 (src line 596)
 
 
 state 171
-	id_or_string:  STRING.    (120)
-
-	.  reduce 120 (src line 680)
-
-
-state 172
-	metric_as_spec:  AS STRING.    (109)
-
-	.  reduce 109 (src line 611)
-
-
-state 173
-	metric_buckets_spec:  BUCKETS metric_buckets_list.    (110)
-	metric_buckets_list:  metric_buckets_list.COMMA FLOATLITERAL 
-	metric_buckets_list:  metric_buckets_list.COMMA INTLITERAL 
-
-	COMMA  shift 178
-	.  reduce 110 (src line 619)
-
-
-state 174
-	metric_buckets_list:  FLOATLITERAL.    (111)
-
-	.  reduce 111 (src line 625)
-
-
-state 175
-	metric_buckets_list:  INTLITERAL.    (112)
-
-	.  reduce 112 (src line 631)
-
-
-state 176
-	arg_expr_list:  arg_expr_list COMMA arg_expr.    (88)
-
-	.  reduce 88 (src line 485)
-
-
-state 177
-	metric_by_expr_list:  metric_by_expr_list COMMA.id_or_string 
-
-	STRING  shift 171
-	ID  shift 170
-	.  error
-
-	id_or_string  goto 179
-
-state 178
-	metric_buckets_list:  metric_buckets_list COMMA.FLOATLITERAL 
-	metric_buckets_list:  metric_buckets_list COMMA.INTLITERAL 
-
-	INTLITERAL  shift 181
-	FLOATLITERAL  shift 180
-	.  error
-
-
-state 179
-	metric_by_expr_list:  metric_by_expr_list COMMA id_or_string.    (108)
+	metric_by_expr_list:  metric_by_expr.    (108)
 
 	.  reduce 108 (src line 603)
 
 
-state 180
-	metric_buckets_list:  metric_buckets_list COMMA FLOATLITERAL.    (113)
+state 172
+	metric_by_expr:  id_or_string.    (110)
 
-	.  reduce 113 (src line 636)
+	.  reduce 110 (src line 616)
+
+
+state 173
+	id_or_string:  ID.    (122)
+
+	.  reduce 122 (src line 693)
+
+
+state 174
+	id_or_string:  STRING.    (123)
+
+	.  reduce 123 (src line 698)
+
+
+state 175
+	metric_as_spec:  AS STRING.    (111)
+
+	.  reduce 111 (src line 622)
+
+
+state 176
+	metric_buckets_spec:  BUCKETS metric_buckets_list.    (113)
+	metric_buckets_list:  metric_buckets_list.COMMA FLOATLITERAL 
+	metric_buckets_list:  metric_buckets_list.COMMA INTLITERAL 
+
+	COMMA  shift 182
+	.  reduce 113 (src line 637)
+
+
+state 177
+	metric_buckets_list:  FLOATLITERAL.    (114)
+
+	.  reduce 114 (src line 643)
+
+
+state 178
+	metric_buckets_list:  INTLITERAL.    (115)
+
+	.  reduce 115 (src line 649)
+
+
+state 179
+	metric_limit_spec:  LIMIT INTLITERAL.    (112)
+
+	.  reduce 112 (src line 629)
+
+
+state 180
+	arg_expr_list:  arg_expr_list COMMA arg_expr.    (88)
+
+	.  reduce 88 (src line 486)
 
 
 state 181
-	metric_buckets_list:  metric_buckets_list COMMA INTLITERAL.    (114)
+	metric_by_expr_list:  metric_by_expr_list COMMA.metric_by_expr 
 
-	.  reduce 114 (src line 641)
+	STRING  shift 174
+	ID  shift 173
+	.  error
+
+	id_or_string  goto 172
+	metric_by_expr  goto 183
+
+state 182
+	metric_buckets_list:  metric_buckets_list COMMA.FLOATLITERAL 
+	metric_buckets_list:  metric_buckets_list COMMA.INTLITERAL 
+
+	INTLITERAL  shift 185
+	FLOATLITERAL  shift 184
+	.  error
 
 
-65 terminals, 53 nonterminals
-125 grammar rules, 182/16000 states
+state 183
+	metric_by_expr_list:  metric_by_expr_list COMMA metric_by_expr.    (109)
+
+	.  reduce 109 (src line 609)
+
+
+state 184
+	metric_buckets_list:  metric_buckets_list COMMA FLOATLITERAL.    (116)
+
+	.  reduce 116 (src line 654)
+
+
+state 185
+	metric_buckets_list:  metric_buckets_list COMMA INTLITERAL.    (117)
+
+	.  reduce 117 (src line 659)
+
+
+66 terminals, 55 nonterminals
+128 grammar rules, 186/16000 states
 0 shift/reduce, 0 reduce/reduce conflicts reported
-102 working sets used
+104 working sets used
 memory: parser 397/240000
-165 extra closures
-280 shift entries, 13 exceptions
-114 goto entries
-192 entries saved by goto default
-Optimizer space used: output 243/240000
-243 table entries, 0 zero
-maximum spread: 65, maximum offset: 177
+169 extra closures
+282 shift entries, 13 exceptions
+116 goto entries
+193 entries saved by goto default
+Optimizer space used: output 249/240000
+249 table entries, 2 zero
+maximum spread: 66, maximum offset: 181


### PR DESCRIPTION
The new keyword `limit` on a metric declaration specifies a storage size limit on simultaneous label values; if the metric exceeds that size then the next GC run will remove the oldest by timestamp until it is back under the limit.

Fixes #617