### PR TITLE
Stabilize order of labels in statsd/graphite/collectd export

### DIFF
--- a/internal/exporter/export.go
+++ b/internal/exporter/export.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -140,10 +141,15 @@ func (e *Exporter) SetOption(options ...Option) error {
 func formatLabels(name string, m map[string]string, ksep, sep, rep string) string {
 	r := name
 	if len(m) > 0 {
+		var keys []string
+		for k := range m {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
 		var s []string
-		for k, v := range m {
+		for _, k := range keys {
 			k1 := strings.ReplaceAll(strings.ReplaceAll(k, ksep, rep), sep, rep)
-			v1 := strings.ReplaceAll(strings.ReplaceAll(v, ksep, rep), sep, rep)
+			v1 := strings.ReplaceAll(strings.ReplaceAll(m[k], ksep, rep), sep, rep)
 			s = append(s, fmt.Sprintf("%s%s%s", k1, ksep, v1))
 		}
 		return r + sep + strings.Join(s, sep)

--- a/internal/exporter/export_test.go
+++ b/internal/exporter/export_test.go
@@ -195,6 +195,15 @@ func TestMetricToStatsd(t *testing.T) {
 		t.Errorf("String didn't match:\n\texpected: %v\n\treceived: %v", expected, r)
 	}
 
+	multiLabelMetric := metrics.NewMetric("bar", "prog", metrics.Gauge, metrics.Int, "c", "a", "b")
+	d, _ = multiLabelMetric.GetDatum("x","z","y")
+	datum.SetInt(d, 37, ts)
+	r = FakeSocketWrite(metricToStatsd, multiLabelMetric)
+	expected = []string{"prog.bar.a.z.b.y.c.x:37|g"}
+	if !reflect.DeepEqual(expected, r) {
+		t.Errorf("String didn't match:\n\texpected: %v\n\treceived: %v", expected, r)
+	}
+
 	timingMetric := metrics.NewMetric("foo", "prog", metrics.Timer, metrics.Int)
 	d, _ = timingMetric.GetDatum()
 	datum.SetInt(d, 37, ts)

--- a/internal/exporter/export_test.go
+++ b/internal/exporter/export_test.go
@@ -196,7 +196,7 @@ func TestMetricToStatsd(t *testing.T) {
 	}
 
 	multiLabelMetric := metrics.NewMetric("bar", "prog", metrics.Gauge, metrics.Int, "c", "a", "b")
-	d, _ = multiLabelMetric.GetDatum("x","z","y")
+	d, _ = multiLabelMetric.GetDatum("x", "z", "y")
 	datum.SetInt(d, 37, ts)
 	r = FakeSocketWrite(metricToStatsd, multiLabelMetric)
 	expected = []string{"prog.bar.a.z.b.y.c.x:37|g"}


### PR DESCRIPTION
When parsing statsd/graphite metrics with the positional [telegraf templates](https://docs.influxdata.com/telegraf/v1.22/data_formats/template-patterns/), the order of labels is critical.

Thus let's ensure that the order of labels in the export is stable by sorting them.

Signed-off-by: Andreas Jaggi <andreas.jaggi@waterwave.ch>