### PR TITLE
Fix Unicode replacement character appear in parse result

### DIFF
--- a/internal/tailer/logstream/filestream.go
+++ b/internal/tailer/logstream/filestream.go
@@ -82,6 +82,7 @@ func (fs *fileStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wake
 		glog.V(2).Infof("%v: seeked to end", fd)
 	}
 	b := make([]byte, defaultReadBufferSize)
+	var lastBytes []byte
 	partial := bytes.NewBufferString("")
 	started := make(chan struct{})
 	var total int
@@ -106,7 +107,13 @@ func (fs *fileStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wake
 			if count > 0 {
 				total += count
 				glog.V(2).Infof("%v: decode and send", fd)
-				decodeAndSend(ctx, fs.lines, fs.pathname, count, b[:count], partial)
+				needSend := append(lastBytes, b[:count]...)
+				sendCount := decodeAndSend(ctx, fs.lines, fs.pathname, len(needSend), needSend, partial)
+				if sendCount < len(needSend) {
+					lastBytes = append([]byte{}, needSend[sendCount:]...)
+				} else {
+					lastBytes = []byte{}
+				}
 				fs.mu.Lock()
 				fs.lastReadTime = time.Now()
 				fs.mu.Unlock()

--- a/internal/tailer/logstream/filestream.go
+++ b/internal/tailer/logstream/filestream.go
@@ -107,7 +107,8 @@ func (fs *fileStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wake
 			if count > 0 {
 				total += count
 				glog.V(2).Infof("%v: decode and send", fd)
-				needSend := append(lastBytes, b[:count]...)
+				needSend := lastBytes
+				needSend = append(needSend, b[:count]...)
 				sendCount := decodeAndSend(ctx, fs.lines, fs.pathname, len(needSend), needSend, partial)
 				if sendCount < len(needSend) {
 					lastBytes = append([]byte{}, needSend[sendCount:]...)

--- a/internal/tailer/logstream/filestream_test.go
+++ b/internal/tailer/logstream/filestream_test.go
@@ -50,6 +50,47 @@ func TestFileStreamRead(t *testing.T) {
 	wg.Wait()
 }
 
+func TestFileStreamReadNonSingleByteEnd(t *testing.T) {
+	var wg sync.WaitGroup
+
+	tmpDir := testutil.TestTempDir(t)
+
+	name := filepath.Join(tmpDir, "log")
+	f := testutil.TestOpenFile(t, name)
+	defer f.Close()
+
+	lines := make(chan *logline.LogLine, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	waker, awaken := waker.NewTest(ctx, 1)
+	fs, err := logstream.New(ctx, &wg, waker, name, lines, true)
+	testutil.FatalIfErr(t, err)
+	awaken(1)
+
+	s := "a"
+	for i := 0; i < 4094; i++ {
+		s += "a"
+	}
+
+	s += "中"
+	testutil.WriteString(t, f, s+"\n")
+	awaken(1)
+
+	fs.Stop()
+	wg.Wait()
+	close(lines)
+	received := testutil.LinesReceived(lines)
+	expected := []*logline.LogLine{
+		{context.TODO(), name, s},
+	}
+	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
+
+	if !fs.IsComplete() {
+		t.Errorf("expecting filestream to be complete because stopped")
+	}
+	cancel()
+	wg.Wait()
+}
+
 func TestFileStreamTruncation(t *testing.T) {
 	var wg sync.WaitGroup
 


### PR DESCRIPTION
We need catch the utf8.RuneError when decode the file stream.

Detail see issue: #637