### PR TITLE
Raise minimum Go version to 1.17.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,3 +13,18 @@ require (
 	go.opencensus.io v0.23.0
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
 )
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/uber/jaeger-client-go v2.25.0+incompatible // indirect
+	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a // indirect
+	google.golang.org/api v0.30.0 // indirect
+	google.golang.org/genproto v0.0.0-20200825200019-8632dd797987 // indirect
+	google.golang.org/grpc v1.33.2 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/mtail
 
-go 1.16
+go 1.17
 
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.1


### PR DESCRIPTION
https://github.com/google/mtail/commit/e494568bb97919b22caeb7949a8158dc0c7238b2#r77513974
indicates that math.MaxInt is not available earlier.