### PR TITLE
ci: Use the version of go specified in go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.x'
+          go-version-file: 'go.mod'
+          cache: true
       - uses: actions/cache@v3
         id: cache
         with:


### PR DESCRIPTION
Use the setup-go cache feature.