### PR TITLE
Fix memory leak on corrupt unicode character

### DIFF
--- a/internal/tailer/logstream/filestream_test.go
+++ b/internal/tailer/logstream/filestream_test.go
@@ -110,9 +110,10 @@ func TestStreamDoesntBreakOnCorruptRune(t *testing.T) {
 	s := string([]byte{0xF1})
 	// 0xF1 = 11110001 , a byte signaling the start of a unicode character that
 	// is 4 bytes long.
-	// The following characters are regular single-byte
-	// characters, which don't start with a 1 bit to signal it's part of a
-	// unicode character. This will result in a RuneError.
+
+	// The following characters are regular single-byte characters.
+	// utf8.DecodeRune will expect bytes that start with a 1 after the initial
+	// unicode character 0xF1. This will result in a RuneError.
 	for i := 0; i < 100; i++ {
 		s += "a"
 	}
@@ -134,7 +135,6 @@ func TestStreamDoesntBreakOnCorruptRune(t *testing.T) {
 	}
 	cancel()
 	wg.Wait()
-
 }
 
 func TestFileStreamTruncation(t *testing.T) {


### PR DESCRIPTION
Fix for a memory leak which is hitting us on v3.0.0-rc50.

When a corrupt unicode character is received, mtail stops processing logs and instead buffers them in memory. It happens because a recent change ( c12a012 ) has made it so parsing of bytes in the log buffer to runes is being retried when parsing results in a RuneError. I guess that change was made under the assumption that rune errors are always recoverable (you just need to increase the buffer), but that is not the case. In production we've seen this memory leak happen multiple times since we deployed the new version of mtail.

With this commit RuneErrors on parsing unicode characters are ignored when there are enough characters after it in the buffer.
This keeps the functionality intact that bytes that gave a RuneError are being reparsed, but with a larger buffer, to not break unicode characters which were split in half from the buffered reading on the logfile being read.