### PR TITLE
ci: Downgrade goreleaser action.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - run: git fetch --force --tags
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.x'
-      - uses: goreleaser/goreleaser-action@v4
+          go-version-file: 'go.mod'
+          cache: true
+      - uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
See if this fixes the goreleaser snapshot mode on pull_request.