### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/benchmark-done.yml
+++ b/.github/workflows/benchmark-done.yml
@@ -36,12 +36,12 @@ jobs:
         run: |
           mkdir -p benchmark-comment
           unzip -d benchmark-comment benchmark-comment.zip
-          echo "::set-output name=pr-number::$(cat benchmark-comment/pr-number)"
+          echo "pr-number=$(cat benchmark-comment/pr-number)" >> $GITHUB_OUTPUT
           COMMENT=$(cat benchmark-comment/benchstat.txt)
           COMMENT="${COMMENT//'%'/'%25'}"
           COMMENT="${COMMENT//$'\n'/'%0A'}"
           COMMENT="${COMMENT//$'\r'/'%0D'}"
-          echo "::set-output name=comment::$COMMENT"
+          echo "comment=$COMMENT" >> $GITHUB_OUTPUT
       - name: post benchmark results
         uses: marocchino/sticky-pull-request-comment@v2
         with:

--- a/.github/workflows/ci-done.yml
+++ b/.github/workflows/ci-done.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           mkdir -p test-results
           unzip -d test-results test-results.zip
-          echo "::set-output name=sha::$(cat test-results/sha-number)"
+          echo "sha=$(cat test-results/sha-number)" >> $GITHUB_OUTPUT
       - uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
         with:
           commit: ${{ steps.unpack.outputs.sha }}


### PR DESCRIPTION
## Description

Resolve  #726 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=comment::$COMMENT"
```

**TO-BE**

```yml
echo "comment=$COMMENT" >> $GITHUB_OUTPUT
```