### PR TITLE
chore: Update Go to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/mtail
 
-go 1.18
+go 1.20
 
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.1

--- a/internal/mtail/examples_integration_unix_test.go
+++ b/internal/mtail/examples_integration_unix_test.go
@@ -150,7 +150,8 @@ func TestFileSocketStreamComparison(t *testing.T) {
 						testutil.FatalIfErr(t, err)
 						s, err := net.DialUnix(scheme, nil, &net.UnixAddr{sockName, scheme})
 						testutil.FatalIfErr(t, err)
-						n, err := io.Copy(s, source)
+						buf := make([]byte, 1024)
+						n, err := io.CopyBuffer(s, source, buf)
 						testutil.FatalIfErr(t, err)
 						glog.Infof("Copied %d bytes into socket", n)
 						if scheme == "unixgram" {


### PR DESCRIPTION
See if reducing the copy buffer size makes the test succeed on MacOS test runners.