### PR TITLE
ci: Remove the archives.replacements field from the goreleaser config.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,13 +18,6 @@ builds:
     gcflags:
       # I love errors.
       - -e
-archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
This has been deprecated and removed upstream.