### PR TITLE
Feature/spl 241392

### DIFF
--- a/cmd/mtail/main.go
+++ b/cmd/mtail/main.go
@@ -59,6 +59,7 @@ var (
 	overrideTimezone     = flag.String("override_timezone", "", "If set, use the provided timezone in timestamp conversion, instead of UTC.")
 	emitProgLabel        = flag.Bool("emit_prog_label", true, "Emit the 'prog' label in variable exports.")
 	emitMetricTimestamp  = flag.Bool("emit_metric_timestamp", false, "Emit the recorded timestamp of a metric.  If disabled (the default) no explicit timestamp is sent to a collector.")
+	emitGaugeArray       = flag.Bool("emit_gauge_array", false, "Emit an array of values when one gauge has multiple metric values.  If disabled (the default), one value is emitted per gauge.")
 	logRuntimeErrors     = flag.Bool("vm_logs_runtime_errors", true, "Enables logging of runtime errors to the standard log.  Set to false to only have the errors printed to the HTTP console.")
 
 	// Ops flags.
@@ -225,6 +226,10 @@ func main() {
 	if *emitMetricTimestamp {
 		opts = append(opts, mtail.EmitMetricTimestamp)
 		eOpts = append(eOpts, exporter.EmitTimestamp())
+	}
+	if *emitGaugeArray {
+		opts = append(opts, mtail.EmitGaugeArray)
+		eOpts = append(eOpts, exporter.EmitGaugeArray())
 	}
 	if *jaegerEndpoint != "" {
 		opts = append(opts, mtail.JaegerReporter(*jaegerEndpoint))

--- a/examples/audit.mtail
+++ b/examples/audit.mtail
@@ -18,8 +18,8 @@ getfilename() !~ /audit\.log$/ {
 #
 # SEARCH PERFORMANCE SLI: runtime
 hidden gauge search_type
-hidden counter audit_count by search_type
-gauge splunkd_mtail_audit_log_search_runtime by search_type,audit_count
+hidden counter audit_gauge_index by search_type
+gauge splunkd_mtail_audit_log_search_runtime by search_type,audit_gauge_index
 histogram splunkd_mtail_audit_log_search_runtime_histogram buckets 0.5,2.0,8.0
 
 #/, action=search, info=completed, .+, fully_completed_search=true, total_run_time=(?P<runtime>[\d\.]+), .+, savedsearch_name="(?P<jobname>[^"]+), .+, provenance="scheduler"/ {
@@ -47,13 +47,13 @@ histogram splunkd_mtail_audit_log_search_runtime_histogram buckets 0.5,2.0,8.0
     search_type = 0 
 # check if metrics are exported
      splunkd_mtail_audit_log_search_runtime[search_type][0] == 0.0 {
-         audit_count[search_type] = 0
+         audit_gauge_index[search_type] = 0
 #         splunkd_mtail_audit_log_search_runtime[0][0] = -1.0
      }
-    splunkd_mtail_audit_log_search_runtime[search_type][audit_count[search_type]] = $runtime
-    audit_count[search_type]++
-    audit_count[search_type] >= 128 {
-        audit_count[search_type] = 0
+    splunkd_mtail_audit_log_search_runtime[search_type][audit_gauge_index[search_type]] = $runtime
+    audit_gauge_index[search_type]++
+    audit_gauge_index[search_type] >= 128 {
+        audit_gauge_index[search_type] = 0
     }
 }
 

--- a/examples/audit.mtail
+++ b/examples/audit.mtail
@@ -1,0 +1,59 @@
+# audit.log: mtail
+
+# ignore other log file names
+getfilename() !~ /audit\.log$/ {
+    stop
+}
+
+# Shared function to be applied to log files that confirm to the splunkd logging format
+#def parse_splunkd_header {
+#    /^(?P<timestamp>^\d\d-\d\d-\d{4}\s\d\d:\d\d:\d\d\.\d{3}\s[+\-]\d{4})/ {
+#
+        # extract the timestamp to manage event delay issues elegantly and have fixed output when running tests
+#        strptime($timestamp, "01-02-2006 15:04:05.000 +0000")
+#        next
+#    }
+#}
+
+#
+# SEARCH PERFORMANCE SLI: runtime
+hidden gauge search_type
+hidden counter audit_count by search_type
+gauge splunkd_mtail_audit_log_search_runtime by search_type,audit_count
+histogram splunkd_mtail_audit_log_search_runtime_histogram buckets 0.5,2.0,8.0
+
+#/, action=search, info=completed, .+, fully_completed_search=true, total_run_time=(?P<runtime>[\d\.]+), .+, savedsearch_name="(?P<jobname>[^"]+), .+, provenance="scheduler"/ {
+#/, action=search, info=completed, .+, fully_completed_search=true, total_run_time=(?P<runtime>[\d]+\.[\d]+), .+, provenance="scheduler"/ {
+/ total_run_time=(?P<runtime>[\d]+\.[\d]+), / {
+#    $jobname = "" {
+#        stop
+#    }
+
+    $runtime <= 0 {
+        stop
+    }
+
+    $runtime >= 86400 {
+        stop
+    }
+
+    # timestamp
+#    @parse_splunkd_header {}
+
+# histogram
+    splunkd_mtail_audit_log_search_runtime_histogram = $runtime
+
+# gauge
+    search_type = 0 
+# check if metrics are exported
+     splunkd_mtail_audit_log_search_runtime[search_type][0] == 0.0 {
+         audit_count[search_type] = 0
+#         splunkd_mtail_audit_log_search_runtime[0][0] = -1.0
+     }
+    splunkd_mtail_audit_log_search_runtime[search_type][audit_count[search_type]] = $runtime
+    audit_count[search_type]++
+    audit_count[search_type] >= 128 {
+        audit_count[search_type] = 0
+    }
+}
+

--- a/internal/exporter/export.go
+++ b/internal/exporter/export.go
@@ -37,6 +37,7 @@ type Exporter struct {
 	hostname      string
 	omitProgLabel bool
 	emitTimestamp bool
+	emitGaugeArray bool
 	pushTargets   []pushOptions
 	initDone      chan struct{}
 }
@@ -64,6 +65,14 @@ func OmitProgLabel() Option {
 func EmitTimestamp() Option {
 	return func(e *Exporter) error {
 		e.emitTimestamp = true
+		return nil
+	}
+}
+
+// EmitMetricTimestamp instructs the exporter to send a gauge array when applicable.
+func EmitGaugeArray() Option {
+	return func(e *Exporter) error {
+		e.emitGaugeArray = true
 		return nil
 	}
 }

--- a/internal/metrics/metric.go
+++ b/internal/metrics/metric.go
@@ -180,6 +180,20 @@ func (m *Metric) GetDatum(labelvalues ...string) (d datum.Datum, err error) {
 	return d, nil
 }
 
+// Clear the "gause" data since they're not accumulated after reporting.
+func (m *Metric) ClearGaugeData() {
+	m.Lock()
+	defer m.Unlock()
+	m.ClearGaugeDataLocked()
+}
+
+func (m *Metric) ClearGaugeDataLocked() {
+	if m.Kind == Gauge  {
+		m.labelValuesMap = make(map[string]*LabelValue)
+		m.LabelValues    = make([]*LabelValue, 0)
+	}
+}
+
 // RemoveOldestDatum scans the Metric's LabelValues for the Datum with the oldest timestamp, and removes it.
 func (m *Metric) RemoveOldestDatum() {
 	var oldestLV *LabelValue

--- a/internal/mtail/mtail.go
+++ b/internal/mtail/mtail.go
@@ -181,6 +181,8 @@ func New(ctx context.Context, store *metrics.Store, options ...Option) (*Server,
 
 	// TODO(jaq): Should these move to initExporter?
 	expvarDescs := map[string]*prometheus.Desc{
+		// internal/exporter/prometheus.go
+		 "metric_export_total":    prometheus.NewDesc("metric_export_total", "number of metrics exporting", nil, nil),
 		// internal/tailer/file.go
 		"log_errors_total":    prometheus.NewDesc("log_errors_total", "number of IO errors encountered per log file", []string{"logfile"}, nil),
 		"log_rotations_total": prometheus.NewDesc("log_rotations_total", "number of log rotation events per log file", []string{"logfile"}, nil),

--- a/internal/mtail/options.go
+++ b/internal/mtail/options.go
@@ -250,6 +250,14 @@ var EmitMetricTimestamp = &niladicOption{
 	},
 }
 
+// EmitMetricTimestamp tells the Server to export a gauge array when applicable
+var EmitGaugeArray = &niladicOption{
+	func(m *Server) error {
+		m.eOpts = append(m.eOpts, exporter.EmitGaugeArray())
+		return nil
+	},
+}
+
 // LogRuntimeErrors instructs the VM to emit runtime errors to the log.
 var LogRuntimeErrors = &niladicOption{
 	func(m *Server) error {


### PR DESCRIPTION
[SPL-241392] hack "mtail" to enhance gauge metrics: new guage option
 - add new option "emit_gauge_array" to emit an array of gauge metrics
 - use the label suffix "_gauge_index" to indicate that gauge is array
 - update the mtail script "audit.mtail"
 - optimize the code: variable names and logs 
 - clean up unused code pieces
# Changes to be committed:
#       modified:   cmd/mtail/main.go
#       modified:   examples/audit.mtail
#       modified:   internal/exporter/export.go
#       modified:   internal/exporter/prometheus.go
#       modified:   internal/mtail/options.go
