### PR TITLE
Run the ci-done on each `runs-on`, and separate test result upload by platform.

### DIFF
--- a/.github/workflows/ci-done.yml
+++ b/.github/workflows/ci-done.yml
@@ -6,7 +6,11 @@ on:
       - completed
 jobs:
   comment:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Sync with matrix in ci.yml
+        runs-on: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.runs-on }}
     permissions:
       # list and download
       actions: read
@@ -24,7 +28,7 @@ jobs:
                run_id: ${{github.event.workflow_run.id }},
             });
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "test-results"
+              return artifact.name == "test-results-${{ matrix.runs-on }}"
             })[0];
             var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     strategy:
       matrix:
         # macos-latest is slow and has weird test failures with unixgram message sizes, so it's been disabled.
+        # Sync with matrix in ci-done.yml        
         runs-on: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -52,7 +53,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results
+          name: test-results-${{ matrix.runs-on }}
           path: test-results/
 
   container:


### PR DESCRIPTION
This should avoid a 409 Conflicts in `upload-artifact@v4` which doesn't like
the conflicting artifact name anymore.