### PR TITLE
ci: Bind permissions as tight as possible.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,12 @@ on:
     tags:
       - v*
 
-permissions:
-  # goreleaser writes to the releases api
-  contents: write
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      # goreleaser writes to the releases api
+      contents: write
     env:
       flags: ""
     steps:


### PR DESCRIPTION
Move the `goreleaser` permissions directly onto the job rather than the whole
workflow, as #771 is going to add a second job with different requirements.