### PR TITLE
Histogram zero fix

### DIFF
--- a/internal/metrics/datum/buckets.go
+++ b/internal/metrics/datum/buckets.go
@@ -44,7 +44,7 @@ func (d *Buckets) Observe(v float64, ts time.Time) {
 	defer d.Unlock()
 
 	for i, b := range d.Buckets {
-		if b.Range.Contains(v) {
+		if v <= b.Range.Max {
 			d.Buckets[i].Count++
 			break
 		}

--- a/internal/runtime/compiler/codegen/codegen.go
+++ b/internal/runtime/compiler/codegen/codegen.go
@@ -130,17 +130,12 @@ func (c *codegen) VisitBefore(node ast.Node) (ast.Visitor, ast.Node) {
 				c.errorf(n.Pos(), "a histogram need at least two boundaries")
 				return nil, n
 			}
-			if n.Buckets[0] >= n.Buckets[1] {
-				c.errorf(n.Pos(), "buckets boundaries must be sorted")
-				return nil, n
-			}
 
 			if n.Buckets[0] > 0 {
 				m.Buckets = append(m.Buckets, datum.Range{0, n.Buckets[0]})
 			}
-			m.Buckets = append(m.Buckets, datum.Range{n.Buckets[0], n.Buckets[1]})
-			min := n.Buckets[1]
-			for _, max := range n.Buckets[2:] {
+			min := n.Buckets[0]
+			for _, max := range n.Buckets[1:] {
 				if max <= min {
 					c.errorf(n.Pos(), "buckets boundaries must be sorted")
 					return nil, n

--- a/internal/runtime/runtime_integration_test.go
+++ b/internal/runtime/runtime_integration_test.go
@@ -71,6 +71,7 @@ histogram hist3 by f buckets -1, 0, 1
 		`b 3
 b 3
 b 3
+b 0
 `,
 		0,
 		metrics.MetricSlice{
@@ -84,7 +85,10 @@ b 3
 					{
 						Value: &datum.Buckets{
 							Buckets: []datum.BucketCount{
-								{Range: datum.Range{Min: 0, Max: 1}},
+								{
+									Range: datum.Range{Min: 0, Max: 1},
+									Count: 1,
+								},
 								{Range: datum.Range{Min: 1, Max: 2}},
 								{
 									Range: datum.Range{Min: 2, Max: 4},
@@ -93,7 +97,7 @@ b 3
 								{Range: datum.Range{Min: 4, Max: 8}},
 								{Range: datum.Range{Min: 8, Max: math.Inf(+1)}},
 							},
-							Count: 3,
+							Count: 4,
 							Sum:   9,
 						},
 					},
@@ -111,7 +115,10 @@ b 3
 						Labels: []string{"b"},
 						Value: &datum.Buckets{
 							Buckets: []datum.BucketCount{
-								{Range: datum.Range{Min: 0, Max: 1}},
+								{
+									Range: datum.Range{Min: 0, Max: 1},
+									Count: 1,
+								},
 								{Range: datum.Range{Min: 1, Max: 2}},
 								{
 									Range: datum.Range{Min: 2, Max: 4},
@@ -120,7 +127,7 @@ b 3
 								{Range: datum.Range{Min: 4, Max: 8}},
 								{Range: datum.Range{Min: 8, Max: math.Inf(+1)}},
 							},
-							Count: 3,
+							Count: 4,
 							Sum:   9,
 						},
 					},
@@ -139,14 +146,17 @@ b 3
 						Labels: []string{"b"},
 						Value: &datum.Buckets{
 							Buckets: []datum.BucketCount{
-								{Range: datum.Range{Min: -1, Max: 0}},
+								{
+									Range: datum.Range{Min: -1, Max: 0},
+									Count: 1,
+								},
 								{Range: datum.Range{Min: 0, Max: 1}},
 								{
 									Range: datum.Range{Min: 1, Max: math.Inf(+1)},
 									Count: 3,
 								},
 							},
-							Count: 3,
+							Count: 4,
 							Sum:   9,
 						},
 					},


### PR DESCRIPTION
Currently, mtail checks both lower and upper bound when searching for a histogram bucket. This is not only unnecessary (because buckets are constructed so that they are sorted and continuous), it leads to bugs like https://github.com/google/mtail/issues/226 (fixed in the past), https://github.com/google/mtail/issues/675 (still open) and the fact that negative values will not be counted in any bucket unless you explicitly add negative bucket that is lower than any value that will be observed (which is not a problem for timings, but histograms could be used for other things).

Behavior of other prometheus clients is to look for first bucket where observed value less or equal to its upper bound. This MR makes mtail to also behave this way, which ensures any observation will always be counted in some bucket. I also changed integration test to check observations of zero are counted and simplified the histogram bucket initialization a bit.
