### PR TITLE
chore: Remove excessive TAB in one import statement

### DIFF
--- a/internal/mtail/mtail.go
+++ b/internal/mtail/mtail.go
@@ -23,7 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	vc "github.com/prometheus/client_golang/prometheus/collectors/version"
-	"github.com/prometheus/common/version"	
+	"github.com/prometheus/common/version"
 	"go.opencensus.io/zpages"
 )
 


### PR DESCRIPTION
This PR fixes the formatting of import statements in one file.

## Details

The PR arose when I ran [`gci`](https://github.com/daixiang0/gci) linter and found that this tool broke on imports with TABS at the end:
```
❯ gci diff internal/mtail/mtail.go
Error: 26:42: expected ';', found "go.opencensus.io/zpages" (and 7 more errors)
```
But when I remove this TAB the`gci` working fine:
```
❯ gci diff internal/mtail/mtail.go
--- internal/mtail/mtail.go
+++ internal/mtail/mtail.go
@@ -21,8 +21,8 @@
        "github.com/google/mtail/internal/tailer"
        "github.com/prometheus/client_golang/prometheus"
        "github.com/prometheus/client_golang/prometheus/collectors"
-       "github.com/prometheus/client_golang/prometheus/promhttp"
        vc "github.com/prometheus/client_golang/prometheus/collectors/version"
+       "github.com/prometheus/client_golang/prometheus/promhttp"
        "github.com/prometheus/common/version"
        "go.opencensus.io/zpages"
 )
```