### PR TITLE
chore: Bump golangci-lint version to v1.57

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,9 +24,4 @@ jobs:
           # Required: the version of golangci-lint is required and must be
           # specified without patch version: we always use the latest patch
           # version.
-          version: v1.52
-
-          # Optional: show only new issues if it's a pull request. The default
-          # value is `false`.  Be careful upgrading because this won't show
-          # existing lints.
-          only-new-issues: true
+          version: v1.57

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,9 +8,10 @@ run:
 
 linters-settings:
   govet:
-    check-shadowing: true
+    enable-all: true
     disable:
-      composites # same as exhaustruct below
+      - composites # same as exhaustruct below
+      - fieldalignment
   asasalint:
     exclude:
       - glog\.Infof
@@ -33,6 +34,7 @@ linters:
   disable:
     - cyclop # boo cyclomatic complexity
     - dupl # exclude test code
+    - depguard
     - errcheck # handled by gosec, lots of false posi
     - exhaustive # this false-positives for switches with a default
     - exhaustivestruct # too noisy, labelling fields is not my jam
@@ -40,6 +42,7 @@ linters:
     - forbidigo # exclude non prod tools
     - forcetypeassert # too many at the moment
     - funlen    # My tests will be as long as they need to be thanks
+    - gci
     - gochecknoglobals    # Flags are fine, as are test tables.
     - gochecknoinits    # How dare you tell me not to use inits.
     - gocognit # boo cyclomatic complexity
@@ -58,6 +61,7 @@ linters:
     - nlreturn    # Not a fan of this one, looks messy
     - nolintlint    # broken on gocritic
     - paralleltest # i had a good reason for this
+    - perfsprint
     - testpackage # need to test internal methods
     - unparam # too noisy
     - whitespace # broken by goyacc

--- a/cmd/mdot/main.go
+++ b/cmd/mdot/main.go
@@ -163,7 +163,7 @@ func main() {
 	}
 
 	http.HandleFunc("/",
-		func(w http.ResponseWriter, r *http.Request) {
+		func(w http.ResponseWriter, _ *http.Request) {
 			dot := exec.Command("dot", "-Tsvg")
 			in, err := dot.StdinPipe()
 			if err != nil {

--- a/internal/metrics/metric_test.go
+++ b/internal/metrics/metric_test.go
@@ -180,7 +180,7 @@ func timeGenerator(rand *rand.Rand) time.Time {
 
 func TestMetricJSONRoundTrip(t *testing.T) {
 	rand := rand.New(rand.NewSource(0))
-	f := func(name, prog string, kind Kind, keys []string, val, ti, tns int64) bool {
+	f := func(name, prog string, kind Kind, keys []string, val, _, _ int64) bool {
 		m := NewMetric(name, prog, kind, Int, keys...)
 		labels := make([]string, 0)
 		for range keys {

--- a/internal/metrics/store_bench_test.go
+++ b/internal/metrics/store_bench_test.go
@@ -81,7 +81,7 @@ func BenchmarkStore(b *testing.B) {
 				fillMetric(b, rand, items, m, s)
 				addToStore(b, items, *m, s)
 			},
-			b: func(b *testing.B, items int, m []*Metric, s *Store) {
+			b: func(b *testing.B, _ int, _ []*Metric, s *Store) {
 				b.Helper()
 				s.Range(func(*Metric) error {
 					return nil

--- a/internal/mtail/mtail.go
+++ b/internal/mtail/mtail.go
@@ -21,8 +21,8 @@ import (
 	"github.com/google/mtail/internal/tailer"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	vc "github.com/prometheus/client_golang/prometheus/collectors/version"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/version"
 	"go.opencensus.io/zpages"
 )


### PR DESCRIPTION
This PR fixes the [failing](https://github.com/google/mtail/actions/runs/8442491054) `golangci-lint` GitHub workflow. It became failing after merging #813 ([action](https://github.com/google/mtail/actions/runs/8104054505/job/22149885469)).

The golangci-lint workflow is failing because golangci-lint v1.52 was [built](https://github.com/golangci/golangci-lint/blob/v1.52.2/go.mod#L3) with Go 1.19, so it's unfamiliar about Go 1.21 features that this repo is using.

Changes:
- Update the golangci-lint version to `v1.57` in `.github/workflows/golangci-lint.yml`. This version is the latest and is compatible with Go 1.21.
- Fix `.golangci.yml` config and disable all new linters after v1.52. Likely, we will fix issues from them later.
- Fix simple issues from the `revive` linter about an unused parameter and from `gofmt` about an unsorted import.
- As now we fix all issues, we can set `only-new-issues: false` (default value) in  `.github/workflows/golangci-lint.yml`.