### PR TITLE
'??' glob pattern not working in recent versions for --logs argument

### DIFF
--- a/internal/tailer/tail.go
+++ b/internal/tailer/tail.go
@@ -222,7 +222,7 @@ func (t *Tailer) AddPattern(pattern string) error {
 		t.socketPaths = append(t.socketPaths, pattern)
 		return nil
 	case "", "file":
-		path = u.Path
+		// Leave path alone; may contain globs
 	}
 	if path != "-" {
 		path, err = filepath.Abs(path)

--- a/internal/tailer/tail_test.go
+++ b/internal/tailer/tail_test.go
@@ -300,3 +300,21 @@ func TestTailExpireStaleHandles(t *testing.T) {
 	ta.logstreamsMu.RUnlock()
 	glog.Info("good")
 }
+
+func TestAddGlob(t *testing.T) {
+	ta := makeTestTail(t)
+
+	pattern := "foo?.log"
+	err := ta.AddPattern(pattern)
+	if err != nil {
+		t.Errorf("AddPattern(%v) -> %v", pattern, err)
+	}
+	absPattern, err := filepath.Abs(pattern)
+	testutil.FatalIfErr(t, err)
+	ta.globPatternsMu.Lock()
+	_, ok := ta.globPatterns[absPattern]
+	if !ok {
+		t.Errorf("pattern not found in globPatterns: %v", ta.globPatterns)
+	}
+	ta.globPatternsMu.Unlock()
+}


### PR DESCRIPTION
'??' glob pattern for --logs argument used to work (in v3.0.0-rc36) but stopped working in recent versions.

I have the following log files:
```
/var/log/my_prog/my_prog.log.20220419_14
/var/log/my_prog/my_prog.log.20220419_15
```

I am starting the latest build of mtail with the following arguments:
`/tmp/mtail.rc48 -port 12345 -progs /etc/mtail/my-progs/ -logtostderr -disable_fsnotify -logs '/var/log/my_prog/my_prog.log.*_??'`

Mtail does not tail the files:
```
runtime.go:188] Loaded program sockets.mtail
runtime.go:84] unmarking sockets.mtail
mtail.go:126] Listening on [::]:12345
```

If I start it with:
`/tmp/mtail.rc48 -port 12345 -progs /etc/mtail/my-progs/ -logtostderr -disable_fsnotify -logs '/var/log/my_prog/my_prog.log.*_[0-9][0-9]'`
It tails the files:
```
runtime.go:188] Loaded program sockets.mtail
runtime.go:84] unmarking sockets.mtail
logstream.go:61] Parsed url as /var/log/my_prog/my_prog.log.20220419_14
tail.go:287] Tailing /var/log/my_prog/my_prog.log.20220419_14
logstream.go:61] Parsed url as /var/log/my_prog/my_prog.log.20220419_15
tail.go:287] Tailing /var/log/my_prog/my_prog.log.20220419_15
mtail.go:126] Listening on [::]:12345
```

the `-logs '/var/log/my_prog/my_prog.log.*_??'` argument works in version **v3.0.0-rc36**, so I think this bug was introduced in a new version.

Moreover, according to https://google.github.io/mtail/Deploying.html,
> `--logs` is a comma separated list of filenames to extract from, but can also be used multiple times, and each filename can be a [glob pattern](http://godoc.org/path/filepath#Match).

And the  [glob pattern](http://godoc.org/path/filepath#Match) documentation says:
> '?'         matches any single non-Separator character

So I expect the glob pattern matching to work as it used to in **v3.0.0-rc36**