### PR TITLE
ci: Split up image and binary verification.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,31 @@
 name: release
 on:
-  # Test that it works on pull_request or merge group;
-  # goreleaser goes into snapshot mode if not a tag; 
-  # docker image will be built but not pushed for pull requests or merge group events.
+  # Test that this workflow works on every pull_request or merge group;
+  # goreleaser is put into snapshot mode when not on a tag
   pull_request:
   merge_group:
   push:
     tags:
       - v*
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     permissions:
-      # goreleaser writes to the releases api
+      # goreleaser uploads artifacts to the releases api
       contents: write
-      # docker writes packages to container registry
+      # goreleaser uploads images to container registry
       packages: write
     env:
       flags: ""
     outputs:
-      hashes: ${{ steps.hash.outputs.hashes }}
+      binary_hashes: ${{ steps.binary.outputs.hashes }}
+      image_subjects: ${{ steps.image.outputs.subjects }}
     steps:
-      - if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      - if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: echo "flags=--snapshot" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
@@ -33,32 +36,35 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
       - uses: docker/login-action@v3.1.0
-        env:
-          # Use docker.io for Docker Hub if empty
-          REGISTRY: ghcr.io
-          # github.repository as <account>/<repo>
-          IMAGE_NAME: ${{ github.repository }}
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: goreleaser/goreleaser-action@v5
-        id: run-goreleaser
+        id: goreleaser
         with:
           version: latest
           args: release --clean ${{ env.flags }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Generate subject
-        id: hash
+      - name: generate hashes for binary artifacts
+        id: binary
         env:
-          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
+          ARTIFACTS: "${{ steps.goreleaser.outputs.artifacts }}"
         run: |
-          set -euo pipefail
-          hashes=$(echo $ARTIFACTS | jq --raw-output '.[] | {name, "digest": (.extra.Digest // .extra.Checksum)} | select(.digest) | {digest} + {name} | join("  ") | sub("^sha256:";"")' | base64 -w0)
-          echo "hashes=$hashes" >> $GITHUB_OUTPUT
+          set -exuo pipefail
+          checksum_file=$(echo "${ARTIFACTS}" | jq -r '.[] | select (.type=="Checksum") | .path')
+          echo "hashes=$(cat ${checksum_file} | base64 -w0)" >> "${GITHUB_OUTPUT}"
+      - name: generate digest for container image
+        id: image
+        env:
+          ARTIFACTS: "${{ steps.goreleaser.outputs.artifacts }}"
+        run: |
+          set -exuo pipefail
+          image_list=$(echo -e "${ARTIFACTS}" | jq -r '.[] | select(.type=="Docker Manifest") | {"image": (.name | sub("^.*?/"; "") | sub(":(.*)"; "")), "digest": .extra.Digest}')
+          echo "subjects=$(echo $image_list | jq -c -s 'unique_by(.digest) | {"include": .}')" >> "$GITHUB_OUTPUT"
 
-  provenance:
+  binary-provenance:
     needs: [goreleaser]
     permissions:
       actions: read # To read the workflow path.
@@ -66,35 +72,76 @@ jobs:
       contents: write # To add assets to a release.
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:
-      base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
+      base64-subjects: "${{ needs.goreleaser.outputs.binary_hashes }}"
       upload-assets: true # upload to a new release
 
-  verify:
-    needs: [goreleaser, provenance]
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+  binary-verify:
+    needs: [goreleaser, binary-provenance]
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read  # Download release assets
-    env:
-      CHECKSUMS: ${{ needs.goreleaser.outputs.hashes }}
-      PROVENANCE: "${{ needs.provenance.outputs.provenance-name }}"
+      contents: read
     steps:
       - uses: slsa-framework/slsa-verifier/actions/installer@v2.5.1
       - name: download assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
+          set -exuo pipefail
           gh release download "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}"
       - name: verify assets
+        env:
+          CHECKSUMS: ${{ needs.goreleaser.outputs.binary_hashes }}
+          PROVENANCE: "${{ needs.binary-provenance.outputs.provenance-name }}"
         run: |
-          set -euo pipefail
-          checksums=$(echo "$CHECKSUMS" | base64 -d)
-          while read -r line; do
+          set -exuo pipefail
+          echo "$CHECKSUMS" | base64 -d | while read -r line; do
               fn=$(echo $line | cut -d ' ' -f2)
               echo "Verifying $fn"
               slsa-verifier verify-artifact --provenance-path "$PROVENANCE" \
                                             --source-uri "github.com/$GITHUB_REPOSITORY" \
                                             --source-tag "$GITHUB_REF_NAME" \
                                             "$fn"
-          done <<<"$checksums"
+          done
+
+  image-provenance:
+    needs: [goreleaser]
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    strategy:
+      matrix: ${{ fromJSON(needs.goreleaser.outputs.image_subjects) }}
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    with:
+      image: ghcr.io/${{ matrix.image }}
+      digest: ${{ matrix.digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+  image-verify:
+    needs: [goreleaser, image-provenance]
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix: ${{ fromJSON(needs.goreleaser.outputs.image_subjects) }}
+    steps:
+      - uses: docker/login-action@v3.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: sigstore/cosign-installer@v3.5.0
+      - name: verify image
+        env:
+          IMAGE: ${{ matrix.image }}
+          DIGEST: ${{ matrix.digest }}
+        run: |
+          cosign verify-attestation \
+             --type slsaprovenance \
+             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+             --certificate-identity-regexp '^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$' \
+             ${REGISTRY}/${IMAGE}@${DIGEST}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,8 +25,7 @@ snapshot:
 changelog:
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - '^ci:'
       - '^Merge'
 release:
   github:


### PR DESCRIPTION
The previous attempt couldn't find the images in the attestation.

Instead copy the goreleaser example
https://github.com/goreleaser/goreleaser-example-slsa-provenance/blob/master/.github/workflows/goreleaser.yml
and separate these two.

Issue: #836