### PR TITLE
ci: Workflow for tagging a new release.

### DIFF
--- a/.github/workflows/tag-new-release.yml
+++ b/.github/workflows/tag-new-release.yml
@@ -1,0 +1,14 @@
+name: tag new release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: hennejg/github-tag-action@v4.1.jh1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          create_annotated_tag: true

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,0 +1,20 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+		  { "type": "build", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "style", "release": "none" },
+		  { "type": "test", "release": "patch" },
+          { "type": "style", "release": "none" },
+		  { "type": "chore", "release": "none" },
+		  { "type": "ci", "release": "none" }
+        ],
+      }
+    ],
+  ]
+}


### PR DESCRIPTION
Set up semantic-release to ignore `ci` type and mark some other common ones as
patch.