### PR TITLE
Explicitly stop the `Exporter` when main routines are done.

### DIFF
--- a/cmd/mtail/main.go
+++ b/cmd/mtail/main.go
@@ -11,7 +11,6 @@ import (
 	"os/signal"
 	"runtime"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -249,23 +248,22 @@ func main() {
 	if *oneShot {
 		switch *oneShotFormat {
 		case "prometheus":
-			var wg sync.WaitGroup
-			e, err := exporter.New(ctx, &wg, store, eOpts...)
+			e, err := exporter.New(ctx, store, eOpts...)
 			if err != nil {
 				glog.Error(err)
 				cancel()
-				wg.Wait()
+				e.Stop()
 				os.Exit(1) //nolint:gocritic // false positive
 			}
 			err = e.Write(os.Stdout)
 			if err != nil {
 				glog.Error(err)
 				cancel()
-				wg.Wait()
+				e.Stop()
 				os.Exit(1) //nolint:gocritic // false positive
 			}
 			cancel()
-			wg.Wait()
+			e.Stop()
 			os.Exit(0) //nolint:gocritic // false positive
 		case "json":
 			err = store.WriteMetrics(os.Stdout)

--- a/internal/exporter/export.go
+++ b/internal/exporter/export.go
@@ -85,9 +85,7 @@ func DisableExport() Option {
 	}
 }
 
-var (
-	ErrNeedsStore = errors.New("exporter needs a Store")
-)
+var ErrNeedsStore = errors.New("exporter needs a Store")
 
 // New creates a new Exporter.
 func New(ctx context.Context, store *metrics.Store, options ...Option) (*Exporter, error) {

--- a/internal/exporter/export.go
+++ b/internal/exporter/export.go
@@ -31,6 +31,7 @@ var (
 // Exporter manages the export of metrics to passive and active collectors.
 type Exporter struct {
 	ctx            context.Context
+	cancelFunc     context.CancelFunc
 	wg             sync.WaitGroup
 	store          *metrics.Store
 	pushInterval   time.Duration
@@ -40,6 +41,7 @@ type Exporter struct {
 	exportDisabled bool
 	pushTargets    []pushOptions
 	initDone       chan struct{}
+	shutdownDone   chan struct{}
 }
 
 // Option configures a new Exporter.
@@ -84,23 +86,20 @@ func DisableExport() Option {
 }
 
 var (
-	ErrNeedsStore     = errors.New("exporter needs a Store")
-	ErrNeedsWaitgroup = errors.New("exporter needs a WaitGroup")
+	ErrNeedsStore = errors.New("exporter needs a Store")
 )
 
 // New creates a new Exporter.
-func New(ctx context.Context, wg *sync.WaitGroup, store *metrics.Store, options ...Option) (*Exporter, error) {
+func New(ctx context.Context, store *metrics.Store, options ...Option) (*Exporter, error) {
 	if store == nil {
 		return nil, ErrNeedsStore
 	}
-	if wg == nil {
-		return nil, ErrNeedsWaitgroup
-	}
 	e := &Exporter{
-		ctx:      ctx,
-		store:    store,
-		initDone: make(chan struct{}),
+		store:        store,
+		initDone:     make(chan struct{}),
+		shutdownDone: make(chan struct{}),
 	}
+	e.ctx, e.cancelFunc = context.WithCancel(ctx)
 	defer close(e.initDone)
 	if err := e.SetOption(options...); err != nil {
 		return nil, err
@@ -128,18 +127,23 @@ func New(ctx context.Context, wg *sync.WaitGroup, store *metrics.Store, options 
 	}
 	e.StartMetricPush()
 
-	wg.Add(1)
 	// This routine manages shutdown of the Exporter.
 	go func() {
-		defer wg.Done()
 		<-e.initDone
 		// Wait for the context to be completed before waiting for subroutines.
 		if !e.exportDisabled {
 			<-e.ctx.Done()
 		}
 		e.wg.Wait()
+		close(e.shutdownDone)
 	}()
 	return e, nil
+}
+
+// Stop instructs the exporter to shut down.  The function returns once the exporter has finished.
+func (e *Exporter) Stop() {
+	e.cancelFunc()
+	<-e.shutdownDone
 }
 
 // SetOption takes one or more option functions and applies them in order to Exporter.

--- a/internal/exporter/graphite_test.go
+++ b/internal/exporter/graphite_test.go
@@ -47,12 +47,13 @@ func TestHandleGraphite(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
-			var wg sync.WaitGroup
+			defer cancel()
+
 			ms := metrics.NewStore()
 			for _, metric := range tc.metrics {
 				testutil.FatalIfErr(t, ms.Add(metric))
 			}
-			e, err := New(ctx, &wg, ms, Hostname("gunstar"))
+			e, err := New(ctx, ms, Hostname("gunstar"))
 			testutil.FatalIfErr(t, err)
 			response := httptest.NewRecorder()
 			e.HandleGraphite(response, &http.Request{})
@@ -64,8 +65,7 @@ func TestHandleGraphite(t *testing.T) {
 				t.Errorf("failed to read response %s", err)
 			}
 			testutil.ExpectNoDiff(t, tc.expected, string(b), testutil.IgnoreUnexported(sync.RWMutex{}))
-			cancel()
-			wg.Wait()
+			e.Stop()
 		})
 	}
 }

--- a/internal/exporter/json_test.go
+++ b/internal/exporter/json_test.go
@@ -141,12 +141,13 @@ func TestHandleJSON(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
-			var wg sync.WaitGroup
+			defer cancel()
+
 			ms := metrics.NewStore()
 			for _, metric := range tc.metrics {
 				testutil.FatalIfErr(t, ms.Add(metric))
 			}
-			e, err := New(ctx, &wg, ms, Hostname("gunstar"))
+			e, err := New(ctx, ms, Hostname("gunstar"))
 			testutil.FatalIfErr(t, err)
 			response := httptest.NewRecorder()
 			e.HandleJSON(response, &http.Request{})
@@ -158,8 +159,8 @@ func TestHandleJSON(t *testing.T) {
 				t.Errorf("failed to read response: %s", err)
 			}
 			testutil.ExpectNoDiff(t, tc.expected, string(b), testutil.IgnoreUnexported(sync.RWMutex{}))
-			cancel()
-			wg.Wait()
+
+			e.Stop()
 		})
 	}
 }

--- a/internal/mtail/mtail.go
+++ b/internal/mtail/mtail.go
@@ -66,7 +66,7 @@ func (m *Server) initRuntime() (err error) {
 
 // initExporter sets up an Exporter for this Server.
 func (m *Server) initExporter() (err error) {
-	m.e, err = exporter.New(m.ctx, &m.wg, m.store, m.eOpts...)
+	m.e, err = exporter.New(m.ctx, m.store, m.eOpts...)
 	if err != nil {
 		return err
 	}
@@ -234,6 +234,7 @@ func (m *Server) SetOption(options ...Option) error {
 // TODO(jaq): remove this once the test server is able to trigger polls on the components.
 func (m *Server) Run() error {
 	m.wg.Wait()
+	m.e.Stop()
 	if m.compileOnly {
 		glog.Info("compile-only is set, exiting")
 		return nil


### PR DESCRIPTION
The `Exporter` and `HTTPServer` are not connected by channels to the `Runtime`,
only indirectly through mutating effects on the Store. As such we can't rely on
the `Exporter` to shut down automatically when the `Runtime` shuts down.

Here instead we remove the `WaitGroup` and allow an `Exporter` to be shut down
explicitly after the `WaitGroup` is `Done`.

Issue: #331