### PR TITLE
ci: Disable benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   benchmark:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     permissions:
       # For benchmark-action comment-always


### PR DESCRIPTION
Benchmark name extraction is broken and makes incorrect reports.