### PR TITLE
feat: Handle `stdin` closure and shut down the tailer.

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -17,20 +17,21 @@ jobs:
   enable-automerge:
     if: github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies')
     runs-on: ubuntu-latest
+    # https://github.com/orgs/community/discussions/24686
     permissions:
-      # enable-automerge is a graphql query, not REST, so isn't documented,
-      # except in a mention in
-      # https://github.blog/changelog/2021-02-04-pull-request-auto-merge-is-now-generally-available/
-      # which says "can only be enabled by users with permissino to merge"; the
-      # REST documentation says you need contents: write to perform a merge.
-      # https://github.community/t/what-permission-does-a-github-action-need-to-call-graphql-enablepullrequestautomerge/197708
-      # says this is it
       contents: write
+      pull-requests: write
     steps:
-      # Enable auto-merge *before* issuing an approval.
-      - uses: alexwilson/enable-github-automerge-action@main
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - run: |
+          gh api graphql -f pullRequestId="${{ github.event.pull_request.node_id }}" -f query='
+          mutation EnablePullRequestAutoMerge($pullRequestId: ID!) {
+            enablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId}) {
+              clientMutationId
+            }
+          }
+          '
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   wait-on-checks:
     needs: enable-automerge

--- a/cmd/mtail/main.go
+++ b/cmd/mtail/main.go
@@ -182,7 +182,7 @@ func main() {
 	}
 	if *staleLogGcTickInterval > 0 {
 		staleLogGcWaker := waker.NewTimed(ctx, *staleLogGcTickInterval)
-		opts = append(opts, mtail.StaleLogGcWaker(staleLogGcWaker))
+		opts = append(opts, mtail.GcWaker(staleLogGcWaker))
 	}
 	if *pollInterval > 0 {
 		logStreamPollWaker := waker.NewTimed(ctx, *pollInterval)

--- a/internal/mtail/basic_tail_integration_test.go
+++ b/internal/mtail/basic_tail_integration_test.go
@@ -17,11 +17,11 @@ import (
 func TestBasicTail(t *testing.T) {
 	testutil.SkipIfShort(t)
 	if testing.Verbose() {
-		testutil.SetFlag(t, "vmodule", "tail=2,log_watcher=2")
+		testutil.SetFlag(t, "vmodule", "tail=2,filestream=2")
 	}
 	logDir := testutil.TestTempDir(t)
 
-	m, stopM := mtail.TestStartServer(t, 1, 1, mtail.LogPathPatterns(logDir+"/*"), mtail.ProgramPath("../../examples/linecount.mtail"))
+	m, stopM := mtail.TestStartServer(t, 2, 1, mtail.LogPathPatterns(logDir+"/*"), mtail.ProgramPath("../../examples/linecount.mtail"))
 	defer stopM()
 
 	logFile := filepath.Join(logDir, "log")
@@ -31,7 +31,7 @@ func TestBasicTail(t *testing.T) {
 
 	f := testutil.TestOpenFile(t, logFile)
 	defer f.Close()
-	m.AwakenPatternPollers(1, 1) // Find `logFile`
+	m.AwakenPatternPollers(2, 2) // Find `logFile`
 	m.AwakenLogStreams(1, 1)     // Force a sync to EOF
 
 	for i := 1; i <= 3; i++ {

--- a/internal/mtail/basic_tail_integration_test.go
+++ b/internal/mtail/basic_tail_integration_test.go
@@ -21,7 +21,7 @@ func TestBasicTail(t *testing.T) {
 	}
 	logDir := testutil.TestTempDir(t)
 
-	m, stopM := mtail.TestStartServer(t, 1, mtail.LogPathPatterns(logDir+"/*"), mtail.ProgramPath("../../examples/linecount.mtail"))
+	m, stopM := mtail.TestStartServer(t, 1, 1, mtail.LogPathPatterns(logDir+"/*"), mtail.ProgramPath("../../examples/linecount.mtail"))
 	defer stopM()
 
 	logFile := filepath.Join(logDir, "log")
@@ -31,12 +31,13 @@ func TestBasicTail(t *testing.T) {
 
 	f := testutil.TestOpenFile(t, logFile)
 	defer f.Close()
-	m.PollWatched(1) // Force sync to EOF
+	m.AwakenPatternPollers(1, 1) // Find `logFile`
+	m.AwakenLogStreams(1, 1)     // Force a sync to EOF
 
 	for i := 1; i <= 3; i++ {
 		testutil.WriteString(t, f, fmt.Sprintf("%d\n", i))
 	}
-	m.PollWatched(1) // Expect to read 3 lines here.
+	m.AwakenLogStreams(1, 1) // Expect to read 3 lines here.
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -57,7 +58,7 @@ func TestNewLogDoesNotMatchIsIgnored(t *testing.T) {
 
 	// Start mtail
 	logFilepath := filepath.Join(workdir, "log")
-	m, stopM := mtail.TestStartServer(t, 0, mtail.LogPathPatterns(logFilepath))
+	m, stopM := mtail.TestStartServer(t, 1, 0, mtail.LogPathPatterns(logFilepath))
 	defer stopM()
 
 	logCountCheck := m.ExpectExpvarDeltaWithDeadline("log_count", 0)
@@ -68,7 +69,7 @@ func TestNewLogDoesNotMatchIsIgnored(t *testing.T) {
 	logFile, err := os.Create(newLogFilepath)
 	testutil.FatalIfErr(t, err)
 	defer logFile.Close()
-	m.PollWatched(0) // No streams so don't wait for any.
+	// No streams so don't wait for any.
 
 	logCountCheck()
 }

--- a/internal/mtail/basic_tail_integration_test.go
+++ b/internal/mtail/basic_tail_integration_test.go
@@ -21,7 +21,7 @@ func TestBasicTail(t *testing.T) {
 	}
 	logDir := testutil.TestTempDir(t)
 
-	m, stopM := mtail.TestStartServer(t, 2, 1, mtail.LogPathPatterns(logDir+"/*"), mtail.ProgramPath("../../examples/linecount.mtail"))
+	m, stopM := mtail.TestStartServer(t, 1, 1, mtail.LogPathPatterns(logDir+"/*"), mtail.ProgramPath("../../examples/linecount.mtail"))
 	defer stopM()
 
 	logFile := filepath.Join(logDir, "log")
@@ -31,7 +31,7 @@ func TestBasicTail(t *testing.T) {
 
 	f := testutil.TestOpenFile(t, logFile)
 	defer f.Close()
-	m.AwakenPatternPollers(2, 2) // Find `logFile`
+	m.AwakenPatternPollers(1, 1) // Find `logFile`
 	m.AwakenLogStreams(1, 1)     // Force a sync to EOF
 
 	for i := 1; i <= 3; i++ {

--- a/internal/mtail/examples_integration_test.go
+++ b/internal/mtail/examples_integration_test.go
@@ -176,7 +176,7 @@ func BenchmarkProgram(b *testing.B) {
 				count, err := io.Copy(log, l)
 				testutil.FatalIfErr(b, err)
 				total += count
-				awaken(1)
+				awaken(1, 1)
 			}
 			cancel()
 			wg.Wait()

--- a/internal/mtail/examples_integration_test.go
+++ b/internal/mtail/examples_integration_test.go
@@ -92,7 +92,7 @@ func TestExamplePrograms(t *testing.T) {
 		t.Run(fmt.Sprintf("%s on %s", tc.programfile, tc.logfile),
 			testutil.TimeoutTest(exampleTimeout, func(t *testing.T) { //nolint:thelper
 				ctx, cancel := context.WithCancel(context.Background())
-				waker, _ := waker.NewTest(ctx, 0) // oneshot means we should never need to wake the stream
+				waker, _ := waker.NewTest(ctx, 0, "waker") // oneshot means we should never need to wake the stream
 				store := metrics.NewStore()
 				programFile := filepath.Join("../..", tc.programfile)
 				mtail, err := mtail.New(ctx, store, mtail.ProgramPath(programFile), mtail.LogPathPatterns(tc.logfile), mtail.OneShot, mtail.OmitMetricSource, mtail.DumpAstTypes, mtail.DumpBytecode, mtail.LogPatternPollWaker(waker), mtail.LogstreamPollWaker(waker))
@@ -155,7 +155,7 @@ func BenchmarkProgram(b *testing.B) {
 			logFile := filepath.Join(logDir, "test.log")
 			log := testutil.TestOpenFile(b, logFile)
 			ctx, cancel := context.WithCancel(context.Background())
-			waker, awaken := waker.NewTest(ctx, 1)
+			waker, awaken := waker.NewTest(ctx, 1, "streams")
 			store := metrics.NewStore()
 			programFile := filepath.Join("../..", bm.programfile)
 			mtail, err := mtail.New(ctx, store, mtail.ProgramPath(programFile), mtail.LogPathPatterns(log.Name()), mtail.LogstreamPollWaker(waker))

--- a/internal/mtail/examples_integration_unix_test.go
+++ b/internal/mtail/examples_integration_unix_test.go
@@ -149,7 +149,7 @@ func TestFileSocketStreamComparison(t *testing.T) {
 						defer wg.Done()
 						source, err := os.OpenFile(tc.logfile, os.O_RDONLY, 0)
 						testutil.FatalIfErr(t, err)
-						s, err := net.DialUnix(scheme, nil, &net.UnixAddr{sockName, scheme})
+						s, err := net.DialUnix(scheme, nil, &net.UnixAddr{Name: sockName, Net: scheme})
 						testutil.FatalIfErr(t, err)
 						n, err := io.Copy(s, source)
 						testutil.FatalIfErr(t, err)

--- a/internal/mtail/log_deletion_integration_unix_test.go
+++ b/internal/mtail/log_deletion_integration_unix_test.go
@@ -25,18 +25,20 @@ func TestLogDeletion(t *testing.T) {
 	logFile := testutil.TestOpenFile(t, logFilepath)
 	defer logFile.Close()
 
-	m, stopM := mtail.TestStartServer(t, 1, mtail.LogPathPatterns(logFilepath))
+	m, stopM := mtail.TestStartServer(t, 1, 1, mtail.LogPathPatterns(logFilepath))
 	defer stopM()
 
 	logCloseCheck := m.ExpectMapExpvarDeltaWithDeadline("log_closes_total", logFilepath, 1)
 	logCountCheck := m.ExpectExpvarDeltaWithDeadline("log_count", -1)
 
-	m.PollWatched(1) // Force sync to EOF
+	m.AwakenPatternPollers(1, 1)
+	m.AwakenLogStreams(1, 1) // Force read to EOF
+
 	glog.Info("remove")
 	testutil.FatalIfErr(t, os.Remove(logFilepath))
 
-	m.PollWatched(0) // one pass to stop
+	m.AwakenLogStreams(1, 1) // run stream to observe it's missing
 	logCloseCheck()
-	m.PollWatched(0) // one pass to remove completed stream
+	m.AwakenLogStreams(1, 1)
 	logCountCheck()
 }

--- a/internal/mtail/log_deletion_integration_unix_test.go
+++ b/internal/mtail/log_deletion_integration_unix_test.go
@@ -39,6 +39,6 @@ func TestLogDeletion(t *testing.T) {
 
 	m.AwakenLogStreams(1, 0) // run stream to observe it's missing
 	logCloseCheck()
-	m.AwakenPatternPollers(1, 1)
+	m.AwakenGcPoller(1, 1)
 	logCountCheck()
 }

--- a/internal/mtail/log_deletion_integration_unix_test.go
+++ b/internal/mtail/log_deletion_integration_unix_test.go
@@ -37,8 +37,8 @@ func TestLogDeletion(t *testing.T) {
 	glog.Info("remove")
 	testutil.FatalIfErr(t, os.Remove(logFilepath))
 
-	m.AwakenLogStreams(1, 1) // run stream to observe it's missing
+	m.AwakenLogStreams(1, 0) // run stream to observe it's missing
 	logCloseCheck()
-	m.AwakenLogStreams(1, 1)
+	m.AwakenPatternPollers(1, 1)
 	logCountCheck()
 }

--- a/internal/mtail/log_glob_integration_test.go
+++ b/internal/mtail/log_glob_integration_test.go
@@ -91,7 +91,6 @@ func TestGlobAfterStart(t *testing.T) {
 		log := testutil.TestOpenFile(t, tt.name)
 		defer log.Close()
 		m.AwakenPatternPollers(1, 1)
-		//m.AwakenLogStreams(0, 1) // wait for zero, wake 1 as we're in a loop
 	}
 	logCountCheck()
 }

--- a/internal/mtail/log_glob_integration_test.go
+++ b/internal/mtail/log_glob_integration_test.go
@@ -45,7 +45,7 @@ func TestGlobBeforeStart(t *testing.T) {
 		testutil.WriteString(t, log, "\n")
 		log.Close()
 	}
-	m, stopM := mtail.TestStartServer(t, 0, mtail.LogPathPatterns(filepath.Join(workdir, "log*")))
+	m, stopM := mtail.TestStartServer(t, 0, 0, mtail.LogPathPatterns(filepath.Join(workdir, "log*")))
 	stopM()
 
 	if r := m.GetExpvar("log_count"); r.(*expvar.Int).Value() != count {
@@ -75,10 +75,10 @@ func TestGlobAfterStart(t *testing.T) {
 			false,
 		},
 	}
-	m, stopM := mtail.TestStartServer(t, 0, mtail.LogPathPatterns(filepath.Join(workdir, "log*")))
+	m, stopM := mtail.TestStartServer(t, 1, 0, mtail.LogPathPatterns(filepath.Join(workdir, "log*")))
 	defer stopM()
 
-	m.PollWatched(0) // Force sync to EOF
+	m.AwakenPatternPollers(1, 1)
 
 	var count int64
 	for _, tt := range globTests {
@@ -90,9 +90,9 @@ func TestGlobAfterStart(t *testing.T) {
 	for _, tt := range globTests {
 		log := testutil.TestOpenFile(t, tt.name)
 		defer log.Close()
-		m.PollWatched(0) // Force sync to EOF
+		m.AwakenPatternPollers(1, 1)
+		//m.AwakenLogStreams(0, 1) // wait for zero, wake 1 as we're in a loop
 	}
-	// m.PollWatched(2)
 	logCountCheck()
 }
 
@@ -142,7 +142,7 @@ func TestGlobIgnoreFolder(t *testing.T) {
 		testutil.WriteString(t, log, "\n")
 	}
 
-	m, stopM := mtail.TestStartServer(t, 0, mtail.LogPathPatterns(filepath.Join(workdir, "log*")), mtail.IgnoreRegexPattern("\\.gz"))
+	m, stopM := mtail.TestStartServer(t, 0, 0, mtail.LogPathPatterns(filepath.Join(workdir, "log*")), mtail.IgnoreRegexPattern("\\.gz"))
 
 	stopM()
 
@@ -184,7 +184,7 @@ func TestFilenameRegexIgnore(t *testing.T) {
 		testutil.WriteString(t, log, "\n")
 	}
 
-	m, stopM := mtail.TestStartServer(t, 0, mtail.LogPathPatterns(filepath.Join(workdir, "log*")), mtail.IgnoreRegexPattern("\\.gz"))
+	m, stopM := mtail.TestStartServer(t, 0, 0, mtail.LogPathPatterns(filepath.Join(workdir, "log*")), mtail.IgnoreRegexPattern("\\.gz"))
 
 	stopM()
 
@@ -207,7 +207,7 @@ func TestGlobRelativeAfterStart(t *testing.T) {
 	// Move to logdir to make relative paths
 	testutil.Chdir(t, logDir)
 
-	m, stopM := mtail.TestStartServer(t, 1, mtail.ProgramPath(progDir), mtail.LogPathPatterns("log.*"))
+	m, stopM := mtail.TestStartServer(t, 1, 0, mtail.ProgramPath(progDir), mtail.LogPathPatterns("log.*"))
 	defer stopM()
 
 	{
@@ -217,9 +217,11 @@ func TestGlobRelativeAfterStart(t *testing.T) {
 		f := testutil.TestOpenFile(t, logFile)
 		defer f.Close()
 
-		m.PollWatched(1) // Force sync to EOF
+		m.AwakenPatternPollers(1, 1)
+		m.AwakenLogStreams(0, 1) // Force read to EOF
+
 		testutil.WriteString(t, f, "line 1\n")
-		m.PollWatched(1)
+		m.AwakenLogStreams(1, 1)
 
 		logCountCheck()
 	}
@@ -232,9 +234,11 @@ func TestGlobRelativeAfterStart(t *testing.T) {
 		f := testutil.TestOpenFile(t, logFile)
 		defer f.Close()
 
-		m.PollWatched(2)
+		m.AwakenPatternPollers(1, 1)
+		m.AwakenLogStreams(1, 2) // Force read to EOF
+
 		testutil.WriteString(t, f, "line 1\n")
-		m.PollWatched(2)
+		m.AwakenLogStreams(2, 2)
 
 		logCountCheck()
 	}
@@ -245,9 +249,11 @@ func TestGlobRelativeAfterStart(t *testing.T) {
 		f := testutil.TestOpenFile(t, logFile)
 		defer f.Close()
 
-		m.PollWatched(2)
+		m.AwakenPatternPollers(1, 1)
+		m.AwakenLogStreams(2, 2) // Force read to EOF
+
 		testutil.WriteString(t, f, "line 2\n")
-		m.PollWatched(2)
+		m.AwakenLogStreams(2, 2)
 
 		logCountCheck()
 	}

--- a/internal/mtail/log_rotation_integration_test.go
+++ b/internal/mtail/log_rotation_integration_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/mtail/internal/testutil"
 )
 
-func TestLogSoftLinkChange(t *testing.T) {
+func TestLogRotationBySoftLinkChange(t *testing.T) {
 	testutil.SkipIfShort(t)
 
 	for _, tc := range []bool{false, true} {

--- a/internal/mtail/log_rotation_integration_test.go
+++ b/internal/mtail/log_rotation_integration_test.go
@@ -54,6 +54,7 @@ func TestLogRotationBySoftLinkChange(t *testing.T) {
 			defer trueLog2.Close()
 			m.AwakenPatternPollers(1, 1)
 			m.AwakenLogStreams(1, 1)
+			m.AwakenGcPoller(1, 1)
 			logClosedCheck := m.ExpectMapExpvarDeltaWithDeadline("log_closes_total", logFilepath, 1)
 			logCompletedCheck := m.ExpectExpvarDeltaWithDeadline("log_count", -1)
 			testutil.FatalIfErr(t, os.Remove(logFilepath))
@@ -63,7 +64,7 @@ func TestLogRotationBySoftLinkChange(t *testing.T) {
 				m.AwakenPatternPollers(1, 1) // simulate race condition with this poll.
 				m.AwakenLogStreams(1, 0)
 				logClosedCheck() // barrier until filestream closes fd
-				m.AwakenPatternPollers(1, 1)
+				m.AwakenGcPoller(1, 1)
 				logCompletedCheck() // barrier until the logstream is removed from tailer
 			}
 			testutil.FatalIfErr(t, os.Symlink(logFilepath+".true2", logFilepath))

--- a/internal/mtail/log_rotation_integration_test.go
+++ b/internal/mtail/log_rotation_integration_test.go
@@ -61,15 +61,14 @@ func TestLogRotationBySoftLinkChange(t *testing.T) {
 				// Simulate a race where we poll for a pattern and remove the
 				// existing stream.
 				m.AwakenPatternPollers(1, 1) // simulate race condition with this poll.
-				m.AwakenLogStreams(1, 1)
+				m.AwakenLogStreams(1, 0)
 				logClosedCheck() // barrier until filestream closes fd
-				m.AwakenLogStreams(1, 1)
-
+				m.AwakenPatternPollers(1, 1)
 				logCompletedCheck() // barrier until the logstream is removed from tailer
 			}
 			testutil.FatalIfErr(t, os.Symlink(logFilepath+".true2", logFilepath))
 			m.AwakenPatternPollers(1, 1)
-			m.AwakenLogStreams(1, 1)
+			m.AwakenLogStreams(0, 1)
 
 			for _, x := range inputLines {
 				testutil.WriteString(t, trueLog2, x+"\n")

--- a/internal/mtail/log_rotation_integration_test.go
+++ b/internal/mtail/log_rotation_integration_test.go
@@ -29,7 +29,7 @@ func TestLogRotationBySoftLinkChange(t *testing.T) {
 
 			logFilepath := filepath.Join(workdir, "log")
 
-			m, stopM := mtail.TestStartServer(t, 1, mtail.LogPathPatterns(logFilepath))
+			m, stopM := mtail.TestStartServer(t, 1, 1, mtail.LogPathPatterns(logFilepath))
 			defer stopM()
 
 			logCountCheck := m.ExpectExpvarDeltaWithDeadline("log_count", 1)
@@ -40,33 +40,42 @@ func TestLogRotationBySoftLinkChange(t *testing.T) {
 
 			testutil.FatalIfErr(t, os.Symlink(logFilepath+".true1", logFilepath))
 			glog.Info("symlinked")
-			m.PollWatched(1)
+			m.AwakenPatternPollers(1, 1)
+			m.AwakenLogStreams(1, 1)
 
 			inputLines := []string{"hi1", "hi2", "hi3"}
 			for _, x := range inputLines {
 				testutil.WriteString(t, trueLog1, x+"\n")
 			}
-			m.PollWatched(1)
+			m.AwakenPatternPollers(1, 1)
+			m.AwakenLogStreams(1, 1)
 
 			trueLog2 := testutil.TestOpenFile(t, logFilepath+".true2")
 			defer trueLog2.Close()
-			m.PollWatched(1)
+			m.AwakenPatternPollers(1, 1)
+			m.AwakenLogStreams(1, 1)
 			logClosedCheck := m.ExpectMapExpvarDeltaWithDeadline("log_closes_total", logFilepath, 1)
 			logCompletedCheck := m.ExpectExpvarDeltaWithDeadline("log_count", -1)
 			testutil.FatalIfErr(t, os.Remove(logFilepath))
 			if tc {
-				m.PollWatched(0)    // simulate race condition with this poll.
-				logClosedCheck()    // sync when filestream closes fd
-				m.PollWatched(0)    // invoke the GC
-				logCompletedCheck() // sync to when the logstream is removed from tailer
+				// Simulate a race where we poll for a pattern and remove the
+				// existing stream.
+				m.AwakenPatternPollers(1, 1) // simulate race condition with this poll.
+				m.AwakenLogStreams(1, 1)
+				logClosedCheck() // barrier until filestream closes fd
+				m.AwakenLogStreams(1, 1)
+
+				logCompletedCheck() // barrier until the logstream is removed from tailer
 			}
 			testutil.FatalIfErr(t, os.Symlink(logFilepath+".true2", logFilepath))
-			m.PollWatched(1)
+			m.AwakenPatternPollers(1, 1)
+			m.AwakenLogStreams(1, 1)
 
 			for _, x := range inputLines {
 				testutil.WriteString(t, trueLog2, x+"\n")
 			}
-			m.PollWatched(1)
+			m.AwakenPatternPollers(1, 1)
+			m.AwakenLogStreams(1, 1)
 
 			var wg sync.WaitGroup
 			wg.Add(2)

--- a/internal/mtail/log_rotation_integration_unix_test.go
+++ b/internal/mtail/log_rotation_integration_unix_test.go
@@ -69,7 +69,7 @@ func TestLogRotationByRename(t *testing.T) {
 				m.AwakenPatternPollers(1, 1) // simulate race condition with this poll.
 				m.AwakenLogStreams(1, 0)
 				logClosedCheck() // barrier until filestream closes fd
-				m.AwakenPatternPollers(1, 1)
+				m.AwakenGcPoller(1, 1)
 				logCompletedCheck() // barrier until the logstream is removed from tailer
 			}
 			glog.Info("create")

--- a/internal/mtail/log_rotation_integration_unix_test.go
+++ b/internal/mtail/log_rotation_integration_unix_test.go
@@ -67,15 +67,15 @@ func TestLogRotationByRename(t *testing.T) {
 				// Simulate a race where we poll for a pattern and remove the
 				// existing stream.
 				m.AwakenPatternPollers(1, 1) // simulate race condition with this poll.
-				m.AwakenLogStreams(1, 1)
-				logClosedCheck()         // barrier until filestream closes fd
-				m.AwakenLogStreams(1, 1) // invoke the GC
-				logCompletedCheck()      // barrier until logstream is removed from tailer
+				m.AwakenLogStreams(1, 0)
+				logClosedCheck() // barrier until filestream closes fd
+				m.AwakenPatternPollers(1, 1)
+				logCompletedCheck() // barrier until the logstream is removed from tailer
 			}
 			glog.Info("create")
 			f = testutil.TestOpenFile(t, logFile)
 			m.AwakenPatternPollers(1, 1)
-			m.AwakenLogStreams(1, 1)
+			m.AwakenLogStreams(0, 1)
 			testutil.WriteString(t, f, "line 1\n")
 			m.AwakenLogStreams(1, 1)
 

--- a/internal/mtail/log_rotation_integration_unix_test.go
+++ b/internal/mtail/log_rotation_integration_unix_test.go
@@ -17,11 +17,12 @@ import (
 	"github.com/google/mtail/internal/testutil"
 )
 
-// TestLogRotation is a unix-specific test because on Windows, files cannot be removed
-// or renamed while there is an open read handle on them. Instead, log rotation would
-// have to be implemented by copying and then truncating the original file. That test
-// case is already covered by TestLogTruncation.
-func TestLogRotation(t *testing.T) {
+// TestLogRotationByRename is a unix-specific test because on Windows, files
+// cannot be removed or renamed while there is an open read handle on
+// them. Instead, log rotation would have to be implemented by copying and then
+// truncating the original file. That test case is already covered by
+// TestLogTruncation.
+func TestLogRotationByRename(t *testing.T) {
 	testutil.SkipIfShort(t)
 
 	for _, tc := range []bool{false, true} {

--- a/internal/mtail/multiple_levels_directory_integration_test.go
+++ b/internal/mtail/multiple_levels_directory_integration_test.go
@@ -20,7 +20,7 @@ func TestPollLogPathPatterns(t *testing.T) {
 	testutil.FatalIfErr(t, os.Mkdir(logDir, 0o700))
 	testutil.Chdir(t, logDir)
 
-	m, stopM := mtail.TestStartServer(t, 0, mtail.LogPathPatterns(logDir+"/files/*/log/*log"))
+	m, stopM := mtail.TestStartServer(t, 1, 0, mtail.LogPathPatterns(logDir+"/files/*/log/*log"))
 	defer stopM()
 
 	logCountCheck := m.ExpectExpvarDeltaWithDeadline("log_count", 1)
@@ -31,11 +31,12 @@ func TestPollLogPathPatterns(t *testing.T) {
 
 	f := testutil.TestOpenFile(t, logFile)
 	defer f.Close()
-	m.PollWatched(1)
+	m.AwakenPatternPollers(1, 1)
+	m.AwakenLogStreams(0, 1)
 
 	logCountCheck()
 
 	testutil.WriteString(t, f, "line 1\n")
-	m.PollWatched(1)
+	m.AwakenLogStreams(1, 1)
 	lineCountCheck()
 }

--- a/internal/mtail/multiple_lines_integration_test.go
+++ b/internal/mtail/multiple_lines_integration_test.go
@@ -29,17 +29,18 @@ func TestMultipleLinesInOneWrite(t *testing.T) {
 	f := testutil.TestOpenFile(t, logFile)
 	defer f.Close()
 
-	m, stopM := mtail.TestStartServer(t, 1, mtail.ProgramPath(progDir), mtail.LogPathPatterns(logDir+"/log"))
+	m, stopM := mtail.TestStartServer(t, 1, 1, mtail.ProgramPath(progDir), mtail.LogPathPatterns(logDir+"/log"))
 	defer stopM()
 
-	m.PollWatched(1) // Force sync to EOF
+	m.AwakenPatternPollers(1, 1)
+	m.AwakenLogStreams(1, 1) // Force read to EOF
 
 	{
 		lineCountCheck := m.ExpectExpvarDeltaWithDeadline("lines_total", 1)
 		n, err := f.WriteString("line 1\n")
 		testutil.FatalIfErr(t, err)
 		glog.Infof("Wrote %d bytes", n)
-		m.PollWatched(1)
+		m.AwakenLogStreams(1, 1)
 		lineCountCheck()
 	}
 
@@ -48,7 +49,7 @@ func TestMultipleLinesInOneWrite(t *testing.T) {
 		n, err := f.WriteString("line 2\nline 3\n")
 		testutil.FatalIfErr(t, err)
 		glog.Infof("Wrote %d bytes", n)
-		m.PollWatched(1)
+		m.AwakenLogStreams(1, 1)
 		lineCountCheck()
 	}
 }

--- a/internal/mtail/options.go
+++ b/internal/mtail/options.go
@@ -109,17 +109,17 @@ func (opt overrideLocation) apply(m *Server) error {
 	return nil
 }
 
-// StaleLogGcWaker triggers garbage collection runs for stale logs in the tailer.
-func StaleLogGcWaker(w waker.Waker) Option {
-	return &staleLogGcWaker{w}
+// GcWaker triggers garbage collection runs for stale logs in the tailer.
+func GcWaker(w waker.Waker) Option {
+	return &gcWaker{w}
 }
 
-type staleLogGcWaker struct {
+type gcWaker struct {
 	waker.Waker
 }
 
-func (opt staleLogGcWaker) apply(m *Server) error {
-	m.tOpts = append(m.tOpts, tailer.StaleLogGcWaker(opt.Waker))
+func (opt gcWaker) apply(m *Server) error {
+	m.tOpts = append(m.tOpts, tailer.GcWaker(opt.Waker))
 	return nil
 }
 

--- a/internal/mtail/permission_denied_integration_unix_test.go
+++ b/internal/mtail/permission_denied_integration_unix_test.go
@@ -14,8 +14,9 @@ import (
 	"github.com/google/mtail/internal/testutil"
 )
 
-// TestPermissionDeniedOnLog is a unix-specific test because on Windows, it is not possible to create a file
-// that you yourself cannot read (minimum permissions are 0222).
+// TestPermissionDeniedOnLog is a unix-specific test because on Windows, it is
+// not possible to create a file that you yourself cannot read; there the
+// minimum permissions are 0222.
 func TestPermissionDeniedOnLog(t *testing.T) {
 	testutil.SkipIfShort(t)
 	// Can't force a permission denied error if run as root.
@@ -35,7 +36,7 @@ func TestPermissionDeniedOnLog(t *testing.T) {
 	// Hide the error from stdout during test.
 	testutil.SetFlag(t, "stderrthreshold", "FATAL")
 
-	m, stopM := mtail.TestStartServer(t, 0, mtail.ProgramPath(progDir), mtail.LogPathPatterns(logDir+"/log"))
+	m, stopM := mtail.TestStartServer(t, 1, 0, mtail.ProgramPath(progDir), mtail.LogPathPatterns(logDir+"/log"))
 	defer stopM()
 
 	errorsTotalCheck := m.ExpectMapExpvarDeltaWithDeadline("log_errors_total", logFile, 1)
@@ -46,7 +47,7 @@ func TestPermissionDeniedOnLog(t *testing.T) {
 
 	// Nothing to await on, we expect to get a Permission Denied in the
 	// synchronous logstream.New path.
-	m.PollWatched(0)
+	m.AwakenPatternPollers(1, 1)
 
 	errorsTotalCheck()
 }

--- a/internal/mtail/prog_load_integration_test.go
+++ b/internal/mtail/prog_load_integration_test.go
@@ -24,7 +24,7 @@ func TestNewProg(t *testing.T) {
 	err = os.Mkdir(progDir, 0o700)
 	testutil.FatalIfErr(t, err)
 
-	m, stopM := mtail.TestStartServer(t, 0, mtail.ProgramPath(progDir), mtail.LogPathPatterns(logDir+"/*"))
+	m, stopM := mtail.TestStartServer(t, 0, 0, mtail.ProgramPath(progDir), mtail.LogPathPatterns(logDir+"/*"))
 	defer stopM()
 
 	progLoadsTotalCheck := m.ExpectMapExpvarDeltaWithDeadline("prog_loads_total", "nocode.mtail", 1)
@@ -50,7 +50,7 @@ func TestProgramReloadNoDuplicateMetrics(t *testing.T) {
 	logFile := testutil.TestOpenFile(t, logFilepath)
 	defer logFile.Close()
 
-	m, stopM := mtail.TestStartServer(t, 0, mtail.ProgramPath(progDir), mtail.LogPathPatterns(logDir+"/*"))
+	m, stopM := mtail.TestStartServer(t, 1, 1, mtail.ProgramPath(progDir), mtail.LogPathPatterns(logDir+"/*"))
 	defer stopM()
 
 	progLoadsTotalCheck := m.ExpectMapExpvarDeltaWithDeadline("prog_loads_total", "program.mtail", 1)
@@ -66,7 +66,7 @@ func TestProgramReloadNoDuplicateMetrics(t *testing.T) {
 	fooIncreaseCheck := m.ExpectProgMetricDeltaWithDeadline("foo", "program.mtail", 1)
 
 	testutil.WriteString(t, logFile, "foo\n")
-	m.PollWatched(1)
+	m.AwakenLogStreams(1, 1)
 
 	fooIncreaseCheck()
 	progLoadsTotalCheck = m.ExpectMapExpvarDeltaWithDeadline("prog_loads_total", "program.mtail", 1)
@@ -96,7 +96,7 @@ func TestProgramUnloadIfDeleted(t *testing.T) {
 	logFile := testutil.TestOpenFile(t, logFilepath)
 	defer logFile.Close()
 
-	m, stopM := mtail.TestStartServer(t, 0, mtail.ProgramPath(progDir), mtail.LogPathPatterns(logDir+"/*"))
+	m, stopM := mtail.TestStartServer(t, 0, 0, mtail.ProgramPath(progDir), mtail.LogPathPatterns(logDir+"/*"))
 	defer stopM()
 
 	progLoadsTotalCheck := m.ExpectMapExpvarDeltaWithDeadline("prog_loads_total", "program.mtail", 1)

--- a/internal/mtail/prog_load_integration_test.go
+++ b/internal/mtail/prog_load_integration_test.go
@@ -31,8 +31,7 @@ func TestNewProg(t *testing.T) {
 
 	f := testutil.TestOpenFile(t, progDir+"/nocode.mtail")
 	defer f.Close()
-	// No logs get watched here.
-	m.PollWatched(0)
+	m.LoadAllPrograms()
 
 	progLoadsTotalCheck()
 }
@@ -60,7 +59,7 @@ func TestProgramReloadNoDuplicateMetrics(t *testing.T) {
 	p := testutil.TestOpenFile(t, progpath)
 	testutil.WriteString(t, p, "counter foo\n/^foo$/ {\n foo++\n }\n")
 	testutil.FatalIfErr(t, p.Close())
-	m.PollWatched(0)
+	m.LoadAllPrograms()
 
 	progLoadsTotalCheck()
 
@@ -75,7 +74,7 @@ func TestProgramReloadNoDuplicateMetrics(t *testing.T) {
 	p = testutil.TestOpenFile(t, progpath) // opens in append mode
 	testutil.WriteString(t, p, "#\n")      // append just enough to change but still valid
 	testutil.FatalIfErr(t, p.Close())
-	m.PollWatched(1)
+	m.LoadAllPrograms()
 
 	progLoadsTotalCheck()
 
@@ -106,15 +105,14 @@ func TestProgramUnloadIfDeleted(t *testing.T) {
 	p := testutil.TestOpenFile(t, progpath)
 	testutil.WriteString(t, p, "counter foo\n/^foo$/ {\n foo++\n }\n")
 	testutil.FatalIfErr(t, p.Close())
-	m.PollWatched(0)
+	m.LoadAllPrograms()
 
 	progLoadsTotalCheck()
 
 	progUnloadsTotalCheck := m.ExpectMapExpvarDeltaWithDeadline("prog_unloads_total", "program.mtail", 1)
 
 	testutil.FatalIfErr(t, os.Remove(progpath))
-
-	m.PollWatched(1)
+	m.LoadAllPrograms()
 
 	progUnloadsTotalCheck()
 }

--- a/internal/mtail/read_pipe_integration_unix_test.go
+++ b/internal/mtail/read_pipe_integration_unix_test.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"syscall"
 	"testing"
-	"time"
 
 	"github.com/google/mtail/internal/mtail"
 	"github.com/google/mtail/internal/testutil"
@@ -70,7 +69,6 @@ func TestReadFromSocket(t *testing.T) {
 			defer stopM()
 
 			lineCountCheck := m.ExpectExpvarDeltaWithDeadline("lines_total", 3)
-			time.Sleep(10 * time.Millisecond)
 
 			s, err := net.DialUnix(scheme, nil, &net.UnixAddr{Name: logFile, Net: scheme})
 			testutil.FatalIfErr(t, err)
@@ -80,9 +78,6 @@ func TestReadFromSocket(t *testing.T) {
 
 			_, err = s.Write([]byte("1\n2\n3\n"))
 			testutil.FatalIfErr(t, err)
-
-			m.AwakenPatternPollers(1, 1)
-			m.AwakenLogStreams(1, 1)
 
 			lineCountCheck()
 		})

--- a/internal/mtail/relative_path_pattern_integration_test.go
+++ b/internal/mtail/relative_path_pattern_integration_test.go
@@ -32,10 +32,11 @@ func TestRelativeLog(t *testing.T) {
 	testutil.FatalIfErr(t, err)
 	defer logFile.Close()
 	pathnames := []string{"log"}
-	m, stopM := mtail.TestStartServer(t, 1, mtail.LogPathPatterns(pathnames...))
+	m, stopM := mtail.TestStartServer(t, 1, 1, mtail.LogPathPatterns(pathnames...))
 	defer stopM()
 
-	m.PollWatched(1) // Force sync to EOF
+	m.AwakenPatternPollers(1, 1)
+	m.AwakenLogStreams(1, 1) // Force read to EOF
 
 	inputLines := []string{"hi", "hi2", "hi3"}
 	lineCountCheck := m.ExpectExpvarDeltaWithDeadline("lines_total", int64(len(inputLines)))
@@ -44,7 +45,7 @@ func TestRelativeLog(t *testing.T) {
 		// write to log file
 		testutil.WriteString(t, logFile, x+"\n")
 	}
-	m.PollWatched(1)
+	m.AwakenLogStreams(1, 1)
 
 	lineCountCheck()
 }

--- a/internal/mtail/testing.go
+++ b/internal/mtail/testing.go
@@ -105,10 +105,6 @@ func (ts *TestServer) PollWatched(n int) {
 	if err := ts.t.Poll(); err != nil {
 		glog.Info(err)
 	}
-	glog.Infof("TestServer reloading programs")
-	if err := ts.r.LoadAllPrograms(); err != nil {
-		glog.Info(err)
-	}
 	glog.Infof("TestServer tailer gcing")
 	if err := ts.t.ExpireStaleLogstreams(); err != nil {
 		glog.Info(err)
@@ -116,6 +112,15 @@ func (ts *TestServer) PollWatched(n int) {
 	glog.Info("TestServer waking idle routines")
 	ts.awakenStreams(n)
 	glog.Info("Testserver finishing poll")
+}
+
+func (ts *TestServer) LoadAllPrograms() {
+	ts.tb.Helper()
+	glog.Infof("TestServer reloading programs")
+	if err := ts.r.LoadAllPrograms(); err != nil {
+		glog.Info(err)
+		ts.tb.Log(err)
+	}
 }
 
 // GetExpvar is a helper function on TestServer that acts like TestGetExpvar.

--- a/internal/mtail/testing.go
+++ b/internal/mtail/testing.go
@@ -105,10 +105,6 @@ func (ts *TestServer) PollWatched(n int) {
 	if err := ts.t.PollLogPatterns(); err != nil {
 		glog.Info(err)
 	}
-	glog.Infof("TestServer tailer gcing")
-	if err := ts.t.ExpireStaleLogstreams(); err != nil {
-		glog.Info(err)
-	}
 	glog.Info("TestServer waking idle routines")
 	ts.awakenStreams(n)
 	glog.Info("Testserver finishing poll")

--- a/internal/mtail/testing.go
+++ b/internal/mtail/testing.go
@@ -56,7 +56,7 @@ func TestMakeServer(tb testing.TB, wakers int, options ...Option) *TestServer {
 		tb:     tb,
 		cancel: cancel,
 	}
-	ts.streamWaker, ts.awakenStreams = waker.NewTest(ctx, wakers)
+	ts.streamWaker, ts.awakenStreams = waker.NewTest(ctx, wakers, "streams")
 	options = append(options,
 		LogstreamPollWaker(ts.streamWaker),
 	)

--- a/internal/mtail/testing.go
+++ b/internal/mtail/testing.go
@@ -102,7 +102,7 @@ func (ts *TestServer) Start() func() {
 func (ts *TestServer) PollWatched(n int) {
 	glog.Info("Testserver starting poll")
 	glog.Infof("TestServer polling filesystem patterns")
-	if err := ts.t.Poll(); err != nil {
+	if err := ts.t.PollLogPatterns(); err != nil {
 		glog.Info(err)
 	}
 	glog.Infof("TestServer tailer gcing")

--- a/internal/mtail/testing.go
+++ b/internal/mtail/testing.go
@@ -34,6 +34,9 @@ type TestServer struct {
 	// method, synchronising the pattern poll with the test.
 	AwakenPatternPollers waker.WakeFunc // the glob awakens
 
+	gcWaker        waker.Waker // activate the cleanup routines
+	AwakenGcPoller waker.WakeFunc
+
 	tb testing.TB
 
 	cancel context.CancelFunc
@@ -65,9 +68,11 @@ func TestMakeServer(tb testing.TB, patternWakers int, streamWakers int, options 
 	}
 	ts.streamWaker, ts.AwakenLogStreams = waker.NewTest(ctx, streamWakers, "streams")
 	ts.patternWaker, ts.AwakenPatternPollers = waker.NewTest(ctx, patternWakers, "patterns")
+	ts.gcWaker, ts.AwakenGcPoller = waker.NewTest(ctx, 1, "gc")
 	options = append(options,
 		LogstreamPollWaker(ts.streamWaker),
 		LogPatternPollWaker(ts.patternWaker),
+		GcWaker(ts.gcWaker),
 	)
 	var err error
 	ts.Server, err = New(ctx, metrics.NewStore(), options...)

--- a/internal/mtail/unix_socket_export_integration_test.go
+++ b/internal/mtail/unix_socket_export_integration_test.go
@@ -18,7 +18,7 @@ func TestBasicUNIXSockets(t *testing.T) {
 	tmpDir := testutil.TestTempDir(t)
 	sockListenAddr := filepath.Join(tmpDir, "mtail_test.sock")
 
-	_, stopM := mtail.TestStartServer(t, 1, mtail.LogPathPatterns(tmpDir+"/*"), mtail.ProgramPath("../../examples/linecount.mtail"), mtail.BindUnixSocket(sockListenAddr))
+	_, stopM := mtail.TestStartServer(t, 1, 1, mtail.LogPathPatterns(tmpDir+"/*"), mtail.ProgramPath("../../examples/linecount.mtail"), mtail.BindUnixSocket(sockListenAddr))
 	defer stopM()
 
 	glog.Infof("check that server is listening")

--- a/internal/tailer/logstream/cancel.go
+++ b/internal/tailer/logstream/cancel.go
@@ -18,9 +18,9 @@ type ReadDeadliner interface {
 func SetReadDeadlineOnDone(ctx context.Context, d ReadDeadliner) {
 	go func() {
 		<-ctx.Done()
-		glog.Info("cancelled, setting read deadline to interrupt read")
+		glog.V(1).Info("cancelled, setting read deadline to interrupt read")
 		if err := d.SetReadDeadline(time.Now()); err != nil {
-			glog.Infof("SetReadDeadline() -> %v", err)
+			glog.V(1).Infof("SetReadDeadline() -> %v", err)
 		}
 	}()
 }

--- a/internal/tailer/logstream/dgramstream_unix_test.go
+++ b/internal/tailer/logstream/dgramstream_unix_test.go
@@ -40,7 +40,7 @@ func TestDgramStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 			}
 			lines := make(chan *logline.LogLine, 1)
 			ctx, cancel := context.WithCancel(context.Background())
-			waker, awaken := waker.NewTest(ctx, 1)
+			waker, awaken := waker.NewTest(ctx, 1, "stream")
 
 			sockName := scheme + "://" + addr
 			ss, err := logstream.New(ctx, &wg, waker, sockName, lines, logstream.OneShotDisabled)
@@ -97,7 +97,7 @@ func TestDgramStreamReadCompletedBecauseCancel(t *testing.T) {
 			}
 			lines := make(chan *logline.LogLine, 1)
 			ctx, cancel := context.WithCancel(context.Background())
-			waker, awaken := waker.NewTest(ctx, 1)
+			waker, awaken := waker.NewTest(ctx, 1, "stream")
 
 			sockName := scheme + "://" + addr
 			ss, err := logstream.New(ctx, &wg, waker, sockName, lines, logstream.OneShotDisabled)

--- a/internal/tailer/logstream/dgramstream_unix_test.go
+++ b/internal/tailer/logstream/dgramstream_unix_test.go
@@ -52,7 +52,7 @@ func TestDgramStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 			_, err = s.Write([]byte("1\n"))
 			testutil.FatalIfErr(t, err)
 
-			awaken(0) // sync past read
+			awaken(0, 0) // sync past read
 
 			ss.Stop()
 
@@ -109,7 +109,7 @@ func TestDgramStreamReadCompletedBecauseCancel(t *testing.T) {
 			_, err = s.Write([]byte("1\n"))
 			testutil.FatalIfErr(t, err)
 
-			awaken(0) // Synchronise past read.
+			awaken(0, 0) // Synchronise past read.
 
 			cancel() // This cancellation should cause the stream to shut down.
 

--- a/internal/tailer/logstream/filestream_test.go
+++ b/internal/tailer/logstream/filestream_test.go
@@ -26,7 +26,7 @@ func TestFileStreamRead(t *testing.T) {
 
 	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
-	waker, awaken := waker.NewTest(ctx, 1)
+	waker, awaken := waker.NewTest(ctx, 1, "stream")
 	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
 	testutil.FatalIfErr(t, err)
 	awaken(1)
@@ -61,7 +61,7 @@ func TestFileStreamReadNonSingleByteEnd(t *testing.T) {
 
 	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
-	waker, awaken := waker.NewTest(ctx, 1)
+	waker, awaken := waker.NewTest(ctx, 1, "stream")
 	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
 	testutil.FatalIfErr(t, err)
 	awaken(1)
@@ -102,7 +102,7 @@ func TestStreamDoesntBreakOnCorruptRune(t *testing.T) {
 
 	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
-	waker, awaken := waker.NewTest(ctx, 1)
+	waker, awaken := waker.NewTest(ctx, 1, "stream")
 	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
 	testutil.FatalIfErr(t, err)
 	awaken(1)
@@ -148,7 +148,7 @@ func TestFileStreamTruncation(t *testing.T) {
 
 	lines := make(chan *logline.LogLine, 3)
 	ctx, cancel := context.WithCancel(context.Background())
-	waker, awaken := waker.NewTest(ctx, 1)
+	waker, awaken := waker.NewTest(ctx, 1, "stream")
 	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
 	// fs.Stop() is also called explicitly further down but a failed test
 	// and early return would lead to the handle staying open
@@ -195,7 +195,7 @@ func TestFileStreamFinishedBecauseCancel(t *testing.T) {
 
 	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
-	waker, awaken := waker.NewTest(ctx, 1)
+	waker, awaken := waker.NewTest(ctx, 1, "stream")
 
 	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
 	testutil.FatalIfErr(t, err)
@@ -230,7 +230,7 @@ func TestFileStreamPartialRead(t *testing.T) {
 
 	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
-	waker, awaken := waker.NewTest(ctx, 1)
+	waker, awaken := waker.NewTest(ctx, 1, "stream")
 
 	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
 	testutil.FatalIfErr(t, err)

--- a/internal/tailer/logstream/filestream_test.go
+++ b/internal/tailer/logstream/filestream_test.go
@@ -29,10 +29,10 @@ func TestFileStreamRead(t *testing.T) {
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
 	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
 	testutil.FatalIfErr(t, err)
-	awaken(1)
+	awaken(1, 1)
 
 	testutil.WriteString(t, f, "yo\n")
-	awaken(1)
+	awaken(1, 1)
 
 	fs.Stop()
 	wg.Wait()
@@ -64,7 +64,7 @@ func TestFileStreamReadNonSingleByteEnd(t *testing.T) {
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
 	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
 	testutil.FatalIfErr(t, err)
-	awaken(1)
+	awaken(1, 1)
 
 	s := "a"
 	for i := 0; i < 4094; i++ {
@@ -73,7 +73,7 @@ func TestFileStreamReadNonSingleByteEnd(t *testing.T) {
 
 	s += "中"
 	testutil.WriteString(t, f, s+"\n")
-	awaken(1)
+	awaken(1, 1)
 
 	fs.Stop()
 	wg.Wait()
@@ -105,7 +105,7 @@ func TestStreamDoesntBreakOnCorruptRune(t *testing.T) {
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
 	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
 	testutil.FatalIfErr(t, err)
-	awaken(1)
+	awaken(1, 1)
 
 	s := string([]byte{0xF1})
 	// 0xF1 = 11110001 , a byte signaling the start of a unicode character that
@@ -119,7 +119,7 @@ func TestStreamDoesntBreakOnCorruptRune(t *testing.T) {
 	}
 
 	testutil.WriteString(t, f, s+"\n")
-	awaken(1)
+	awaken(1, 1)
 
 	fs.Stop()
 	wg.Wait()
@@ -155,17 +155,17 @@ func TestFileStreamTruncation(t *testing.T) {
 	defer fs.Stop()
 
 	testutil.FatalIfErr(t, err)
-	awaken(1) // Synchronise past first read after seekToEnd
+	awaken(1, 1) // Synchronise past first read after seekToEnd
 
 	testutil.WriteString(t, f, "1\n2\n")
-	awaken(1)
+	awaken(1, 1)
 	testutil.FatalIfErr(t, f.Close())
-	awaken(1)
+	awaken(1, 1)
 	f = testutil.OpenLogFile(t, name)
 	defer f.Close()
 
 	testutil.WriteString(t, f, "3\n")
-	awaken(1)
+	awaken(1, 1)
 
 	fs.Stop()
 	wg.Wait()
@@ -199,10 +199,10 @@ func TestFileStreamFinishedBecauseCancel(t *testing.T) {
 
 	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
 	testutil.FatalIfErr(t, err)
-	awaken(1) // Synchronise past first read after seekToEnd
+	awaken(1, 1) // Synchronise past first read after seekToEnd
 
 	testutil.WriteString(t, f, "yo\n")
-	awaken(1)
+	awaken(1, 1)
 
 	cancel()
 	wg.Wait()
@@ -234,17 +234,17 @@ func TestFileStreamPartialRead(t *testing.T) {
 
 	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
 	testutil.FatalIfErr(t, err)
-	awaken(1)
+	awaken(1, 1)
 
 	testutil.WriteString(t, f, "yo")
-	awaken(1)
+	awaken(1, 1)
 
 	// received := testutil.LinesReceived(lines)
 	// expected := []*logline.LogLine{}
 	// testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 
 	testutil.WriteString(t, f, "\n")
-	awaken(1)
+	awaken(1, 1)
 
 	fs.Stop()
 	wg.Wait()

--- a/internal/tailer/logstream/filestream_unix_test.go
+++ b/internal/tailer/logstream/filestream_unix_test.go
@@ -35,7 +35,7 @@ func TestFileStreamRotation(t *testing.T) {
 	lines := make(chan *logline.LogLine, 2)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	waker, awaken := waker.NewTest(ctx, 1)
+	waker, awaken := waker.NewTest(ctx, 1, "stream")
 
 	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
 	// fs.Stop() is also called explicitly further down but a failed test
@@ -87,7 +87,7 @@ func TestFileStreamURL(t *testing.T) {
 
 	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
-	waker, awaken := waker.NewTest(ctx, 1)
+	waker, awaken := waker.NewTest(ctx, 1, "stream")
 	fs, err := logstream.New(ctx, &wg, waker, "file://"+name, lines, logstream.OneShotEnabled)
 	testutil.FatalIfErr(t, err)
 	awaken(1)
@@ -129,7 +129,7 @@ func TestFileStreamOpenFailure(t *testing.T) {
 
 	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
-	waker, _ := waker.NewTest(ctx, 0)
+	waker, _ := waker.NewTest(ctx, 0, "stream")
 
 	_, err = logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
 	if err == nil || !os.IsPermission(err) {

--- a/internal/tailer/logstream/filestream_unix_test.go
+++ b/internal/tailer/logstream/filestream_unix_test.go
@@ -43,11 +43,11 @@ func TestFileStreamRotation(t *testing.T) {
 	defer fs.Stop()
 
 	testutil.FatalIfErr(t, err)
-	awaken(1)
+	awaken(1, 1)
 
 	glog.Info("write 1")
 	testutil.WriteString(t, f, "1\n")
-	awaken(1)
+	awaken(1, 1)
 
 	glog.Info("rename")
 	testutil.FatalIfErr(t, os.Rename(name, name+".1"))
@@ -56,10 +56,10 @@ func TestFileStreamRotation(t *testing.T) {
 	f = testutil.TestOpenFile(t, name)
 	defer f.Close()
 
-	awaken(1)
+	awaken(1, 1)
 	glog.Info("write 2")
 	testutil.WriteString(t, f, "2\n")
-	awaken(1)
+	awaken(1, 1)
 
 	fs.Stop()
 	wg.Wait()
@@ -90,10 +90,10 @@ func TestFileStreamURL(t *testing.T) {
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
 	fs, err := logstream.New(ctx, &wg, waker, "file://"+name, lines, logstream.OneShotEnabled)
 	testutil.FatalIfErr(t, err)
-	awaken(1)
+	awaken(1, 1)
 
 	testutil.WriteString(t, f, "yo\n")
-	awaken(1)
+	awaken(1, 1)
 
 	fs.Stop()
 	wg.Wait()

--- a/internal/tailer/logstream/logstream.go
+++ b/internal/tailer/logstream/logstream.go
@@ -88,20 +88,18 @@ func New(ctx context.Context, wg *sync.WaitGroup, waker waker.Waker, pathname st
 	case "", "file":
 		path = u.Path
 	}
-	var fi os.FileInfo
 	if IsStdinPattern(path) {
-		fi, err = os.Stdin.Stat()
+		fi, err := os.Stdin.Stat()
 		if err != nil {
 			logErrors.Add(path, 1)
 			return nil, err
 		}
 		return newPipeStream(ctx, wg, waker, path, fi, lines)
-	} else {
-		fi, err = os.Stat(path)
-		if err != nil {
-			logErrors.Add(path, 1)
-			return nil, err
-		}
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		logErrors.Add(path, 1)
+		return nil, err
 	}
 	switch m := fi.Mode(); {
 	case m.IsRegular():

--- a/internal/tailer/logstream/pipestream_unix_test.go
+++ b/internal/tailer/logstream/pipestream_unix_test.go
@@ -88,7 +88,7 @@ func TestPipeStreamReadCompletedBecauseCancel(t *testing.T) {
 		testutil.WriteString(t, f, "1\n")
 
 		// Avoid a race with cancellation if we can synchronise with waker.Wake()
-		awaken(0)
+		awaken(0, 0)
 
 		cancel() // Cancellation here should cause the stream to shut down.
 
@@ -165,7 +165,7 @@ func TestPipeStreamReadStdin(t *testing.T) {
 	ps, err := logstream.New(ctx, &wg, waker, "-", lines, logstream.OneShotDisabled)
 	testutil.FatalIfErr(t, err)
 
-	awaken(0)
+	awaken(0, 0)
 
 	testutil.FatalIfErr(t, f.Close())
 

--- a/internal/tailer/logstream/pipestream_unix_test.go
+++ b/internal/tailer/logstream/pipestream_unix_test.go
@@ -77,7 +77,7 @@ func TestPipeStreamReadCompletedBecauseCancel(t *testing.T) {
 
 		lines := make(chan *logline.LogLine, 1)
 		ctx, cancel := context.WithCancel(context.Background())
-		waker, awaken := waker.NewTest(ctx, 1)
+		waker, awaken := waker.NewTest(ctx, 1, "stream")
 
 		f, err := os.OpenFile(name, os.O_RDWR, os.ModeNamedPipe)
 		testutil.FatalIfErr(t, err)
@@ -160,7 +160,7 @@ func TestPipeStreamReadStdin(t *testing.T) {
 
 	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
-	waker, awaken := waker.NewTest(ctx, 1)
+	waker, awaken := waker.NewTest(ctx, 1, "stream")
 
 	ps, err := logstream.New(ctx, &wg, waker, "-", lines, logstream.OneShotDisabled)
 	testutil.FatalIfErr(t, err)

--- a/internal/tailer/logstream/pipestream_unix_test.go
+++ b/internal/tailer/logstream/pipestream_unix_test.go
@@ -54,7 +54,7 @@ func TestPipeStreamReadCompletedBecauseClosed(t *testing.T) {
 
 		received := testutil.LinesReceived(lines)
 		expected := []*logline.LogLine{
-			{context.TODO(), name, "1"},
+			{Context: context.TODO(), Filename: name, Line: "1"},
 		}
 		testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 
@@ -97,7 +97,7 @@ func TestPipeStreamReadCompletedBecauseCancel(t *testing.T) {
 
 		received := testutil.LinesReceived(lines)
 		expected := []*logline.LogLine{
-			{context.TODO(), name, "1"},
+			{Context: context.TODO(), Filename: name, Line: "1"},
 		}
 		testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 
@@ -135,7 +135,7 @@ func TestPipeStreamReadURL(t *testing.T) {
 
 	received := testutil.LinesReceived(lines)
 	expected := []*logline.LogLine{
-		{context.TODO(), name, "1"},
+		{Context: context.TODO(), Filename: name, Line: "1"},
 	}
 	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 

--- a/internal/tailer/logstream/socketstream_unix_test.go
+++ b/internal/tailer/logstream/socketstream_unix_test.go
@@ -50,7 +50,7 @@ func TestSocketStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 			_, err = s.Write([]byte("1\n"))
 			testutil.FatalIfErr(t, err)
 
-			awaken(0) // Sync past read
+			awaken(0, 0) // Sync past read
 
 			// Close the socket to signal to the socketStream to shut down.
 			testutil.FatalIfErr(t, s.Close())
@@ -105,7 +105,7 @@ func TestSocketStreamReadCompletedBecauseCancel(t *testing.T) {
 			_, err = s.Write([]byte("1\n"))
 			testutil.FatalIfErr(t, err)
 
-			awaken(0) // Sync past read to ensure we read
+			awaken(0, 0) // Sync past read to ensure we read
 
 			cancel() // This cancellation should cause the stream to shut down immediately.
 

--- a/internal/tailer/logstream/socketstream_unix_test.go
+++ b/internal/tailer/logstream/socketstream_unix_test.go
@@ -38,7 +38,7 @@ func TestSocketStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 			}
 			lines := make(chan *logline.LogLine, 1)
 			ctx, cancel := context.WithCancel(context.Background())
-			waker, awaken := waker.NewTest(ctx, 1)
+			waker, awaken := waker.NewTest(ctx, 1, "stream")
 
 			sockName := scheme + "://" + addr
 			ss, err := logstream.New(ctx, &wg, waker, sockName, lines, logstream.OneShotDisabled)
@@ -93,7 +93,7 @@ func TestSocketStreamReadCompletedBecauseCancel(t *testing.T) {
 			}
 			lines := make(chan *logline.LogLine, 1)
 			ctx, cancel := context.WithCancel(context.Background())
-			waker, awaken := waker.NewTest(ctx, 1)
+			waker, awaken := waker.NewTest(ctx, 1, "stream")
 
 			sockName := scheme + "://" + addr
 			ss, err := logstream.New(ctx, &wg, waker, sockName, lines, logstream.OneShotDisabled)

--- a/internal/tailer/tail.go
+++ b/internal/tailer/tail.go
@@ -220,11 +220,12 @@ func (t *Tailer) AddPattern(pattern string) error {
 	path := pattern
 	switch u.Scheme {
 	default:
-		glog.V(2).Infof("%v: %q in path pattern %q, treating as path", ErrUnsupportedURLScheme, u.Scheme, pattern)
+		glog.V(2).Infof("AddPattern(%v): %v in path pattern %q, treating as path", pattern, ErrUnsupportedURLScheme, u.Scheme)
+		// Leave path alone per log message
 	case "unix", "unixgram", "tcp", "udp":
 		// Keep the scheme.
-		glog.V(2).Infof("AddPattern: socket %q", pattern)
-		t.socketPaths = append(t.socketPaths, pattern)
+		glog.V(2).Infof("AddPattern(%v): is a socket", path)
+		t.socketPaths = append(t.socketPaths, path)
 		return nil
 	case "", "file":
 		// Leave path alone; may contain globs
@@ -236,11 +237,11 @@ func (t *Tailer) AddPattern(pattern string) error {
 	} else {
 		path, err = filepath.Abs(path)
 		if err != nil {
-			glog.V(2).Infof("Couldn't canonicalize path %q: %s", u.Path, err)
+			glog.V(2).Infof("AddPattern(%v): couldn't canonicalize path: %v", path, err)
 			return err
 		}
 	}
-	glog.V(2).Infof("AddPattern: file %q", path)
+	glog.V(2).Infof("AddPattern(%v): is a file-like pattern", path)
 	t.globPatternsMu.Lock()
 	t.globPatterns[path] = struct{}{}
 	t.globPatternsMu.Unlock()

--- a/internal/tailer/tail.go
+++ b/internal/tailer/tail.go
@@ -224,12 +224,11 @@ func (t *Tailer) AddPattern(pattern string) error {
 		// stdin is not really a socket, but it is handled by this codepath and should not be in the globs.
 		glog.V(2).Infof("AddPattern(%v): is stdin", pattern)
 		return t.TailPath(pattern)
-	} else {
-		path, err = filepath.Abs(path)
-		if err != nil {
-			glog.V(2).Infof("AddPattern(%v): couldn't canonicalize path: %v", path, err)
-			return err
-		}
+	}
+	path, err = filepath.Abs(path)
+	if err != nil {
+		glog.V(2).Infof("AddPattern(%v): couldn't canonicalize path: %v", path, err)
+		return err
 	}
 	glog.V(2).Infof("AddPattern(%v): is a file-like pattern", path)
 	t.globPatternsMu.Lock()

--- a/internal/tailer/tail_test.go
+++ b/internal/tailer/tail_test.go
@@ -39,7 +39,7 @@ func makeTestTail(t *testing.T, options ...Option) *testTail {
 	ctx, cancel := context.WithCancel(context.Background())
 	lines := make(chan *logline.LogLine, 5) // 5 loglines ought to be enough for any test
 	var wg sync.WaitGroup
-	waker, awaken := waker.NewTest(ctx, 1)
+	waker, awaken := waker.NewTest(ctx, 1, "streams")
 	options = append(options, LogPatterns([]string{tmpDir}), LogstreamPollWaker(waker))
 	ta, err := New(ctx, &wg, lines, options...)
 	testutil.FatalIfErr(t, err)

--- a/internal/tailer/tail_test.go
+++ b/internal/tailer/tail_test.go
@@ -22,8 +22,11 @@ type testTail struct {
 	// Output lnes channel
 	lines chan *logline.LogLine
 
-	// Method to wake the waker
-	awaken func(int)
+	// Method to wake the stream poller
+	awakenStreams waker.WakeFunc
+
+	// Method to wake the pattern poller
+	awakenPattern waker.WakeFunc
 
 	// Temporary dir for test
 	tmpDir string
@@ -39,31 +42,17 @@ func makeTestTail(t *testing.T, options ...Option) *testTail {
 	ctx, cancel := context.WithCancel(context.Background())
 	lines := make(chan *logline.LogLine, 5) // 5 loglines ought to be enough for any test
 	var wg sync.WaitGroup
-	waker, awaken := waker.NewTest(ctx, 1, "streams")
-	options = append(options, LogPatterns([]string{tmpDir}), LogstreamPollWaker(waker))
+	streamWaker, awakenStreams := waker.NewTest(ctx, 1, "streams")
+	patternWaker, awakenPattern := waker.NewTest(ctx, 1, "pattern")
+	options = append(options, LogPatterns([]string{tmpDir}), LogPatternPollWaker(patternWaker), LogstreamPollWaker(streamWaker))
 	ta, err := New(ctx, &wg, lines, options...)
 	testutil.FatalIfErr(t, err)
 	stop := func() { cancel(); wg.Wait() }
 	t.Cleanup(stop)
-	return &testTail{Tailer: ta, lines: lines, awaken: awaken, tmpDir: tmpDir, stop: stop}
+	return &testTail{Tailer: ta, lines: lines, awakenStreams: awakenStreams, awakenPattern: awakenPattern, tmpDir: tmpDir, stop: stop}
 }
 
-func TestTail(t *testing.T) {
-	ta := makeTestTail(t)
-
-	logfile := filepath.Join(ta.tmpDir, "log")
-	f := testutil.TestOpenFile(t, logfile)
-	defer f.Close()
-
-	err := ta.TailPath(logfile)
-	testutil.FatalIfErr(t, err)
-
-	if _, ok := ta.logstreams[logfile]; !ok {
-		t.Errorf("path not found in files map: %+#v", ta.logstreams)
-	}
-}
-
-func TestTailErrors(t *testing.T) {
+func TestNewErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	lines := make(chan *logline.LogLine)
@@ -78,6 +67,21 @@ func TestTailErrors(t *testing.T) {
 	}
 }
 
+func TestTailPath(t *testing.T) {
+	ta := makeTestTail(t)
+
+	logfile := filepath.Join(ta.tmpDir, "log")
+	f := testutil.TestOpenFile(t, logfile)
+	defer f.Close()
+
+	err := ta.TailPath(logfile)
+	testutil.FatalIfErr(t, err)
+
+	if _, ok := ta.logstreams[logfile]; !ok {
+		t.Errorf("path not found in files map: %+#v", ta.logstreams)
+	}
+}
+
 func TestHandleLogUpdate(t *testing.T) {
 	ta := makeTestTail(t)
 
@@ -86,10 +90,10 @@ func TestHandleLogUpdate(t *testing.T) {
 	defer f.Close()
 
 	testutil.FatalIfErr(t, ta.TailPath(logfile))
-	ta.awaken(1)
+	ta.awakenStreams(1, 1)
 
 	testutil.WriteString(t, f, "a\nb\nc\nd\n")
-	ta.awaken(1)
+	ta.awakenStreams(1, 1)
 
 	ta.stop()
 
@@ -115,10 +119,10 @@ func TestHandleLogTruncate(t *testing.T) {
 
 	testutil.FatalIfErr(t, ta.TailPath(logfile))
 	// Expect to wake 1 wakee, the logstream reading `logfile`.
-	ta.awaken(1)
+	ta.awakenStreams(1, 1)
 
 	testutil.WriteString(t, f, "a\nb\nc\n")
-	ta.awaken(1)
+	ta.awakenStreams(1, 1)
 
 	if err := f.Truncate(0); err != nil {
 		t.Fatal(err)
@@ -127,10 +131,10 @@ func TestHandleLogTruncate(t *testing.T) {
 	// "File.Truncate" does not change the file offset, force a seek to start.
 	_, err := f.Seek(0, 0)
 	testutil.FatalIfErr(t, err)
-	ta.awaken(1)
+	ta.awakenStreams(1, 1)
 
 	testutil.WriteString(t, f, "d\ne\n")
-	ta.awaken(1)
+	ta.awakenStreams(1, 1)
 
 	ta.stop()
 
@@ -153,16 +157,16 @@ func TestHandleLogUpdatePartialLine(t *testing.T) {
 	defer f.Close()
 
 	testutil.FatalIfErr(t, ta.TailPath(logfile))
-	ta.awaken(1) // ensure we've hit an EOF before writing starts
+	ta.awakenStreams(1, 1) // ensure we've hit an EOF before writing starts
 
 	testutil.WriteString(t, f, "a")
-	ta.awaken(1)
+	ta.awakenStreams(1, 1)
 
 	testutil.WriteString(t, f, "b")
-	ta.awaken(1)
+	ta.awakenStreams(1, 1)
 
 	testutil.WriteString(t, f, "\n")
-	ta.awaken(1)
+	ta.awakenStreams(1, 1)
 
 	ta.stop()
 
@@ -187,12 +191,13 @@ func TestTailerUnreadableFile(t *testing.T) {
 	f := testutil.TestOpenFile(t, logfile)
 	defer f.Close()
 
-	testutil.FatalIfErr(t, ta.PollLogPatterns())
+	ta.awakenPattern(1, 1)
+
 	testutil.FatalIfErr(t, ta.PollLogStreamsForCompletion())
 
 	glog.Info("write string")
 	testutil.WriteString(t, f, "\n")
-	ta.awaken(1)
+	ta.awakenStreams(1, 1)
 
 	ta.stop()
 
@@ -257,7 +262,7 @@ func TestTailExpireStaleHandles(t *testing.T) {
 	testutil.WriteString(t, f1, "1\n")
 	testutil.WriteString(t, f2, "2\n")
 
-	ta.awaken(1)
+	ta.awakenStreams(1, 1)
 
 	ta.stop()
 

--- a/internal/tailer/tail_unix_test.go
+++ b/internal/tailer/tail_unix_test.go
@@ -36,26 +36,26 @@ func TestTailerOpenRetries(t *testing.T) {
 	if err := ta.TailPath(logfile); err == nil || !os.IsPermission(err) {
 		t.Fatalf("Expected a permission denied error here: %s", err)
 	}
-	testutil.FatalIfErr(t, ta.PollLogStreamsForCompletion())
+	testutil.FatalIfErr(t, ta.RemoveCompletedLogstreams())
 	ta.awakenPattern(1, 1)
 	glog.Info("remove")
 	if err := os.Remove(logfile); err != nil {
 		t.Fatal(err)
 	}
-	testutil.FatalIfErr(t, ta.PollLogStreamsForCompletion())
+	testutil.FatalIfErr(t, ta.RemoveCompletedLogstreams())
 	ta.awakenPattern(1, 1)
 	glog.Info("openfile")
 	f, err := os.OpenFile(logfile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0)
 	//nolint:staticcheck // test code
 	defer f.Close()
 	testutil.FatalIfErr(t, err)
-	testutil.FatalIfErr(t, ta.PollLogStreamsForCompletion())
+	testutil.FatalIfErr(t, ta.RemoveCompletedLogstreams())
 	ta.awakenPattern(1, 1)
 	glog.Info("chmod")
 	if err := os.Chmod(logfile, 0o666); err != nil {
 		t.Fatal(err)
 	}
-	testutil.FatalIfErr(t, ta.PollLogStreamsForCompletion())
+	testutil.FatalIfErr(t, ta.RemoveCompletedLogstreams())
 	ta.awakenPattern(1, 1)
 	ta.awakenStreams(1, 1) // force sync to EOF
 	glog.Info("write string")

--- a/internal/tailer/tail_unix_test.go
+++ b/internal/tailer/tail_unix_test.go
@@ -17,8 +17,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// TestTailerOpenRetries is a unix-specific test because on Windows, it is not possible to create a file
-// that you yourself cannot read (minimum permissions are 0222).
+// TestTailerOpenRetries is a unix-specific test because on Windows, it is not
+// possible to create a file that you yourself cannot read; the minimum permissions
+// there are 0222.
 func TestTailerOpenRetries(t *testing.T) {
 	// Can't force a permission denied error if run as root.
 	testutil.SkipIfRoot(t)
@@ -35,31 +36,31 @@ func TestTailerOpenRetries(t *testing.T) {
 	if err := ta.TailPath(logfile); err == nil || !os.IsPermission(err) {
 		t.Fatalf("Expected a permission denied error here: %s", err)
 	}
-	testutil.FatalIfErr(t, ta.PollLogPatterns())
 	testutil.FatalIfErr(t, ta.PollLogStreamsForCompletion())
+	ta.awakenPattern(1, 1)
 	glog.Info("remove")
 	if err := os.Remove(logfile); err != nil {
 		t.Fatal(err)
 	}
-	testutil.FatalIfErr(t, ta.PollLogPatterns())
 	testutil.FatalIfErr(t, ta.PollLogStreamsForCompletion())
+	ta.awakenPattern(1, 1)
 	glog.Info("openfile")
 	f, err := os.OpenFile(logfile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0)
 	//nolint:staticcheck // test code
 	defer f.Close()
 	testutil.FatalIfErr(t, err)
-	testutil.FatalIfErr(t, ta.PollLogPatterns())
 	testutil.FatalIfErr(t, ta.PollLogStreamsForCompletion())
+	ta.awakenPattern(1, 1)
 	glog.Info("chmod")
 	if err := os.Chmod(logfile, 0o666); err != nil {
 		t.Fatal(err)
 	}
-	testutil.FatalIfErr(t, ta.PollLogPatterns())
 	testutil.FatalIfErr(t, ta.PollLogStreamsForCompletion())
-	ta.awaken(1) // force sync to EOF
+	ta.awakenPattern(1, 1)
+	ta.awakenStreams(1, 1) // force sync to EOF
 	glog.Info("write string")
 	testutil.WriteString(t, f, "\n")
-	ta.awaken(1)
+	ta.awakenStreams(1, 1)
 
 	ta.stop()
 
@@ -83,7 +84,6 @@ func TestAddStdin(t *testing.T) {
 	if err := ta.AddPattern("-"); err != nil {
 		t.Errorf("AddPattern(-) -> %v", err)
 	}
-	testutil.FatalIfErr(t, ta.PollLogPatterns())
 
 	ta.stop()
 

--- a/internal/waker/testwaker.go
+++ b/internal/waker/testwaker.go
@@ -53,7 +53,7 @@ func NewTest(ctx context.Context, wait int, name string) (Waker, WakeFunc) {
 	initDone := make(chan struct{})
 	go func() {
 		defer close(initDone)
-		glog.InfoDepthf(1, "TestWaker(%s) waiting for %d wakees to call Wake()", t.name, wait)
+		glog.Infof("TestWaker(%s) init waiting for %d wakees to call Wake()", t.name, wait)
 		for i := 0; i < wait; i++ {
 			<-t.wakeeDone
 		}
@@ -68,17 +68,17 @@ func NewTest(ctx context.Context, wait int, name string) (Waker, WakeFunc) {
 			t.waiting <- struct{}{}
 		}
 		// First wait for `t.n` wakees to have called `Wake`, synchronising them.
-		glog.Infof("TestWaker(%s) waiting for %d wakees to receive from the wake chan", t.name, wake)
+		glog.InfoDepthf(1, "TestWaker(%s) waiting for %d wakees to receive from the wake chan", t.name, wake)
 		for i := 0; i < wake; i++ {
 			<-t.wakeeReady
 		}
 		t.broadcastWakeAndReset()
 		// Now `awaken` blocks here, as we wait for them in turn to return to another call to Wake, in their polling loops.  We wait for only a count of `after` routines this time, as some may exit.
-		glog.Infof("TestWaker(%s) waiting for %d wakees to call Wake()", t.name, wait)
+		glog.InfoDepthf(1, "TestWaker(%s) waiting for %d wakees to call Wake()", t.name, wait)
 		for i := 0; i < wait; i++ {
 			<-t.wakeeDone
 		}
-		glog.Infof("TestWaker(%s): Wakees returned, yielding to TestWaker", t.name)
+		glog.InfoDepthf(1, "TestWaker(%s): Wakees returned, yielding to TestWaker", t.name)
 	}
 	return t, awaken
 }

--- a/internal/waker/testwaker.go
+++ b/internal/waker/testwaker.go
@@ -20,8 +20,6 @@ type testWaker struct {
 
 	ctx context.Context
 
-	n int
-
 	name string
 
 	wakeeReady chan struct{}

--- a/internal/waker/testwaker_test.go
+++ b/internal/waker/testwaker_test.go
@@ -21,7 +21,7 @@ func TestTestWakerWakes(t *testing.T) {
 		t.Errorf("<-w.Wake() == %v, expected nothing (should block)", x)
 	default:
 	}
-	awaken(0)
+	awaken(1, 0)
 	select {
 	case <-c:
 		// Luke Luck likes lakes.  Luke's duck likes lakes.
@@ -68,7 +68,7 @@ func TestTestWakerTwoWakees(t *testing.T) {
 		}
 	}()
 	wg1.Done()
-	awaken(0) // wake 2, and await none
+	awaken(2, 0) // wake 2, and await none
 	wg2.Done()
 	wg3.Wait()
 }
@@ -99,10 +99,10 @@ func TestTestWakerTwoWakeups(t *testing.T) {
 		defer wg.Done()
 		<-begin
 		<-s
-		awaken(1)
+		awaken(1, 1) // awaken 1, wait for 1
 		<-s
 		// we don't expect anyone to call Wake() after this
-		awaken(0)
+		awaken(1, 0)
 	}()
 	close(begin)
 	wg.Wait()

--- a/internal/waker/testwaker_test.go
+++ b/internal/waker/testwaker_test.go
@@ -14,7 +14,7 @@ import (
 func TestTestWakerWakes(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	w, awaken := waker.NewTest(ctx, 1)
+	w, awaken := waker.NewTest(ctx, 1, "test")
 	c := w.Wake()
 	select {
 	case x := <-c:
@@ -33,7 +33,7 @@ func TestTestWakerWakes(t *testing.T) {
 func TestTestWakerTwoWakees(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	w, awaken := waker.NewTest(ctx, 2)
+	w, awaken := waker.NewTest(ctx, 2, "test")
 	var wg1, wg2, wg3 sync.WaitGroup
 	wg1.Add(1)
 	wg2.Add(1)
@@ -76,7 +76,7 @@ func TestTestWakerTwoWakees(t *testing.T) {
 func TestTestWakerTwoWakeups(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	w, awaken := waker.NewTest(ctx, 1)
+	w, awaken := waker.NewTest(ctx, 1, "test")
 	s := make(chan struct{})
 	begin := make(chan struct{})
 	var wg sync.WaitGroup


### PR DESCRIPTION
With this change the tailer does a better job of tracking current and future work, shutting down when all streams are completed.  If there are no filesystem patterns to watch and all streams close, (e.g. stdin closes) then `mtail` will also stop.

This fixes a longstanding issue where `mtail` would remain running if `stdin` was the only log, and was closed.

Fixes: #331