### PR TITLE
ci: Run this workflow on tag push again.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,11 @@ on:
   # goreleaser is put into snapshot mode when not on a tag
   pull_request:
   merge_group:
-  # Run when a tag is created, i.e. after the tag-release workflow.
+  # Run when a tag is pushed.
+  push:
+    tags:
+      - v*
+  # Run when a ref is created, i.e. after the tag-release workflow.
   # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#create
   create:
 


### PR DESCRIPTION
GITHUB_TOKEN can't cause new workflows to run.  That's the core problem with `on: create:` in this case; the tag-new-release workflow doesn't issue the create event, because the github-actions credential isn't allowed to do so.