### PR TITLE
Reduce wait friction when reading from a pipe

### DIFF
--- a/internal/tailer/logstream/pipestream.go
+++ b/internal/tailer/logstream/pipestream.go
@@ -104,6 +104,12 @@ func (ps *pipeStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wake
 				ps.mu.Lock()
 				ps.lastReadTime = time.Now()
 				ps.mu.Unlock()
+
+				// No error implies there is more to read in this pipe so go
+				// straight back to read unless it looks like context is Done.
+				if err == nil && ctx.Err() == nil {
+					continue
+				}
 			}
 
 			// Test to see if we should exit.

--- a/internal/tailer/logstream/pipestream_unix_test.go
+++ b/internal/tailer/logstream/pipestream_unix_test.go
@@ -77,7 +77,7 @@ func TestPipeStreamReadCompletedBecauseCancel(t *testing.T) {
 
 		lines := make(chan *logline.LogLine, 1)
 		ctx, cancel := context.WithCancel(context.Background())
-		waker, awaken := waker.NewTest(ctx, 1, "stream")
+		waker, awaken := waker.NewTest(ctx, 0, "stream")
 
 		f, err := os.OpenFile(name, os.O_RDWR, os.ModeNamedPipe)
 		testutil.FatalIfErr(t, err)
@@ -160,7 +160,7 @@ func TestPipeStreamReadStdin(t *testing.T) {
 
 	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
-	waker, awaken := waker.NewTest(ctx, 1, "stream")
+	waker, awaken := waker.NewTest(ctx, 0, "stream")
 
 	ps, err := logstream.New(ctx, &wg, waker, "-", lines, logstream.OneShotDisabled)
 	testutil.FatalIfErr(t, err)


### PR DESCRIPTION
Uses logic similar to `fileStream` to circumvent waiting when there may be more to read immediately on a pipe.