### PR TITLE
fix: Use context cancellation instead of `Stop` to stop streams.

### DIFF
--- a/internal/tailer/logstream/dgramstream_unix_test.go
+++ b/internal/tailer/logstream/dgramstream_unix_test.go
@@ -43,7 +43,7 @@ func TestDgramStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 			waker, awaken := waker.NewTest(ctx, 1, "stream")
 
 			sockName := scheme + "://" + addr
-			ss, err := logstream.New(ctx, &wg, waker, sockName, lines, logstream.OneShotDisabled)
+			ss, err := logstream.New(ctx, &wg, waker, sockName, lines, logstream.OneShotEnabled)
 			testutil.FatalIfErr(t, err)
 
 			s, err := net.Dial(scheme, addr)
@@ -54,9 +54,7 @@ func TestDgramStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 
 			awaken(0, 0) // sync past read
 
-			ss.Stop()
-
-			// "Close" the socket by sending zero bytes, which after Stop tells the stream to act as if we're done.
+			// "Close" the socket by sending zero bytes, which in oneshot mode tells the stream to act as if we're done.
 			_, err = s.Write([]byte{})
 			testutil.FatalIfErr(t, err)
 

--- a/internal/tailer/logstream/dgramstream_unix_test.go
+++ b/internal/tailer/logstream/dgramstream_unix_test.go
@@ -65,7 +65,7 @@ func TestDgramStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 
 			received := testutil.LinesReceived(lines)
 			expected := []*logline.LogLine{
-				{context.TODO(), addr, "1"},
+				{Context: context.TODO(), Filename: addr, Line: "1"},
 			}
 			testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 
@@ -118,7 +118,7 @@ func TestDgramStreamReadCompletedBecauseCancel(t *testing.T) {
 
 			received := testutil.LinesReceived(lines)
 			expected := []*logline.LogLine{
-				{context.TODO(), addr, "1"},
+				{Context: context.TODO(), Filename: addr, Line: "1"},
 			}
 			testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 

--- a/internal/tailer/logstream/filestream_test.go
+++ b/internal/tailer/logstream/filestream_test.go
@@ -39,7 +39,7 @@ func TestFileStreamRead(t *testing.T) {
 	close(lines)
 	received := testutil.LinesReceived(lines)
 	expected := []*logline.LogLine{
-		{context.TODO(), name, "yo"},
+		{Context: context.TODO(), Filename: name, Line: "yo"},
 	}
 	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 
@@ -80,7 +80,7 @@ func TestFileStreamReadNonSingleByteEnd(t *testing.T) {
 	close(lines)
 	received := testutil.LinesReceived(lines)
 	expected := []*logline.LogLine{
-		{context.TODO(), name, s},
+		{Context: context.TODO(), Filename: name, Line: s},
 	}
 	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 
@@ -126,7 +126,7 @@ func TestStreamDoesntBreakOnCorruptRune(t *testing.T) {
 	close(lines)
 	received := testutil.LinesReceived(lines)
 	expected := []*logline.LogLine{
-		{context.TODO(), name, s[1:]},
+		{Context: context.TODO(), Filename: name, Line: s[1:]},
 	}
 	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 
@@ -174,9 +174,9 @@ func TestFileStreamTruncation(t *testing.T) {
 	received := testutil.LinesReceived(lines)
 
 	expected := []*logline.LogLine{
-		{context.TODO(), name, "1"},
-		{context.TODO(), name, "2"},
-		{context.TODO(), name, "3"},
+		{Context: context.TODO(), Filename: name, Line: "1"},
+		{Context: context.TODO(), Filename: name, Line: "2"},
+		{Context: context.TODO(), Filename: name, Line: "3"},
 	}
 	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 
@@ -210,7 +210,7 @@ func TestFileStreamFinishedBecauseCancel(t *testing.T) {
 
 	received := testutil.LinesReceived(lines)
 	expected := []*logline.LogLine{
-		{context.TODO(), name, "yo"},
+		{Context: context.TODO(), Filename: name, Line: "yo"},
 	}
 	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 
@@ -251,7 +251,7 @@ func TestFileStreamPartialRead(t *testing.T) {
 	close(lines)
 	received := testutil.LinesReceived(lines)
 	expected := []*logline.LogLine{
-		{context.TODO(), name, "yo"},
+		{Context: context.TODO(), Filename: name, Line: "yo"},
 	}
 	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 

--- a/internal/tailer/logstream/filestream_test.go
+++ b/internal/tailer/logstream/filestream_test.go
@@ -27,7 +27,7 @@ func TestFileStreamRead(t *testing.T) {
 	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
-	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
+	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotDisabled)
 	testutil.FatalIfErr(t, err)
 	awaken(1, 1)
 
@@ -62,7 +62,7 @@ func TestFileStreamReadNonSingleByteEnd(t *testing.T) {
 	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
-	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
+	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotDisabled)
 	testutil.FatalIfErr(t, err)
 	awaken(1, 1)
 
@@ -103,7 +103,7 @@ func TestStreamDoesntBreakOnCorruptRune(t *testing.T) {
 	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
-	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
+	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotDisabled)
 	testutil.FatalIfErr(t, err)
 	awaken(1, 1)
 
@@ -149,7 +149,7 @@ func TestFileStreamTruncation(t *testing.T) {
 	lines := make(chan *logline.LogLine, 3)
 	ctx, cancel := context.WithCancel(context.Background())
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
-	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
+	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotDisabled)
 	// fs.Stop() is also called explicitly further down but a failed test
 	// and early return would lead to the handle staying open
 	defer fs.Stop()
@@ -197,7 +197,7 @@ func TestFileStreamFinishedBecauseCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
 
-	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
+	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotDisabled)
 	testutil.FatalIfErr(t, err)
 	awaken(1, 1) // Synchronise past first read after seekToEnd
 
@@ -232,7 +232,7 @@ func TestFileStreamPartialRead(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
 
-	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
+	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotDisabled)
 	testutil.FatalIfErr(t, err)
 	awaken(1, 1)
 

--- a/internal/tailer/logstream/filestream_unix_test.go
+++ b/internal/tailer/logstream/filestream_unix_test.go
@@ -37,7 +37,8 @@ func TestFileStreamRotation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
 
-	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
+	// OneShotDisabled because we hit EOF and need to wait.
+	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotDisabled)
 	// fs.Stop() is also called explicitly further down but a failed test
 	// and early return would lead to the handle staying open
 	defer fs.Stop()
@@ -88,7 +89,7 @@ func TestFileStreamURL(t *testing.T) {
 	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
-	fs, err := logstream.New(ctx, &wg, waker, "file://"+name, lines, logstream.OneShotEnabled)
+	fs, err := logstream.New(ctx, &wg, waker, "file://"+name, lines, logstream.OneShotDisabled)
 	testutil.FatalIfErr(t, err)
 	awaken(1, 1)
 

--- a/internal/tailer/logstream/filestream_unix_test.go
+++ b/internal/tailer/logstream/filestream_unix_test.go
@@ -39,12 +39,9 @@ func TestFileStreamRotation(t *testing.T) {
 
 	// OneShotDisabled because we hit EOF and need to wait.
 	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotDisabled)
-	// fs.Stop() is also called explicitly further down but a failed test
-	// and early return would lead to the handle staying open
-	defer fs.Stop()
 
 	testutil.FatalIfErr(t, err)
-	awaken(1, 1)
+	awaken(1, 1) // sync to eof
 
 	glog.Info("write 1")
 	testutil.WriteString(t, f, "1\n")
@@ -62,19 +59,20 @@ func TestFileStreamRotation(t *testing.T) {
 	testutil.WriteString(t, f, "2\n")
 	awaken(1, 1)
 
-	fs.Stop()
+	cancel()
 	wg.Wait()
-	close(lines)
 
+	close(lines)
 	received := testutil.LinesReceived(lines)
 	expected := []*logline.LogLine{
-		{context.TODO(), name, "1"},
-		{context.TODO(), name, "2"},
+		{Context: context.TODO(), Filename: name, Line: "1"},
+		{Context: context.TODO(), Filename: name, Line: "2"},
 	}
 	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 
-	cancel()
-	wg.Wait()
+	if !fs.IsComplete() {
+		t.Errorf("expecting filestream to be complete because stopped")
+	}
 }
 
 func TestFileStreamURL(t *testing.T) {
@@ -96,20 +94,19 @@ func TestFileStreamURL(t *testing.T) {
 	testutil.WriteString(t, f, "yo\n")
 	awaken(1, 1)
 
-	fs.Stop()
+	cancel()
 	wg.Wait()
+
 	close(lines)
 	received := testutil.LinesReceived(lines)
 	expected := []*logline.LogLine{
-		{context.TODO(), name, "yo"},
+		{Context: context.TODO(), Filename: name, Line: "yo"},
 	}
 	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 
 	if !fs.IsComplete() {
 		t.Errorf("expecting filestream to be complete because stopped")
 	}
-	cancel()
-	wg.Wait()
 }
 
 // TestFileStreamOpenFailure is a unix-specific test because on Windows, it is not possible to create a file

--- a/internal/tailer/logstream/logstream.go
+++ b/internal/tailer/logstream/logstream.go
@@ -80,13 +80,13 @@ func New(ctx context.Context, wg *sync.WaitGroup, waker waker.Waker, pathname st
 	default:
 		glog.V(2).Infof("%v: %q in path pattern %q, treating as path", ErrUnsupportedURLScheme, u.Scheme, pathname)
 	case "unixgram":
-		return newDgramStream(ctx, wg, waker, u.Scheme, u.Path, lines)
+		return newDgramStream(ctx, wg, waker, u.Scheme, u.Path, lines, oneShot)
 	case "unix":
 		return newSocketStream(ctx, wg, waker, u.Scheme, u.Path, lines, oneShot)
 	case "tcp":
 		return newSocketStream(ctx, wg, waker, u.Scheme, u.Host, lines, oneShot)
 	case "udp":
-		return newDgramStream(ctx, wg, waker, u.Scheme, u.Host, lines)
+		return newDgramStream(ctx, wg, waker, u.Scheme, u.Host, lines, oneShot)
 	case "", "file":
 		path = u.Path
 	}

--- a/internal/tailer/logstream/socketstream_unix_test.go
+++ b/internal/tailer/logstream/socketstream_unix_test.go
@@ -70,7 +70,6 @@ func TestSocketStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 			}
 
 			cancel() // stop after connection closes
-
 		}))
 	}
 }

--- a/internal/tailer/logstream/socketstream_unix_test.go
+++ b/internal/tailer/logstream/socketstream_unix_test.go
@@ -41,7 +41,7 @@ func TestSocketStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 			waker, awaken := waker.NewTest(ctx, 1, "stream")
 
 			sockName := scheme + "://" + addr
-			ss, err := logstream.New(ctx, &wg, waker, sockName, lines, logstream.OneShotDisabled)
+			ss, err := logstream.New(ctx, &wg, waker, sockName, lines, logstream.OneShotEnabled)
 			testutil.FatalIfErr(t, err)
 
 			s, err := net.Dial(scheme, addr)
@@ -55,9 +55,8 @@ func TestSocketStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 			// Close the socket to signal to the socketStream to shut down.
 			testutil.FatalIfErr(t, s.Close())
 
-			ss.Stop() // stop after connection closes
-
 			wg.Wait()
+
 			close(lines)
 
 			received := testutil.LinesReceived(lines)
@@ -66,11 +65,12 @@ func TestSocketStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 			}
 			testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 
-			cancel()
-
 			if !ss.IsComplete() {
 				t.Errorf("expecting socketstream to be complete because socket closed")
 			}
+
+			cancel() // stop after connection closes
+
 		}))
 	}
 }
@@ -108,8 +108,8 @@ func TestSocketStreamReadCompletedBecauseCancel(t *testing.T) {
 			awaken(0, 0) // Sync past read to ensure we read
 
 			cancel() // This cancellation should cause the stream to shut down immediately.
-
 			wg.Wait()
+
 			close(lines)
 
 			received := testutil.LinesReceived(lines)

--- a/internal/tailer/logstream/socketstream_unix_test.go
+++ b/internal/tailer/logstream/socketstream_unix_test.go
@@ -62,7 +62,7 @@ func TestSocketStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 
 			received := testutil.LinesReceived(lines)
 			expected := []*logline.LogLine{
-				{context.TODO(), addr, "1"},
+				{Context: context.TODO(), Filename: addr, Line: "1"},
 			}
 			testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 
@@ -114,7 +114,7 @@ func TestSocketStreamReadCompletedBecauseCancel(t *testing.T) {
 
 			received := testutil.LinesReceived(lines)
 			expected := []*logline.LogLine{
-				{context.TODO(), addr, "1"},
+				{Context: context.TODO(), Filename: addr, Line: "1"},
 			}
 			testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
 

--- a/internal/tailer/tail.go
+++ b/internal/tailer/tail.go
@@ -287,10 +287,6 @@ func (t *Tailer) TailPath(pathname string) error {
 	if err != nil {
 		return err
 	}
-	if t.oneShot {
-		glog.V(2).Infof("Starting oneshot read at startup of %q", pathname)
-		l.Stop()
-	}
 	t.logstreams[pathname] = l
 	glog.Infof("Tailing %s", pathname)
 	logCount.Add(1)


### PR DESCRIPTION
This improves the interface for stream shutdown, though we can't remove `Stop` completely yet.

Also fixes `oneShot` handling in various streams.

Issue: #199