### PR TITLE
fix: Give a full path in Dockerfile ENTRYPOINT

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,5 +1,5 @@
 FROM scratch
-COPY mtail mtail
-ENTRYPOINT ["mtail"]
+COPY mtail /mtail
+ENTRYPOINT ["/mtail"]
 EXPOSE 3903
 WORKDIR /tmp


### PR DESCRIPTION
Container runtimes can't find their entrypoint because the search path?

Issue: #880