### PR TITLE
fix: LogStreams create and close their own lines channels.

### DIFF
--- a/internal/tailer/logstream/dgramstream.go
+++ b/internal/tailer/logstream/dgramstream.go
@@ -18,7 +18,7 @@ import (
 type dgramStream struct {
 	cancel context.CancelFunc
 
-	lines chan<- *logline.LogLine
+	lines chan *logline.LogLine
 
 	scheme  string // Datagram scheme, either "unixgram" or "udp".
 	address string // Given name for the underlying socket path on the filesystem or hostport.
@@ -28,34 +28,34 @@ type dgramStream struct {
 	lastReadTime time.Time    // Last time a log line was read from this named pipe
 }
 
-func newDgramStream(ctx context.Context, wg *sync.WaitGroup, waker waker.Waker, scheme, address string, lines chan<- *logline.LogLine, oneShot OneShotMode) (LogStream, error) {
+func newDgramStream(ctx context.Context, wg *sync.WaitGroup, waker waker.Waker, scheme, address string, oneShot OneShotMode) (LogStream, error) {
 	if address == "" {
 		return nil, ErrEmptySocketAddress
 	}
 	ctx, cancel := context.WithCancel(ctx)
-	ss := &dgramStream{cancel: cancel, scheme: scheme, address: address, lastReadTime: time.Now(), lines: lines}
+	ss := &dgramStream{cancel: cancel, scheme: scheme, address: address, lastReadTime: time.Now(), lines: make(chan *logline.LogLine)}
 	if err := ss.stream(ctx, wg, waker, oneShot); err != nil {
 		return nil, err
 	}
 	return ss, nil
 }
 
-func (ss *dgramStream) LastReadTime() time.Time {
-	ss.mu.RLock()
-	defer ss.mu.RUnlock()
-	return ss.lastReadTime
+func (ds *dgramStream) LastReadTime() time.Time {
+	ds.mu.RLock()
+	defer ds.mu.RUnlock()
+	return ds.lastReadTime
 }
 
 // The read buffer size for datagrams.
 const datagramReadBufferSize = 131072
 
-func (ss *dgramStream) stream(ctx context.Context, wg *sync.WaitGroup, waker waker.Waker, oneShot OneShotMode) error {
-	c, err := net.ListenPacket(ss.scheme, ss.address)
+func (ds *dgramStream) stream(ctx context.Context, wg *sync.WaitGroup, waker waker.Waker, oneShot OneShotMode) error {
+	c, err := net.ListenPacket(ds.scheme, ds.address)
 	if err != nil {
-		logErrors.Add(ss.address, 1)
+		logErrors.Add(ds.address, 1)
 		return err
 	}
-	glog.V(2).Infof("stream(%s:%s): opened new datagram socket %v", ss.scheme, ss.address, c)
+	glog.V(2).Infof("stream(%s:%s): opened new datagram socket %v", ds.scheme, ds.address, c)
 	b := make([]byte, datagramReadBufferSize)
 	partial := bytes.NewBufferString("")
 	var total int
@@ -63,18 +63,19 @@ func (ss *dgramStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wak
 	go func() {
 		defer wg.Done()
 		defer func() {
-			glog.V(2).Infof("stream(%s:%s): read total %d bytes", ss.scheme, ss.address, total)
-			glog.V(2).Infof("stream(%s:%s): closing connection", ss.scheme, ss.address)
+			glog.V(2).Infof("stream(%s:%s): read total %d bytes", ds.scheme, ds.address, total)
+			glog.V(2).Infof("stream(%s:%s): closing connection", ds.scheme, ds.address)
 			err := c.Close()
 			if err != nil {
-				logErrors.Add(ss.address, 1)
+				logErrors.Add(ds.address, 1)
 				glog.Info(err)
 			}
-			logCloses.Add(ss.address, 1)
-			ss.mu.Lock()
-			ss.completed = true
-			ss.mu.Unlock()
-			ss.Stop()
+			logCloses.Add(ds.address, 1)
+			ds.mu.Lock()
+			ds.completed = true
+			close(ds.lines)
+			ds.mu.Unlock()
+			ds.Stop()
 		}()
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
@@ -82,24 +83,24 @@ func (ss *dgramStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wak
 
 		for {
 			n, _, err := c.ReadFrom(b)
-			glog.V(2).Infof("stream(%s:%s): read %d bytes, err is %v", ss.scheme, ss.address, n, err)
+			glog.V(2).Infof("stream(%s:%s): read %d bytes, err is %v", ds.scheme, ds.address, n, err)
 
 			// This is a test-only trick that says if we've already put this
 			// logstream in graceful shutdown, then a zero-byte read is
 			// equivalent to an "EOF" in connection and file oriented streams.
 			if n == 0 {
 				if oneShot {
-					glog.V(2).Infof("stream(%s:%s): exiting because zero byte read and one shot", ss.scheme, ss.address)
+					glog.V(2).Infof("stream(%s:%s): exiting because zero byte read and one shot", ds.scheme, ds.address)
 					if partial.Len() > 0 {
-						sendLine(ctx, ss.address, partial, ss.lines)
+						sendLine(ctx, ds.address, partial, ds.lines)
 					}
 					return
 				}
 				select {
 				case <-ctx.Done():
-					glog.V(2).Infof("stream(%s:%s): exiting because zero byte read after cancellation", ss.scheme, ss.address)
+					glog.V(2).Infof("stream(%s:%s): exiting because zero byte read after cancellation", ds.scheme, ds.address)
 					if partial.Len() > 0 {
-						sendLine(ctx, ss.address, partial, ss.lines)
+						sendLine(ctx, ds.address, partial, ds.lines)
 					}
 					return
 				default:
@@ -109,22 +110,22 @@ func (ss *dgramStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wak
 			if n > 0 {
 				total += n
 				//nolint:contextcheck
-				decodeAndSend(ctx, ss.lines, ss.address, n, b[:n], partial)
-				ss.mu.Lock()
-				ss.lastReadTime = time.Now()
-				ss.mu.Unlock()
+				decodeAndSend(ctx, ds.lines, ds.address, n, b[:n], partial)
+				ds.mu.Lock()
+				ds.lastReadTime = time.Now()
+				ds.mu.Unlock()
 			}
 
 			if err != nil && IsEndOrCancel(err) {
 				if partial.Len() > 0 {
-					sendLine(ctx, ss.address, partial, ss.lines)
+					sendLine(ctx, ds.address, partial, ds.lines)
 				}
-				glog.V(2).Infof("stream(%s:%s): exiting, stream has error %s", ss.scheme, ss.address, err)
+				glog.V(2).Infof("stream(%s:%s): exiting, stream has error %s", ds.scheme, ds.address, err)
 				return
 			}
 
 			// Yield and wait
-			glog.V(2).Infof("stream(%s:%s): waiting", ss.scheme, ss.address)
+			glog.V(2).Infof("stream(%s:%s): waiting", ds.scheme, ds.address)
 			select {
 			case <-ctx.Done():
 				// We may have started waiting here when the stop signal
@@ -132,23 +133,28 @@ func (ss *dgramStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wak
 				// written to.  The file is not technically yet at EOF so
 				// we need to go back and try one more read.  We'll exit
 				// the stream in the zero byte handler above.
-				glog.V(2).Infof("stream(%s:%s): Stopping after next zero byte read", ss.scheme, ss.address)
+				glog.V(2).Infof("stream(%s:%s): Stopping after next zero byte read", ds.scheme, ds.address)
 			case <-waker.Wake():
 				// sleep until next Wake()
-				glog.V(2).Infof("stream(%s:%s): Wake received", ss.scheme, ss.address)
+				glog.V(2).Infof("stream(%s:%s): Wake received", ds.scheme, ds.address)
 			}
 		}
 	}()
 	return nil
 }
 
-func (ss *dgramStream) IsComplete() bool {
-	ss.mu.RLock()
-	defer ss.mu.RUnlock()
-	return ss.completed
+func (ds *dgramStream) IsComplete() bool {
+	ds.mu.RLock()
+	defer ds.mu.RUnlock()
+	return ds.completed
 }
 
-func (ss *dgramStream) Stop() {
-	glog.V(2).Infof("stream(%s:%s): Stop received on datagram stream.", ss.scheme, ss.address)
-	ss.cancel()
+func (ds *dgramStream) Stop() {
+	glog.V(2).Infof("stream(%s:%s): Stop received on datagram stream.", ds.scheme, ds.address)
+	ds.cancel()
+}
+
+// Lines implements the LogStream interface, returning the output lines channel.
+func (ds *dgramStream) Lines() <-chan *logline.LogLine {
+	return ds.lines
 }

--- a/internal/tailer/logstream/filestream_test.go
+++ b/internal/tailer/logstream/filestream_test.go
@@ -24,11 +24,16 @@ func TestFileStreamRead(t *testing.T) {
 	f := testutil.TestOpenFile(t, name)
 	defer f.Close()
 
-	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
-	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotDisabled)
+	fs, err := logstream.New(ctx, &wg, waker, name, logstream.OneShotDisabled)
 	testutil.FatalIfErr(t, err)
+
+	expected := []*logline.LogLine{
+		{Context: context.TODO(), Filename: name, Line: "yo"},
+	}
+	checkLineDiff := testutil.ExpectLinesReceivedNoDiff(t, expected, fs.Lines())
+
 	awaken(1, 1) // synchronise past first read
 
 	testutil.WriteString(t, f, "yo\n")
@@ -36,12 +41,8 @@ func TestFileStreamRead(t *testing.T) {
 
 	cancel()
 	wg.Wait()
-	close(lines)
-	received := testutil.LinesReceived(lines)
-	expected := []*logline.LogLine{
-		{Context: context.TODO(), Filename: name, Line: "yo"},
-	}
-	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
+
+	checkLineDiff()
 
 	if !fs.IsComplete() {
 		t.Errorf("expecting filestream to be complete because stopped")
@@ -58,19 +59,20 @@ func TestFileStreamReadOneShot(t *testing.T) {
 	defer f.Close()
 	testutil.WriteString(t, f, "yo\n")
 
-	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	waker := waker.NewTestAlways()
-	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotEnabled)
+
+	fs, err := logstream.New(ctx, &wg, waker, name, logstream.OneShotEnabled)
 	testutil.FatalIfErr(t, err)
 
-	wg.Wait()
-	close(lines)
-	received := testutil.LinesReceived(lines)
 	expected := []*logline.LogLine{
 		{Context: context.TODO(), Filename: name, Line: "yo"},
 	}
-	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
+	checkLineDiff := testutil.ExpectLinesReceivedNoDiff(t, expected, fs.Lines())
+
+	wg.Wait()
+
+	checkLineDiff()
 
 	if !fs.IsComplete() {
 		t.Errorf("expecting filestream to be complete because stopped")
@@ -88,30 +90,31 @@ func TestFileStreamReadNonSingleByteEnd(t *testing.T) {
 	f := testutil.TestOpenFile(t, name)
 	defer f.Close()
 
-	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
-	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotDisabled)
+	fs, err := logstream.New(ctx, &wg, waker, name, logstream.OneShotDisabled)
 	testutil.FatalIfErr(t, err)
-	awaken(1, 1)
 
 	s := "a"
 	for i := 0; i < 4094; i++ {
 		s += "a"
 	}
-
 	s += "中"
+
+	expected := []*logline.LogLine{
+		{Context: context.TODO(), Filename: name, Line: s},
+	}
+	checkLineDiff := testutil.ExpectLinesReceivedNoDiff(t, expected, fs.Lines())
+
+	awaken(1, 1)
+
 	testutil.WriteString(t, f, s+"\n")
 	awaken(1, 1)
 
 	fs.Stop()
 	wg.Wait()
-	close(lines)
-	received := testutil.LinesReceived(lines)
-	expected := []*logline.LogLine{
-		{Context: context.TODO(), Filename: name, Line: s},
-	}
-	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
+
+	checkLineDiff()
 
 	if !fs.IsComplete() {
 		t.Errorf("expecting filestream to be complete because stopped")
@@ -129,12 +132,11 @@ func TestStreamDoesntBreakOnCorruptRune(t *testing.T) {
 	f := testutil.TestOpenFile(t, name)
 	defer f.Close()
 
-	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
-	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotDisabled)
+
+	fs, err := logstream.New(ctx, &wg, waker, name, logstream.OneShotDisabled)
 	testutil.FatalIfErr(t, err)
-	awaken(1, 1)
 
 	s := string([]byte{0xF1})
 	// 0xF1 = 11110001 , a byte signaling the start of a unicode character that
@@ -146,18 +148,20 @@ func TestStreamDoesntBreakOnCorruptRune(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		s += "a"
 	}
+	expected := []*logline.LogLine{
+		{Context: context.TODO(), Filename: name, Line: s[1:]},
+	}
+	checkLineDiff := testutil.ExpectLinesReceivedNoDiff(t, expected, fs.Lines())
+
+	awaken(1, 1)
 
 	testutil.WriteString(t, f, s+"\n")
 	awaken(1, 1)
 
 	fs.Stop()
 	wg.Wait()
-	close(lines)
-	received := testutil.LinesReceived(lines)
-	expected := []*logline.LogLine{
-		{Context: context.TODO(), Filename: name, Line: s[1:]},
-	}
-	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
+
+	checkLineDiff()
 
 	if !fs.IsComplete() {
 		t.Errorf("expecting filestream to be complete because stopped")
@@ -175,15 +179,21 @@ func TestFileStreamTruncation(t *testing.T) {
 	f := testutil.OpenLogFile(t, name)
 	defer f.Close()
 
-	lines := make(chan *logline.LogLine, 3)
 	ctx, cancel := context.WithCancel(context.Background())
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
-	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotDisabled)
+	fs, err := logstream.New(ctx, &wg, waker, name, logstream.OneShotDisabled)
 	// fs.Stop() is also called explicitly further down but a failed test
 	// and early return would lead to the handle staying open
 	defer fs.Stop()
-
 	testutil.FatalIfErr(t, err)
+
+	expected := []*logline.LogLine{
+		{Context: context.TODO(), Filename: name, Line: "1"},
+		{Context: context.TODO(), Filename: name, Line: "2"},
+		{Context: context.TODO(), Filename: name, Line: "3"},
+	}
+	checkLineDiff := testutil.ExpectLinesReceivedNoDiff(t, expected, fs.Lines())
+
 	awaken(1, 1) // Synchronise past first read after seekToEnd
 
 	testutil.WriteString(t, f, "1\n2\n")
@@ -198,16 +208,8 @@ func TestFileStreamTruncation(t *testing.T) {
 
 	fs.Stop()
 	wg.Wait()
-	close(lines)
 
-	received := testutil.LinesReceived(lines)
-
-	expected := []*logline.LogLine{
-		{Context: context.TODO(), Filename: name, Line: "1"},
-		{Context: context.TODO(), Filename: name, Line: "2"},
-		{Context: context.TODO(), Filename: name, Line: "3"},
-	}
-	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
+	checkLineDiff()
 
 	cancel()
 	wg.Wait()
@@ -222,12 +224,17 @@ func TestFileStreamPartialRead(t *testing.T) {
 	f := testutil.TestOpenFile(t, name)
 	defer f.Close()
 
-	lines := make(chan *logline.LogLine, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
 
-	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotDisabled)
+	fs, err := logstream.New(ctx, &wg, waker, name, logstream.OneShotDisabled)
 	testutil.FatalIfErr(t, err)
+
+	expected := []*logline.LogLine{
+		{Context: context.TODO(), Filename: name, Line: "yo"},
+	}
+	checkLineDiff := testutil.ExpectLinesReceivedNoDiff(t, expected, fs.Lines())
+
 	awaken(1, 1)
 
 	testutil.WriteString(t, f, "yo")
@@ -239,12 +246,7 @@ func TestFileStreamPartialRead(t *testing.T) {
 	cancel()
 	wg.Wait()
 
-	close(lines)
-	received := testutil.LinesReceived(lines)
-	expected := []*logline.LogLine{
-		{Context: context.TODO(), Filename: name, Line: "yo"},
-	}
-	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
+	checkLineDiff()
 
 	if !fs.IsComplete() {
 		t.Errorf("expecting filestream to be complete because cancellation")
@@ -261,11 +263,17 @@ func TestFileStreamReadToEOFOnCancel(t *testing.T) {
 	f := testutil.TestOpenFile(t, name)
 	defer f.Close()
 
-	lines := make(chan *logline.LogLine, 2)
 	waker, awaken := waker.NewTest(ctx, 1, "stream")
 
-	fs, err := logstream.New(ctx, &wg, waker, name, lines, logstream.OneShotDisabled)
+	fs, err := logstream.New(ctx, &wg, waker, name, logstream.OneShotDisabled)
 	testutil.FatalIfErr(t, err)
+
+	expected := []*logline.LogLine{
+		{Context: context.TODO(), Filename: name, Line: "line 1"},
+		{Context: context.TODO(), Filename: name, Line: "line 2"},
+	}
+	checkLineDiff := testutil.ExpectLinesReceivedNoDiff(t, expected, fs.Lines())
+
 	awaken(1, 1)
 
 	testutil.WriteString(t, f, "line 1\n")
@@ -276,13 +284,7 @@ func TestFileStreamReadToEOFOnCancel(t *testing.T) {
 
 	wg.Wait()
 
-	close(lines) // Signal it's time to go.
-	received := testutil.LinesReceived(lines)
-	expected := []*logline.LogLine{
-		{Context: context.TODO(), Filename: name, Line: "line 1"},
-		{Context: context.TODO(), Filename: name, Line: "line 2"},
-	}
-	testutil.ExpectNoDiff(t, expected, received, testutil.IgnoreFields(logline.LogLine{}, "Context"))
+	checkLineDiff()
 
 	if !fs.IsComplete() {
 		t.Errorf("expecting filestream to be complete because cancellation")

--- a/internal/tailer/logstream/logstream_test.go
+++ b/internal/tailer/logstream/logstream_test.go
@@ -10,12 +10,12 @@ import (
 
 func TestNewErrors(t *testing.T) {
 	ctx := context.Background()
-	_, err := logstream.New(ctx, nil, nil, "", nil, logstream.OneShotDisabled)
+	_, err := logstream.New(ctx, nil, nil, "", logstream.OneShotDisabled)
 	if err == nil {
 		t.Errorf("New(ctx, nil) expecting error, received nil")
 	}
 	var wg sync.WaitGroup
-	_, err = logstream.New(ctx, &wg, nil, ":a/b", nil, logstream.OneShotDisabled)
+	_, err = logstream.New(ctx, &wg, nil, ":a/b", logstream.OneShotDisabled)
 	if err == nil {
 		t.Error("New(ctg, wg, ..., path) expecting error, received nil")
 	}

--- a/internal/tailer/logstream/logstream_unix_test.go
+++ b/internal/tailer/logstream/logstream_unix_test.go
@@ -24,7 +24,7 @@ func TestReadStdin(t *testing.T) {
 	testutil.FatalIfErr(t, err)
 	testutil.OverrideStdin(t, f)
 
-	_, err = logstream.New(ctx, &wg, nil, "-", nil, logstream.OneShotDisabled)
+	_, err = logstream.New(ctx, &wg, nil, "-", logstream.OneShotDisabled)
 	if err != nil {
 		t.Errorf("New(.., '-') -> %v, expecting nil", err)
 	}


### PR DESCRIPTION
This makes it easier to observe logstream state externally because we can read
the lines channel until it closes.

The tests are changed slightly to asynchronously drain the output channel at
the start of the stream.

Fix some naming issues and log formatting.