### PR TITLE
Fix: Use channel semantics to manage `LogStream` lifecycle in `Tailer`.

### DIFF
--- a/cmd/mtail/main.go
+++ b/cmd/mtail/main.go
@@ -65,7 +65,6 @@ var (
 	pollInterval                = flag.Duration("poll_interval", 250*time.Millisecond, "Set the interval to poll each log file for data; must be positive, or zero to disable polling.  With polling mode, only the files found at mtail startup will be polled.")
 	pollLogInterval             = flag.Duration("poll_log_interval", 250*time.Millisecond, "Set the interval to find all matched log files for polling; must be positive, or zero to disable polling.  With polling mode, only the files found at mtail startup will be polled.")
 	expiredMetricGcTickInterval = flag.Duration("expired_metrics_gc_interval", time.Hour, "interval between expired metric garbage collection runs")
-	staleLogGcTickInterval      = flag.Duration("stale_log_gc_interval", time.Hour, "interval between stale log garbage collection runs")
 	metricPushInterval          = flag.Duration("metric_push_interval", time.Minute, "interval between metric pushes to passive collectors")
 	maxRegexpLength             = flag.Int("max_regexp_length", 1024, "The maximum length a mtail regexp expression can have. Excessively long patterns are likely to cause compilation and runtime performance problems.")
 	maxRecursionDepth           = flag.Int("max_recursion_depth", 100, "The maximum length a mtail statement can be, as measured by parsed tokens. Excessively long mtail expressions are likely to cause compilation and runtime performance problems.")
@@ -83,6 +82,7 @@ var (
 	// Deprecated.
 	_ = flag.Bool("disable_fsnotify", true, "DEPRECATED: this flag is no longer in use.")
 	_ = flag.Int("metric_push_interval_seconds", 0, "DEPRECATED: use --metric_push_interval instead")
+	_ = flag.Duration("stale_log_gc_interval", time.Hour, "DEPRECATED: this flag is no longer in use")
 )
 
 func init() {
@@ -179,10 +179,6 @@ func main() {
 	eOpts := []exporter.Option{}
 	if *logRuntimeErrors {
 		opts = append(opts, mtail.LogRuntimeErrors)
-	}
-	if *staleLogGcTickInterval > 0 {
-		staleLogGcWaker := waker.NewTimed(ctx, *staleLogGcTickInterval)
-		opts = append(opts, mtail.GcWaker(staleLogGcWaker))
 	}
 	if *pollInterval > 0 {
 		logStreamPollWaker := waker.NewTimed(ctx, *pollInterval)

--- a/internal/mtail/log_deletion_integration_unix_test.go
+++ b/internal/mtail/log_deletion_integration_unix_test.go
@@ -39,6 +39,5 @@ func TestLogDeletion(t *testing.T) {
 
 	m.AwakenLogStreams(1, 0) // run stream to observe it's missing
 	logCloseCheck()
-	m.AwakenGcPoller(1, 1)
 	logCountCheck()
 }

--- a/internal/mtail/log_glob_integration_test.go
+++ b/internal/mtail/log_glob_integration_test.go
@@ -46,7 +46,7 @@ func TestGlobBeforeStart(t *testing.T) {
 		log.Close()
 	}
 	m, stopM := mtail.TestStartServer(t, 0, 0, mtail.LogPathPatterns(filepath.Join(workdir, "log*")))
-	stopM()
+	defer stopM()
 
 	if r := m.GetExpvar("log_count"); r.(*expvar.Int).Value() != count {
 		t.Errorf("Expecting log count of %d, received %d", count, r)
@@ -142,8 +142,7 @@ func TestGlobIgnoreFolder(t *testing.T) {
 	}
 
 	m, stopM := mtail.TestStartServer(t, 0, 0, mtail.LogPathPatterns(filepath.Join(workdir, "log*")), mtail.IgnoreRegexPattern("\\.gz"))
-
-	stopM()
+	defer stopM()
 
 	if r := m.GetExpvar("log_count"); r.(*expvar.Int).Value() != count {
 		t.Errorf("Expecting log count of %d, received %v", count, r)
@@ -184,8 +183,7 @@ func TestFilenameRegexIgnore(t *testing.T) {
 	}
 
 	m, stopM := mtail.TestStartServer(t, 0, 0, mtail.LogPathPatterns(filepath.Join(workdir, "log*")), mtail.IgnoreRegexPattern("\\.gz"))
-
-	stopM()
+	defer stopM()
 
 	if r := m.GetExpvar("log_count"); r.(*expvar.Int).Value() != count {
 		t.Errorf("Log count not matching, expected: %d received: %v", count, r)

--- a/internal/mtail/log_rotation_integration_test.go
+++ b/internal/mtail/log_rotation_integration_test.go
@@ -54,7 +54,6 @@ func TestLogRotationBySoftLinkChange(t *testing.T) {
 			defer trueLog2.Close()
 			m.AwakenPatternPollers(1, 1)
 			m.AwakenLogStreams(1, 1)
-			m.AwakenGcPoller(1, 1)
 			logClosedCheck := m.ExpectMapExpvarDeltaWithDeadline("log_closes_total", logFilepath, 1)
 			logCompletedCheck := m.ExpectExpvarDeltaWithDeadline("log_count", -1)
 			testutil.FatalIfErr(t, os.Remove(logFilepath))
@@ -63,8 +62,7 @@ func TestLogRotationBySoftLinkChange(t *testing.T) {
 				// existing stream.
 				m.AwakenPatternPollers(1, 1) // simulate race condition with this poll.
 				m.AwakenLogStreams(1, 0)
-				logClosedCheck() // barrier until filestream closes fd
-				m.AwakenGcPoller(1, 1)
+				logClosedCheck()    // barrier until filestream closes fd
 				logCompletedCheck() // barrier until the logstream is removed from tailer
 			}
 			testutil.FatalIfErr(t, os.Symlink(logFilepath+".true2", logFilepath))

--- a/internal/mtail/log_rotation_integration_unix_test.go
+++ b/internal/mtail/log_rotation_integration_unix_test.go
@@ -68,8 +68,7 @@ func TestLogRotationByRename(t *testing.T) {
 				// existing stream.
 				m.AwakenPatternPollers(1, 1) // simulate race condition with this poll.
 				m.AwakenLogStreams(1, 0)
-				logClosedCheck() // barrier until filestream closes fd
-				m.AwakenGcPoller(1, 1)
+				logClosedCheck()    // barrier until filestream closes fd
 				logCompletedCheck() // barrier until the logstream is removed from tailer
 			}
 			glog.Info("create")

--- a/internal/mtail/options.go
+++ b/internal/mtail/options.go
@@ -109,20 +109,6 @@ func (opt overrideLocation) apply(m *Server) error {
 	return nil
 }
 
-// GcWaker triggers garbage collection runs for stale logs in the tailer.
-func GcWaker(w waker.Waker) Option {
-	return &gcWaker{w}
-}
-
-type gcWaker struct {
-	waker.Waker
-}
-
-func (opt gcWaker) apply(m *Server) error {
-	m.tOpts = append(m.tOpts, tailer.GcWaker(opt.Waker))
-	return nil
-}
-
 // LogPatternPollWaker triggers polls on the filesystem for new logs that match the log glob patterns.
 func LogPatternPollWaker(w waker.Waker) Option {
 	return &logPatternPollWaker{w}

--- a/internal/mtail/testing.go
+++ b/internal/mtail/testing.go
@@ -34,9 +34,6 @@ type TestServer struct {
 	// method, synchronising the pattern poll with the test.
 	AwakenPatternPollers waker.WakeFunc // the glob awakens
 
-	gcWaker        waker.Waker // activate the cleanup routines
-	AwakenGcPoller waker.WakeFunc
-
 	tb testing.TB
 
 	cancel context.CancelFunc
@@ -68,11 +65,9 @@ func TestMakeServer(tb testing.TB, patternWakers int, streamWakers int, options 
 	}
 	ts.streamWaker, ts.AwakenLogStreams = waker.NewTest(ctx, streamWakers, "streams")
 	ts.patternWaker, ts.AwakenPatternPollers = waker.NewTest(ctx, patternWakers, "patterns")
-	ts.gcWaker, ts.AwakenGcPoller = waker.NewTest(ctx, 1, "gc")
 	options = append(options,
 		LogstreamPollWaker(ts.streamWaker),
 		LogPatternPollWaker(ts.patternWaker),
-		GcWaker(ts.gcWaker),
 	)
 	var err error
 	ts.Server, err = New(ctx, metrics.NewStore(), options...)

--- a/internal/tailer/logstream/dgramstream.go
+++ b/internal/tailer/logstream/dgramstream.go
@@ -77,7 +77,7 @@ func (ds *dgramStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wak
 			ds.completed = true
 			close(ds.lines)
 			ds.mu.Unlock()
-			ds.Stop()
+			ds.cancel()
 		}()
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
@@ -154,11 +154,6 @@ func (ds *dgramStream) IsComplete() bool {
 	ds.mu.RLock()
 	defer ds.mu.RUnlock()
 	return ds.completed
-}
-
-func (ds *dgramStream) Stop() {
-	glog.V(2).Infof("stream(%s:%s): Stop received on datagram stream.", ds.scheme, ds.address)
-	ds.cancel()
 }
 
 // Lines implements the LogStream interface, returning the output lines channel.

--- a/internal/tailer/logstream/dgramstream.go
+++ b/internal/tailer/logstream/dgramstream.go
@@ -42,12 +42,6 @@ func newDgramStream(ctx context.Context, wg *sync.WaitGroup, waker waker.Waker, 
 	return ss, nil
 }
 
-func (ds *dgramStream) LastReadTime() time.Time {
-	ds.mu.RLock()
-	defer ds.mu.RUnlock()
-	return ds.lastReadTime
-}
-
 // The read buffer size for datagrams.
 const datagramReadBufferSize = 131072
 

--- a/internal/tailer/logstream/dgramstream_unix_test.go
+++ b/internal/tailer/logstream/dgramstream_unix_test.go
@@ -40,6 +40,8 @@ func TestDgramStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())
+			// Stream is not shut down with cancel in this test
+			defer cancel()
 			waker, awaken := waker.NewTest(ctx, 1, "stream")
 
 			sockName := scheme + "://" + addr
@@ -66,9 +68,6 @@ func TestDgramStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 			wg.Wait()
 
 			checkLineDiff()
-
-			cancel()
-			wg.Wait()
 
 			if v := <-ds.Lines(); v != nil {
 				t.Errorf("expecting dgramstream to be complete because socket closed")
@@ -115,7 +114,6 @@ func TestDgramStreamReadCompletedBecauseCancel(t *testing.T) {
 			awaken(0, 0) // Synchronise past read.
 
 			cancel() // This cancellation should cause the stream to shut down.
-
 			wg.Wait()
 
 			checkLineDiff()

--- a/internal/tailer/logstream/dgramstream_unix_test.go
+++ b/internal/tailer/logstream/dgramstream_unix_test.go
@@ -70,7 +70,7 @@ func TestDgramStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 			cancel()
 			wg.Wait()
 
-			if !ds.IsComplete() {
+			if v := <-ds.Lines(); v != nil {
 				t.Errorf("expecting dgramstream to be complete because socket closed")
 			}
 		}))
@@ -120,7 +120,7 @@ func TestDgramStreamReadCompletedBecauseCancel(t *testing.T) {
 
 			checkLineDiff()
 
-			if !ds.IsComplete() {
+			if v := <-ds.Lines(); v != nil {
 				t.Errorf("expecting dgramstream to be complete because cancel")
 			}
 		}))

--- a/internal/tailer/logstream/filestream.go
+++ b/internal/tailer/logstream/filestream.go
@@ -286,11 +286,6 @@ func (fs *fileStream) IsComplete() bool {
 	return fs.completed
 }
 
-// Stop implements the LogStream interface.
-func (fs *fileStream) Stop() {
-	fs.cancel()
-}
-
 // Lines implements the LogStream interface, returning the output lines channel.
 func (fs *fileStream) Lines() <-chan *logline.LogLine {
 	return fs.lines

--- a/internal/tailer/logstream/filestream.go
+++ b/internal/tailer/logstream/filestream.go
@@ -274,12 +274,6 @@ func (fs *fileStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wake
 	return nil
 }
 
-func (fs *fileStream) IsComplete() bool {
-	fs.mu.RLock()
-	defer fs.mu.RUnlock()
-	return fs.completed
-}
-
 // Lines implements the LogStream interface, returning the output lines channel.
 func (fs *fileStream) Lines() <-chan *logline.LogLine {
 	return fs.lines

--- a/internal/tailer/logstream/filestream.go
+++ b/internal/tailer/logstream/filestream.go
@@ -59,12 +59,6 @@ func newFileStream(ctx context.Context, wg *sync.WaitGroup, waker waker.Waker, p
 	return fs, nil
 }
 
-func (fs *fileStream) LastReadTime() time.Time {
-	fs.mu.RLock()
-	defer fs.mu.RUnlock()
-	return fs.lastReadTime
-}
-
 func (fs *fileStream) stream(ctx context.Context, wg *sync.WaitGroup, waker waker.Waker, fi os.FileInfo, oneShot OneShotMode, streamFromStart bool) error {
 	fd, err := os.OpenFile(fs.pathname, os.O_RDONLY, 0o600)
 	if err != nil {

--- a/internal/tailer/logstream/filestream_test.go
+++ b/internal/tailer/logstream/filestream_test.go
@@ -70,6 +70,7 @@ func TestFileStreamReadOneShot(t *testing.T) {
 	}
 	checkLineDiff := testutil.ExpectLinesReceivedNoDiff(t, expected, fs.Lines())
 
+	// The stream should end at EOF in oneshot, no need to cancel
 	wg.Wait()
 
 	checkLineDiff()
@@ -166,8 +167,6 @@ func TestStreamDoesntBreakOnCorruptRune(t *testing.T) {
 	if v := <-fs.Lines(); v != nil {
 		t.Errorf("expecting filestream to be complete because stopped")
 	}
-	cancel()
-	wg.Wait()
 }
 
 func TestFileStreamTruncation(t *testing.T) {
@@ -280,8 +279,8 @@ func TestFileStreamReadToEOFOnCancel(t *testing.T) {
 	awaken(1, 1)
 
 	testutil.WriteString(t, f, "line 2\n")
-	cancel() // cancel wakes the stream
 
+	cancel() // cancel wakes the stream
 	wg.Wait()
 
 	checkLineDiff()

--- a/internal/tailer/logstream/filestream_test.go
+++ b/internal/tailer/logstream/filestream_test.go
@@ -111,7 +111,7 @@ func TestFileStreamReadNonSingleByteEnd(t *testing.T) {
 	testutil.WriteString(t, f, s+"\n")
 	awaken(1, 1)
 
-	fs.Stop()
+	cancel()
 	wg.Wait()
 
 	checkLineDiff()
@@ -158,7 +158,7 @@ func TestStreamDoesntBreakOnCorruptRune(t *testing.T) {
 	testutil.WriteString(t, f, s+"\n")
 	awaken(1, 1)
 
-	fs.Stop()
+	cancel()
 	wg.Wait()
 
 	checkLineDiff()
@@ -184,7 +184,7 @@ func TestFileStreamTruncation(t *testing.T) {
 	fs, err := logstream.New(ctx, &wg, waker, name, logstream.OneShotDisabled)
 	// fs.Stop() is also called explicitly further down but a failed test
 	// and early return would lead to the handle staying open
-	defer fs.Stop()
+	defer cancel()
 	testutil.FatalIfErr(t, err)
 
 	expected := []*logline.LogLine{
@@ -206,7 +206,7 @@ func TestFileStreamTruncation(t *testing.T) {
 	testutil.WriteString(t, f, "3\n")
 	awaken(1, 1)
 
-	fs.Stop()
+	cancel()
 	wg.Wait()
 
 	checkLineDiff()

--- a/internal/tailer/logstream/filestream_test.go
+++ b/internal/tailer/logstream/filestream_test.go
@@ -44,7 +44,7 @@ func TestFileStreamRead(t *testing.T) {
 
 	checkLineDiff()
 
-	if !fs.IsComplete() {
+	if v := <-fs.Lines(); v != nil {
 		t.Errorf("expecting filestream to be complete because stopped")
 	}
 }
@@ -74,7 +74,7 @@ func TestFileStreamReadOneShot(t *testing.T) {
 
 	checkLineDiff()
 
-	if !fs.IsComplete() {
+	if v := <-fs.Lines(); v != nil {
 		t.Errorf("expecting filestream to be complete because stopped")
 	}
 	cancel()
@@ -116,7 +116,7 @@ func TestFileStreamReadNonSingleByteEnd(t *testing.T) {
 
 	checkLineDiff()
 
-	if !fs.IsComplete() {
+	if v := <-fs.Lines(); v != nil {
 		t.Errorf("expecting filestream to be complete because stopped")
 	}
 	cancel()
@@ -163,7 +163,7 @@ func TestStreamDoesntBreakOnCorruptRune(t *testing.T) {
 
 	checkLineDiff()
 
-	if !fs.IsComplete() {
+	if v := <-fs.Lines(); v != nil {
 		t.Errorf("expecting filestream to be complete because stopped")
 	}
 	cancel()
@@ -248,7 +248,7 @@ func TestFileStreamPartialRead(t *testing.T) {
 
 	checkLineDiff()
 
-	if !fs.IsComplete() {
+	if v := <-fs.Lines(); v != nil {
 		t.Errorf("expecting filestream to be complete because cancellation")
 	}
 }
@@ -286,7 +286,7 @@ func TestFileStreamReadToEOFOnCancel(t *testing.T) {
 
 	checkLineDiff()
 
-	if !fs.IsComplete() {
+	if v := <-fs.Lines(); v != nil {
 		t.Errorf("expecting filestream to be complete because cancellation")
 	}
 }

--- a/internal/tailer/logstream/filestream_unix_test.go
+++ b/internal/tailer/logstream/filestream_unix_test.go
@@ -68,7 +68,7 @@ func TestFileStreamRotation(t *testing.T) {
 
 	checkLineDiff()
 
-	if !fs.IsComplete() {
+	if v := <-fs.Lines(); v != nil {
 		t.Errorf("expecting filestream to be complete because stopped")
 	}
 }
@@ -103,7 +103,7 @@ func TestFileStreamURL(t *testing.T) {
 
 	checkLineDiff()
 
-	if !fs.IsComplete() {
+	if v := <-fs.Lines(); v != nil {
 		t.Errorf("expecting filestream to be complete because stopped")
 	}
 }

--- a/internal/tailer/logstream/filestream_unix_test.go
+++ b/internal/tailer/logstream/filestream_unix_test.go
@@ -125,7 +125,7 @@ func TestFileStreamOpenFailure(t *testing.T) {
 	testutil.FatalIfErr(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	waker, _ := waker.NewTest(ctx, 0, "stream")
+	waker := waker.NewTestAlways()
 
 	_, err = logstream.New(ctx, &wg, waker, name, logstream.OneShotEnabled)
 	if err == nil || !os.IsPermission(err) {

--- a/internal/tailer/logstream/logstream.go
+++ b/internal/tailer/logstream/logstream.go
@@ -16,7 +16,6 @@ import (
 	"net/url"
 	"os"
 	"sync"
-	"time"
 
 	"github.com/golang/glog"
 	"github.com/google/mtail/internal/logline"
@@ -34,7 +33,6 @@ var (
 
 // LogStream.
 type LogStream interface {
-	LastReadTime() time.Time        // Return the time when the last log line was read from the source
 	IsComplete() bool               // True if the logstream has completed work and cannot recover.  The caller should clean up this logstream, creating a new logstream on a pathname if necessary.
 	Lines() <-chan *logline.LogLine // Returns the output channel of this LogStream.
 }

--- a/internal/tailer/logstream/logstream.go
+++ b/internal/tailer/logstream/logstream.go
@@ -33,7 +33,6 @@ var (
 
 // LogStream.
 type LogStream interface {
-	IsComplete() bool               // True if the logstream has completed work and cannot recover.  The caller should clean up this logstream, creating a new logstream on a pathname if necessary.
 	Lines() <-chan *logline.LogLine // Returns the output channel of this LogStream.
 }
 

--- a/internal/tailer/logstream/logstream.go
+++ b/internal/tailer/logstream/logstream.go
@@ -35,7 +35,6 @@ var (
 // LogStream.
 type LogStream interface {
 	LastReadTime() time.Time        // Return the time when the last log line was read from the source
-	Stop()                          // Ask to gracefully stop the stream; e.g. stream keeps reading until EOF and then completes work.
 	IsComplete() bool               // True if the logstream has completed work and cannot recover.  The caller should clean up this logstream, creating a new logstream on a pathname if necessary.
 	Lines() <-chan *logline.LogLine // Returns the output channel of this LogStream.
 }

--- a/internal/tailer/logstream/pipestream.go
+++ b/internal/tailer/logstream/pipestream.go
@@ -17,19 +17,24 @@ import (
 )
 
 type pipeStream struct {
+	cancel context.CancelFunc
+
 	lines chan *logline.LogLine
 
 	pathname string // Given name for the underlying named pipe on the filesystem
 
-	mu           sync.RWMutex // protects following fields
-	completed    bool         // This pipestream is completed and can no longer be used.
-	lastReadTime time.Time    // Last time a log line was read from this named pipe
+	mu        sync.RWMutex // protects following fields
+	completed bool         // This pipestream is completed and can no longer be used.
+
+	lastReadTime time.Time   // Last time a log line was read from this named pipe
+	staleTimer   *time.Timer // Expire the stream if no read in 24h
 }
 
 // newPipeStream creates a new stream reader for Unix Pipes.
 // `pathname` must already be verified as clean.
 func newPipeStream(ctx context.Context, wg *sync.WaitGroup, waker waker.Waker, pathname string, fi os.FileInfo) (LogStream, error) {
-	ps := &pipeStream{pathname: pathname, lastReadTime: time.Now(), lines: make(chan *logline.LogLine)}
+	ctx, cancel := context.WithCancel(ctx)
+	ps := &pipeStream{cancel: cancel, pathname: pathname, lastReadTime: time.Now(), lines: make(chan *logline.LogLine)}
 	if err := ps.stream(ctx, wg, waker, fi); err != nil {
 		return nil, err
 	}
@@ -98,6 +103,10 @@ func (ps *pipeStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wake
 			n, err := fd.Read(b)
 			glog.V(2).Infof("stream(%s): read %d bytes, err is %v", ps.pathname, n, err)
 
+			if ps.staleTimer != nil {
+				ps.staleTimer.Stop()
+			}
+
 			if n > 0 {
 				total += n
 				decodeAndSend(ctx, ps.lines, ps.pathname, n, b[:n], partial)
@@ -105,6 +114,7 @@ func (ps *pipeStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wake
 				ps.mu.Lock()
 				ps.lastReadTime = time.Now()
 				ps.mu.Unlock()
+				ps.staleTimer = time.AfterFunc(time.Hour*24, ps.cancel)
 			}
 
 			// Test to see if we should exit.

--- a/internal/tailer/logstream/pipestream.go
+++ b/internal/tailer/logstream/pipestream.go
@@ -149,11 +149,6 @@ func (ps *pipeStream) IsComplete() bool {
 	return ps.completed
 }
 
-// Stop implements the Logstream interface.
-// Calling Stop on a PipeStream is a no-op; PipeStreams always read until the input pipe is closed, which is what calling Stop means on a Logstream.
-func (ps *pipeStream) Stop() {
-}
-
 // Lines implements the LogStream interface, returning the output lines channel.
 func (ps *pipeStream) Lines() <-chan *logline.LogLine {
 	return ps.lines

--- a/internal/tailer/logstream/pipestream.go
+++ b/internal/tailer/logstream/pipestream.go
@@ -41,12 +41,6 @@ func newPipeStream(ctx context.Context, wg *sync.WaitGroup, waker waker.Waker, p
 	return ps, nil
 }
 
-func (ps *pipeStream) LastReadTime() time.Time {
-	ps.mu.RLock()
-	defer ps.mu.RUnlock()
-	return ps.lastReadTime
-}
-
 func pipeOpen(pathname string) (*os.File, error) {
 	if IsStdinPattern(pathname) {
 		return os.Stdin, nil

--- a/internal/tailer/logstream/pipestream_unix_test.go
+++ b/internal/tailer/logstream/pipestream_unix_test.go
@@ -59,7 +59,7 @@ func TestPipeStreamReadCompletedBecauseClosed(t *testing.T) {
 
 		cancel()
 
-		if !ps.IsComplete() {
+		if v := <-ps.Lines(); v != nil {
 			t.Errorf("expecting pipestream to be complete because fifo closed")
 		}
 	})(t)
@@ -98,7 +98,7 @@ func TestPipeStreamReadCompletedBecauseCancel(t *testing.T) {
 
 		checkLineDiff()
 
-		if !ps.IsComplete() {
+		if v := <-ps.Lines(); v != nil {
 			t.Errorf("expecting pipestream to be complete because cancelled")
 		}
 	})(t)
@@ -137,7 +137,7 @@ func TestPipeStreamReadURL(t *testing.T) {
 
 	cancel()
 
-	if !ps.IsComplete() {
+	if v := <-ps.Lines(); v != nil {
 		t.Errorf("expecting pipestream to be complete because fifo closed")
 	}
 }
@@ -177,7 +177,7 @@ func TestPipeStreamReadStdin(t *testing.T) {
 	checkLineDiff()
 
 	cancel()
-	if !ps.IsComplete() {
+	if v := <-ps.Lines(); v != nil {
 		t.Errorf("expecting pipestream to be complete beacuse fifo closed")
 	}
 }

--- a/internal/tailer/logstream/pipestream_unix_test.go
+++ b/internal/tailer/logstream/pipestream_unix_test.go
@@ -52,7 +52,7 @@ func TestPipeStreamReadCompletedBecauseClosed(t *testing.T) {
 		// Pipes need to be closed to signal to the pipeStream to finish up.
 		testutil.FatalIfErr(t, f.Close())
 
-		ps.Stop() // no-op for pipes
+		cancel() // no-op for pipes
 		wg.Wait()
 
 		checkLineDiff()
@@ -130,7 +130,7 @@ func TestPipeStreamReadURL(t *testing.T) {
 	// Pipes need to be closed to signal to the pipeStream to finish up.
 	testutil.FatalIfErr(t, f.Close())
 
-	ps.Stop() // no-op for pipes
+	cancel() // no-op for pipes
 	wg.Wait()
 
 	checkLineDiff()
@@ -171,7 +171,7 @@ func TestPipeStreamReadStdin(t *testing.T) {
 
 	cancel()
 
-	ps.Stop()
+	cancel()
 	wg.Wait()
 
 	checkLineDiff()

--- a/internal/tailer/logstream/socketstream.go
+++ b/internal/tailer/logstream/socketstream.go
@@ -60,9 +60,7 @@ func (ss *socketStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wa
 		// If oneshot, wait only for the one conn handler to start, otherwise wait for context Done or stopChan.
 		<-initDone
 		if !ss.oneShot {
-			select {
-			case <-ctx.Done():
-			}
+			<-ctx.Done()
 		}
 		glog.V(2).Infof("stream(%s:%s): closing listener", ss.scheme, ss.address)
 		err := l.Close()

--- a/internal/tailer/logstream/socketstream.go
+++ b/internal/tailer/logstream/socketstream.go
@@ -44,12 +44,6 @@ func newSocketStream(ctx context.Context, wg *sync.WaitGroup, waker waker.Waker,
 	return ss, nil
 }
 
-func (ss *socketStream) LastReadTime() time.Time {
-	ss.mu.RLock()
-	defer ss.mu.RUnlock()
-	return ss.lastReadTime
-}
-
 // stream starts goroutines to read data from the stream socket, until Stop is called or the context is cancelled.
 func (ss *socketStream) stream(ctx context.Context, wg *sync.WaitGroup, waker waker.Waker) error {
 	l, err := net.Listen(ss.scheme, ss.address)

--- a/internal/tailer/logstream/socketstream.go
+++ b/internal/tailer/logstream/socketstream.go
@@ -190,12 +190,6 @@ func (ss *socketStream) IsComplete() bool {
 	return ss.completed
 }
 
-// Stop implements the Logstream interface.
-// Stop will close the listener so no new connections will be accepted, and close all current connections once they have been closed by their peers.
-func (ss *socketStream) Stop() {
-	ss.cancel()
-}
-
 // Lines implements the LogStream interface, returning the output lines channel.
 func (ss *socketStream) Lines() <-chan *logline.LogLine {
 	return ss.lines

--- a/internal/tailer/logstream/socketstream.go
+++ b/internal/tailer/logstream/socketstream.go
@@ -28,7 +28,6 @@ type socketStream struct {
 	lastReadTime time.Time    // Last time a log line was read from this socket
 
 	staleTimer *time.Timer // Expire the stream if no read in 24h
-
 }
 
 func newSocketStream(ctx context.Context, wg *sync.WaitGroup, waker waker.Waker, scheme, address string, oneShot OneShotMode) (LogStream, error) {
@@ -73,9 +72,7 @@ func (ss *socketStream) stream(ctx context.Context, wg *sync.WaitGroup, waker wa
 			glog.Info(err)
 		}
 		connWg.Wait()
-		if !ss.oneShot {
-			close(ss.lines)
-		}
+		close(ss.lines)
 	}()
 
 	var connOnce sync.Once
@@ -117,9 +114,6 @@ func (ss *socketStream) handleConn(ctx context.Context, wg *sync.WaitGroup, wake
 			glog.Info(err)
 		}
 		logCloses.Add(ss.address, 1)
-		if ss.oneShot {
-			close(ss.lines)
-		}
 	}()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/internal/tailer/logstream/socketstream_unix_test.go
+++ b/internal/tailer/logstream/socketstream_unix_test.go
@@ -64,7 +64,7 @@ func TestSocketStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 
 			checkLineDiff()
 
-			if !ss.IsComplete() {
+			if v := <-ss.Lines(); v != nil {
 				t.Errorf("expecting socketstream to be complete because socket closed")
 			}
 
@@ -115,7 +115,7 @@ func TestSocketStreamReadCompletedBecauseCancel(t *testing.T) {
 
 			checkLineDiff()
 
-			if !ss.IsComplete() {
+			if v := <-ss.Lines(); v != nil {
 				t.Errorf("expecting socketstream to be complete because cancel")
 			}
 		}))

--- a/internal/tailer/logstream/socketstream_unix_test.go
+++ b/internal/tailer/logstream/socketstream_unix_test.go
@@ -38,6 +38,8 @@ func TestSocketStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())
+			// The stream is not shut down with cancel in this test.
+			defer cancel()
 			waker, awaken := waker.NewTest(ctx, 1, "stream")
 
 			sockName := scheme + "://" + addr
@@ -67,8 +69,6 @@ func TestSocketStreamReadCompletedBecauseSocketClosed(t *testing.T) {
 			if v := <-ss.Lines(); v != nil {
 				t.Errorf("expecting socketstream to be complete because socket closed")
 			}
-
-			cancel() // stop after connection closes
 		}))
 	}
 }

--- a/internal/tailer/tail.go
+++ b/internal/tailer/tail.go
@@ -376,26 +376,7 @@ func (t *Tailer) StartGcPoller(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-t.gcWaker.Wake():
-				if err := t.RemoveCompletedLogstreams(); err != nil {
-					glog.Info(err)
-				}
 			}
 		}
 	}()
-}
-
-// RemoveCompletedLogstreams checks if current logstreams have completed,
-// removing it from the map if so.
-func (t *Tailer) RemoveCompletedLogstreams() error {
-	t.logstreamsMu.Lock()
-	defer t.logstreamsMu.Unlock()
-	for name, l := range t.logstreams {
-		if l.IsComplete() {
-			glog.Infof("%s is complete", name)
-			delete(t.logstreams, name)
-			logCount.Add(-1)
-			continue
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
Removes most of the `LogStream` interface functions, moving some functionality into the `LogStream` and using only closure of the lines channel to signal stream shutdown.  All external notices are now handled by `Context` cancellation.

The `stale_log_gc_interval` flag is now deprecated as these are cleaned up at stream shutdown.

Issue: #199