### PR TITLE
feat: update HTTP server write timeout to 5 seconds

### DIFF
--- a/internal/mtail/mtail.go
+++ b/internal/mtail/mtail.go
@@ -124,7 +124,7 @@ func (m *Server) initHTTPServer() error {
 
 	srv := &http.Server{
 		ReadTimeout:       1 * time.Second,
-		WriteTimeout:      1 * time.Second,
+		WriteTimeout:      5 * time.Second,
 		IdleTimeout:       30 * time.Second,
 		ReadHeaderTimeout: 2 * time.Second,
 		Handler:           mux,


### PR DESCRIPTION
This change updates the HTTP server's write timeout to 5 seconds to ensure the exporters have enough time to write their output.